### PR TITLE
fix(composer): per-platform character limit (closes #33)

### DIFF
--- a/packages/shared/src/__tests__/platform-text-limits.test.ts
+++ b/packages/shared/src/__tests__/platform-text-limits.test.ts
@@ -3,7 +3,12 @@
 // drives these GREEN by shipping the module.
 
 import { describe, it, expect } from 'vitest';
-import { countCodePoints, PLATFORM_TEXT_LIMITS } from '../lib/platform-text-limits.js';
+import {
+  countCodePoints,
+  PLATFORM_TEXT_LIMITS,
+  PLATFORM_COMPOSER_CHAR_LIMIT,
+  getComposerCharLimit,
+} from '../lib/platform-text-limits.js';
 
 describe('countCodePoints', () => {
   it('counts ASCII characters by code point', () => {
@@ -35,5 +40,41 @@ describe('PLATFORM_TEXT_LIMITS', () => {
 
   it('exports twitter = 25000', () => {
     expect(PLATFORM_TEXT_LIMITS.twitter).toBe(25000);
+  });
+});
+
+describe('PLATFORM_COMPOSER_CHAR_LIMIT (issue #33)', () => {
+  it('twitter composer counter caps at 280 (per-tweet, distinct from the thread combined max)', () => {
+    expect(PLATFORM_COMPOSER_CHAR_LIMIT.twitter).toBe(280);
+  });
+
+  it('linkedin composer counter caps at 3000', () => {
+    expect(PLATFORM_COMPOSER_CHAR_LIMIT.linkedin).toBe(3000);
+  });
+
+  it('facebook composer counter caps at 63206', () => {
+    expect(PLATFORM_COMPOSER_CHAR_LIMIT.facebook).toBe(63206);
+  });
+
+  it('linkedin composer limit tracks PLATFORM_TEXT_LIMITS.linkedin', () => {
+    expect(PLATFORM_COMPOSER_CHAR_LIMIT.linkedin).toBe(PLATFORM_TEXT_LIMITS.linkedin);
+  });
+
+  it('facebook composer limit tracks PLATFORM_TEXT_LIMITS.facebook', () => {
+    expect(PLATFORM_COMPOSER_CHAR_LIMIT.facebook).toBe(PLATFORM_TEXT_LIMITS.facebook);
+  });
+});
+
+describe('getComposerCharLimit', () => {
+  it('returns 280 for twitter', () => {
+    expect(getComposerCharLimit('twitter')).toBe(280);
+  });
+
+  it('returns 3000 for linkedin', () => {
+    expect(getComposerCharLimit('linkedin')).toBe(3000);
+  });
+
+  it('returns 63206 for facebook', () => {
+    expect(getComposerCharLimit('facebook')).toBe(63206);
   });
 });

--- a/packages/shared/src/lib/platform-text-limits.ts
+++ b/packages/shared/src/lib/platform-text-limits.ts
@@ -21,6 +21,27 @@ export const PLATFORM_TEXT_LIMITS = {
 export type PlatformTextLimitKey = keyof typeof PLATFORM_TEXT_LIMITS;
 
 /**
+ * Per-platform character cap surfaced by the post-composer counter UI.
+ *
+ * Twitter here is the per-tweet 280 limit — distinct from
+ * `PLATFORM_TEXT_LIMITS.twitter` (25,000) which is the thread-combined max.
+ * LinkedIn/Facebook match the platform text limits because those platforms
+ * have a single per-post cap. Use this for any per-post counter, ring, or
+ * over-limit styling in the composer.
+ */
+export const PLATFORM_COMPOSER_CHAR_LIMIT = {
+  twitter: 280,
+  linkedin: PLATFORM_TEXT_LIMITS.linkedin,
+  facebook: PLATFORM_TEXT_LIMITS.facebook,
+} as const;
+
+export type PlatformComposerKey = keyof typeof PLATFORM_COMPOSER_CHAR_LIMIT;
+
+export function getComposerCharLimit(platform: PlatformComposerKey): number {
+  return PLATFORM_COMPOSER_CHAR_LIMIT[platform];
+}
+
+/**
  * Counts Unicode code points using the spread iterator.
  *
  * The spread iterator walks the string by code point, so astral-plane

--- a/packages/web/src/components/posts/CharacterCountRing.tsx
+++ b/packages/web/src/components/posts/CharacterCountRing.tsx
@@ -1,13 +1,25 @@
-import { getCharacterCount } from '../../lib/twitter-text';
+import {
+  getPlatformCharCount,
+  PLATFORM_COMPOSER_CHAR_LIMIT,
+  type PlatformComposerKey,
+} from '@sms/shared';
 import { cn } from '../../lib/utils';
 
 interface CharacterCountRingProps {
   text: string;
+  platform: PlatformComposerKey;
   size?: 'sm' | 'lg';
 }
 
-export function CharacterCountRing({ text, size = 'lg' }: CharacterCountRingProps) {
-  const { permillage, remaining } = getCharacterCount(text);
+export function CharacterCountRing({
+  text,
+  platform,
+  size = 'lg',
+}: CharacterCountRingProps) {
+  const limit = PLATFORM_COMPOSER_CHAR_LIMIT[platform];
+  const { count, exceedsCap } = getPlatformCharCount(text, platform);
+  const remaining = limit - count;
+  const permillage = limit > 0 ? Math.round((count / limit) * 1000) : 0;
 
   const radius = size === 'sm' ? 10 : 14;
   const circumference = 2 * Math.PI * radius;
@@ -18,8 +30,11 @@ export function CharacterCountRing({ text, size = 'lg' }: CharacterCountRingProp
   const center = diameter / 2;
   const strokeWidth = 2;
 
-  const isOverLimit = remaining < 0;
-  const isWarning = permillage > 928 && permillage <= 1000;
+  const isOverLimit = exceedsCap || remaining < 0;
+  const isWarning = !isOverLimit && permillage > 928;
+  // Show the number once the user is within 20 chars of the limit, in either
+  // direction. For high-cap platforms (FB 63k) the trailing number is only
+  // useful near the boundary.
   const showCount = remaining <= 20;
 
   const progressColor = isOverLimit
@@ -37,6 +52,8 @@ export function CharacterCountRing({ text, size = 'lg' }: CharacterCountRingProp
       className="relative inline-flex items-center justify-center"
       role="status"
       aria-label={ariaLabel}
+      data-platform={platform}
+      data-over-limit={isOverLimit ? 'true' : 'false'}
     >
       <svg
         width={diameter}

--- a/packages/web/src/components/posts/CharacterCountRing.tsx
+++ b/packages/web/src/components/posts/CharacterCountRing.tsx
@@ -17,7 +17,7 @@ export function CharacterCountRing({
   size = 'lg',
 }: CharacterCountRingProps) {
   const limit = PLATFORM_COMPOSER_CHAR_LIMIT[platform];
-  const { count, exceedsCap } = getPlatformCharCount(text, platform);
+  const { count } = getPlatformCharCount(text, platform);
   const remaining = limit - count;
   const permillage = limit > 0 ? Math.round((count / limit) * 1000) : 0;
 
@@ -30,7 +30,11 @@ export function CharacterCountRing({
   const center = diameter / 2;
   const strokeWidth = 2;
 
-  const isOverLimit = exceedsCap || remaining < 0;
+  // Drive over-limit purely from `remaining`. `getPlatformCharCount` returns
+  // `exceedsCap = !parseTweet.valid` for Twitter, but twitter-text marks an
+  // empty tweet invalid — using exceedsCap would render the blank composer
+  // as over-limit on initial render.
+  const isOverLimit = remaining < 0;
   const isWarning = !isOverLimit && permillage > 928;
   // Show the number once the user is within 20 chars of the limit, in either
   // direction. For high-cap platforms (FB 63k) the trailing number is only

--- a/packages/web/src/components/posts/ThreadCard.tsx
+++ b/packages/web/src/components/posts/ThreadCard.tsx
@@ -94,7 +94,7 @@ export function ThreadCard({
           aria-label={`Tweet ${index + 1} text`}
         />
         <div className="flex items-center justify-between mt-2">
-          <CharacterCountRing text={text} size="sm" />
+          <CharacterCountRing text={text} platform="twitter" size="sm" />
           {total > 1 && (
             <Button
               variant="ghost"

--- a/packages/web/src/components/posts/TwitterPostFields.tsx
+++ b/packages/web/src/components/posts/TwitterPostFields.tsx
@@ -81,7 +81,7 @@ export function TwitterPostFields({
               disabled={disabled}
             />
             <div className="absolute bottom-2 right-2">
-              <CharacterCountRing text={text} />
+              <CharacterCountRing text={text} platform="twitter" />
             </div>
           </div>
         </div>

--- a/packages/web/src/lib/twitter-text.ts
+++ b/packages/web/src/lib/twitter-text.ts
@@ -1,4 +1,6 @@
 import twitterText from 'twitter-text';
+import { PLATFORM_COMPOSER_CHAR_LIMIT } from '@sms/shared';
+
 const { parseTweet } = twitterText;
 
 export interface CharacterCountResult {
@@ -18,6 +20,6 @@ export function getCharacterCount(text: string): CharacterCountResult {
     weightedLength: result.weightedLength,
     valid: result.valid,
     permillage: result.permillage,
-    remaining: 280 - result.weightedLength,
+    remaining: PLATFORM_COMPOSER_CHAR_LIMIT.twitter - result.weightedLength,
   };
 }

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -560,7 +560,7 @@ export default function EditPostPage() {
                     rows={5}
                   />
                   <div className="absolute bottom-2 right-2">
-                    <CharacterCountRing text={formState.text} />
+                    <CharacterCountRing text={formState.text} platform="linkedin" />
                   </div>
                 </div>
               </div>
@@ -591,7 +591,7 @@ export default function EditPostPage() {
                     rows={5}
                   />
                   <div className="absolute bottom-2 right-2">
-                    <CharacterCountRing text={formState.text} />
+                    <CharacterCountRing text={formState.text} platform="facebook" />
                   </div>
                 </div>
               </div>

--- a/packages/web/src/pages/posts/NewPostPage.tsx
+++ b/packages/web/src/pages/posts/NewPostPage.tsx
@@ -484,7 +484,7 @@ export default function NewPostPage() {
                     rows={5}
                   />
                   <div className="absolute bottom-2 right-2">
-                    <CharacterCountRing text={formState.text} />
+                    <CharacterCountRing text={formState.text} platform="linkedin" />
                   </div>
                 </div>
               </div>
@@ -515,7 +515,7 @@ export default function NewPostPage() {
                     rows={5}
                   />
                   <div className="absolute bottom-2 right-2">
-                    <CharacterCountRing text={formState.text} />
+                    <CharacterCountRing text={formState.text} platform="facebook" />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

The post composer's character counter was wired to the Twitter `parseTweet` helper, which always uses the 280-character per-tweet weight. Selecting a LinkedIn or Facebook profile still rendered "280 characters remaining" even though those platforms accept 3,000 and 63,206 characters respectively (closes #33).

The platform limits already lived in `packages/shared/src/lib/platform-text-limits.ts` (Phase 8). This change extends that file with a per-platform composer cap and rewires `CharacterCountRing` to read its count + cap from the shared source.

## Changes

- `packages/shared/src/lib/platform-text-limits.ts` — add `PLATFORM_COMPOSER_CHAR_LIMIT` and `getComposerCharLimit()`. Twitter is the per-tweet 280 cap; LinkedIn (3,000) and Facebook (63,206) track `PLATFORM_TEXT_LIMITS`.
- `packages/web/src/components/posts/CharacterCountRing.tsx` — accept a `platform` prop and route through `getPlatformCharCount` + the new shared cap. Exposes `data-platform` and `data-over-limit` for testability.
- Six callers updated to pass `platform`: `TwitterPostFields`, `ThreadCard`, and the LinkedIn + Facebook branches of `NewPostPage` and `EditPostPage`.
- `packages/web/src/lib/twitter-text.ts` — route the remaining hardcoded 280 through the shared constant.
- `packages/shared/src/__tests__/platform-text-limits.test.ts` — new unit tests covering each platform's limit lookup.

## Verification

- `pnpm build` (typecheck) — exit 0 across all 5 packages.
- `pnpm test` — exit 0. shared: 181/181, db: 11/11, web: 180/180, api: 481/481, worker: 217/217.
- Browser UAT against the running dev stack via agent-browser. For each of Twitter / LinkedIn / Facebook, the composer was driven to one character under and one character over the limit:
  - Twitter @ 279/281 — `1 characters remaining` / `1 characters over limit`
  - LinkedIn @ 2999/3001 — `1 characters remaining` / `1 characters over limit`
  - Facebook @ 63205/63207 — `1 characters remaining` / `1 characters over limit`
- `pnpm lint` was not run — the develop baseline is missing `eslint.config.js`, so the script fails before reaching any source. Not introduced by this PR.

## Out of scope

- ESLint config restoration.