### PR TITLE
fix(rate-limit): compute Twitter reset date from current time (closes #35)

### DIFF
--- a/packages/api/src/__tests__/routes/rate-limit-collection.test.ts
+++ b/packages/api/src/__tests__/routes/rate-limit-collection.test.ts
@@ -1,0 +1,141 @@
+// Route-level coverage for `routes/rate-limit.ts` — the new collection /
+// single-profile endpoints introduced by Plan 03. The legacy test file in
+// this directory (`rate-limit.test.ts`) exercises the older
+// `/api/profiles/:id/rate-limit` config endpoint living in `profiles.ts`,
+// which does NOT read `monthResetAtUtc`. This file covers the actual route
+// touched by the issue-#35 fix:
+//   GET /api/rate-limit/:profileId
+//
+// Specifically asserts that the JSON `windowResetAt` is the start of the
+// NEXT UTC month (the future boundary), not `monthStartUtc` (the current
+// boundary, which is always in the past).
+//
+// Uses an isolated Express harness rather than `createApp` so the test
+// doesn't need the full session/CSRF/Redis scaffolding — the router is
+// pure (no auth dependency besides a session-injecting middleware) and
+// the service layer is mocked.
+
+import express from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCheckTwitterBudgetWithDb = vi.fn();
+const mockLoadLinkedInUsage = vi.fn();
+const mockLoadFacebookUsage = vi.fn();
+
+vi.mock('../../services/rate-limit.service.js', () => ({
+  checkTwitterBudgetWithDb: (...args: unknown[]) =>
+    mockCheckTwitterBudgetWithDb(...args),
+  loadLinkedInUsage: (...args: unknown[]) => mockLoadLinkedInUsage(...args),
+  loadFacebookUsage: (...args: unknown[]) => mockLoadFacebookUsage(...args),
+}));
+
+vi.mock('@sms/db', () => ({
+  socialProfiles: {
+    id: { name: 'id' },
+    platform: { name: 'platform' },
+    userId: { name: 'user_id' },
+  },
+}));
+
+// Import after mocks are declared.
+import { createRateLimitRouter } from '../../routes/rate-limit.js';
+
+const PROFILE_ID = '550e8400-e29b-41d4-a716-446655440099';
+const USER_ID = 'user-issue-35';
+
+interface OwnedRow {
+  id: string;
+  platform: 'twitter' | 'linkedin' | 'facebook';
+}
+
+let ownedRows: OwnedRow[] = [];
+
+function createMockDb() {
+  return {
+    select: vi.fn().mockImplementation(() => {
+      const chain: Record<string, unknown> = {};
+      (chain as { from: () => unknown }).from = vi.fn().mockReturnValue(chain);
+      (chain as { where: () => unknown }).where = vi
+        .fn()
+        .mockImplementation(() => Promise.resolve(ownedRows));
+      return chain;
+    }),
+  } as unknown as Parameters<typeof createRateLimitRouter>[0]['db'];
+}
+
+function buildApp() {
+  const app = express();
+  app.use(
+    session({
+      secret: 'issue-35-test-secret-that-is-long-enough-for-session-cookie',
+      resave: false,
+      saveUninitialized: false,
+    }),
+  );
+  // Inject a fixed session userId so requireAuth passes.
+  app.use((req, _res, next) => {
+    req.session.userId = USER_ID;
+    next();
+  });
+  app.use(createRateLimitRouter({ db: createMockDb() }));
+  return app;
+}
+
+describe('GET /api/rate-limit/:profileId — issue #35 windowResetAt wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ownedRows = [{ id: PROFILE_ID, platform: 'twitter' }];
+  });
+
+  it('returns windowResetAt as the start of the next UTC month (not monthStartUtc)', async () => {
+    // The service is stubbed to return the May 2026 window — reset must be
+    // the start of June 2026, which is strictly after the start of May.
+    mockCheckTwitterBudgetWithDb.mockResolvedValue({
+      currentUsage: 120,
+      budget: 500,
+      warnThresholdPercent: 80,
+      projectedCount: 120,
+      wouldExceed: false,
+      warnThresholdHit: false,
+      blockThresholdHit: false,
+      remainingBudget: 380,
+      monthStartUtc: new Date('2026-05-01T00:00:00Z'),
+      monthResetAtUtc: new Date('2026-06-01T00:00:00Z'),
+    });
+
+    const res = await request(buildApp()).get(`/api/rate-limit/${PROFILE_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.windowResetAt).toBe('2026-06-01T00:00:00.000Z');
+    expect(res.body.monthStartUtc).toBe('2026-05-01T00:00:00.000Z');
+    // Invariant the bug violated: reset must be strictly after window start.
+    expect(new Date(res.body.windowResetAt).getTime()).toBeGreaterThan(
+      new Date(res.body.monthStartUtc).getTime(),
+    );
+  });
+
+  it('does not leak the previous bug: windowResetAt must not equal monthStartUtc', async () => {
+    // Regression guard. If a refactor reverts `windowResetAt` back to
+    // `state.monthStartUtc.toISOString()` (the issue-#35 bug), this assertion
+    // fails.
+    mockCheckTwitterBudgetWithDb.mockResolvedValue({
+      currentUsage: 0,
+      budget: 500,
+      warnThresholdPercent: 80,
+      projectedCount: 0,
+      wouldExceed: false,
+      warnThresholdHit: false,
+      blockThresholdHit: false,
+      remainingBudget: 500,
+      monthStartUtc: new Date('2026-05-01T00:00:00Z'),
+      monthResetAtUtc: new Date('2026-06-01T00:00:00Z'),
+    });
+
+    const res = await request(buildApp()).get(`/api/rate-limit/${PROFILE_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.windowResetAt).not.toBe(res.body.monthStartUtc);
+  });
+});

--- a/packages/api/src/routes/rate-limit.ts
+++ b/packages/api/src/routes/rate-limit.ts
@@ -79,7 +79,10 @@ async function buildRateLimitState(
       warnThresholdHit: state.warnThresholdHit,
       blockThresholdHit: state.blockThresholdHit,
       windowStartUtc: state.monthStartUtc.toISOString(),
-      windowResetAt: state.monthStartUtc.toISOString(),
+      // Issue #35: windowResetAt is the start of NEXT month, not the start of
+      // the current window. monthStartUtc is always in the past (or "now"),
+      // so using it as the reset date renders a stale "Resets <past date>".
+      windowResetAt: state.monthResetAtUtc.toISOString(),
       monthStartUtc: state.monthStartUtc.toISOString(),
     };
   }

--- a/packages/api/src/routes/rate-limit.ts
+++ b/packages/api/src/routes/rate-limit.ts
@@ -79,9 +79,7 @@ async function buildRateLimitState(
       warnThresholdHit: state.warnThresholdHit,
       blockThresholdHit: state.blockThresholdHit,
       windowStartUtc: state.monthStartUtc.toISOString(),
-      // Issue #35: windowResetAt is the start of NEXT month, not the start of
-      // the current window. monthStartUtc is always in the past (or "now"),
-      // so using it as the reset date renders a stale "Resets <past date>".
+      // fix #35 — see UsageSnapshot.monthResetAtUtc
       windowResetAt: state.monthResetAtUtc.toISOString(),
       monthStartUtc: state.monthStartUtc.toISOString(),
     };

--- a/packages/api/src/services/__tests__/rate-limit.service.test.ts
+++ b/packages/api/src/services/__tests__/rate-limit.service.test.ts
@@ -120,6 +120,96 @@ describe('rate-limit service', () => {
         /Profile missing-profile not found/,
       );
     });
+
+    // Issue #35 regression coverage. The Twitter monthly window is a UTC
+    // calendar month; the reset date is the start of the NEXT calendar month
+    // and must always be strictly in the future relative to `now`.
+    describe('monthResetAtUtc (issue #35)', () => {
+      it('mid-month: returns the start of the next month', async () => {
+        const db = createMockDb({
+          profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
+          countRows: [{ publishedCount: 0 }],
+        });
+        const now = new Date('2026-05-13T12:00:00Z');
+
+        const snapshot = await loadTwitterUsage(db, 'profile-uuid', now);
+
+        expect(snapshot.monthStartUtc).toEqual(new Date('2026-05-01T00:00:00Z'));
+        expect(snapshot.monthResetAtUtc).toEqual(
+          new Date('2026-06-01T00:00:00Z'),
+        );
+        expect(snapshot.monthResetAtUtc.getTime()).toBeGreaterThan(now.getTime());
+      });
+
+      it('last day of month: returns the first of the following month', async () => {
+        const db = createMockDb({
+          profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
+          countRows: [{ publishedCount: 0 }],
+        });
+        // 23:59:59 on the last day of March — last possible moment of the
+        // March window. Reset must still be the start of April, not March.
+        const now = new Date('2026-03-31T23:59:59Z');
+
+        const snapshot = await loadTwitterUsage(db, 'profile-uuid', now);
+
+        expect(snapshot.monthStartUtc).toEqual(new Date('2026-03-01T00:00:00Z'));
+        expect(snapshot.monthResetAtUtc).toEqual(
+          new Date('2026-04-01T00:00:00Z'),
+        );
+        expect(snapshot.monthResetAtUtc.getTime()).toBeGreaterThan(now.getTime());
+      });
+
+      it('just past a prior month boundary: reset is current month\'s end, not the boundary that just passed', async () => {
+        const db = createMockDb({
+          profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
+          countRows: [{ publishedCount: 0 }],
+        });
+        // One second after the May boundary. Reset must roll forward to
+        // June — the prior boundary (May 1) is already in the past and must
+        // never be reported as the next reset.
+        const now = new Date('2026-05-01T00:00:01Z');
+
+        const snapshot = await loadTwitterUsage(db, 'profile-uuid', now);
+
+        expect(snapshot.monthStartUtc).toEqual(new Date('2026-05-01T00:00:00Z'));
+        expect(snapshot.monthResetAtUtc).toEqual(
+          new Date('2026-06-01T00:00:00Z'),
+        );
+        expect(snapshot.monthResetAtUtc.getTime()).toBeGreaterThan(now.getTime());
+      });
+
+      it('rolls over December → January of next year', async () => {
+        const db = createMockDb({
+          profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
+          countRows: [{ publishedCount: 0 }],
+        });
+        const now = new Date('2026-12-15T08:00:00Z');
+
+        const snapshot = await loadTwitterUsage(db, 'profile-uuid', now);
+
+        expect(snapshot.monthStartUtc).toEqual(new Date('2026-12-01T00:00:00Z'));
+        expect(snapshot.monthResetAtUtc).toEqual(
+          new Date('2027-01-01T00:00:00Z'),
+        );
+      });
+
+      it('propagates monthResetAtUtc through checkTwitterBudgetWithDb', async () => {
+        const db = createMockDb({
+          profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
+          countRows: [{ publishedCount: 10 }],
+        });
+        const now = new Date('2026-05-13T12:00:00Z');
+
+        const result = await checkTwitterBudgetWithDb(db, {
+          profileId: 'profile-uuid',
+          additionalPostCount: 1,
+          now,
+        });
+
+        expect(result.monthResetAtUtc).toEqual(new Date('2026-06-01T00:00:00Z'));
+        expect(result.monthResetAtUtc.getTime()).toBeGreaterThan(now.getTime());
+      });
+    });
   });
 
   describe('checkTwitterBudgetWithDb', () => {

--- a/packages/api/src/services/__tests__/rate-limit.service.test.ts
+++ b/packages/api/src/services/__tests__/rate-limit.service.test.ts
@@ -81,6 +81,17 @@ function createMockDb(options: MockDbOptions) {
   };
 }
 
+// Issue-#35 helper: zero-usage Twitter profile with the default 500/80 caps.
+// Most monthResetAtUtc tests don't care about the post count — they only
+// assert calendar math — so this trims four otherwise-identical stub setups
+// to one line each.
+function createEmptyTwitterDb() {
+  return createMockDb({
+    profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
+    countRows: [{ publishedCount: 0 }],
+  });
+}
+
 describe('rate-limit service', () => {
   // Pin clock to 2026-04-15 12:00 UTC so every test sees the same month boundary
   // (2026-04-01 00:00 UTC).
@@ -126,10 +137,7 @@ describe('rate-limit service', () => {
     // and must always be strictly in the future relative to `now`.
     describe('monthResetAtUtc (issue #35)', () => {
       it('mid-month: returns the start of the next month', async () => {
-        const db = createMockDb({
-          profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
-          countRows: [{ publishedCount: 0 }],
-        });
+        const db = createEmptyTwitterDb();
         const now = new Date('2026-05-13T12:00:00Z');
 
         const snapshot = await loadTwitterUsage(db, 'profile-uuid', now);
@@ -142,10 +150,7 @@ describe('rate-limit service', () => {
       });
 
       it('last day of month: returns the first of the following month', async () => {
-        const db = createMockDb({
-          profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
-          countRows: [{ publishedCount: 0 }],
-        });
+        const db = createEmptyTwitterDb();
         // 23:59:59 on the last day of March — last possible moment of the
         // March window. Reset must still be the start of April, not March.
         const now = new Date('2026-03-31T23:59:59Z');
@@ -160,10 +165,7 @@ describe('rate-limit service', () => {
       });
 
       it('just past a prior month boundary: reset is current month\'s end, not the boundary that just passed', async () => {
-        const db = createMockDb({
-          profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
-          countRows: [{ publishedCount: 0 }],
-        });
+        const db = createEmptyTwitterDb();
         // One second after the May boundary. Reset must roll forward to
         // June — the prior boundary (May 1) is already in the past and must
         // never be reported as the next reset.
@@ -179,10 +181,7 @@ describe('rate-limit service', () => {
       });
 
       it('rolls over December → January of next year', async () => {
-        const db = createMockDb({
-          profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
-          countRows: [{ publishedCount: 0 }],
-        });
+        const db = createEmptyTwitterDb();
         const now = new Date('2026-12-15T08:00:00Z');
 
         const snapshot = await loadTwitterUsage(db, 'profile-uuid', now);
@@ -337,6 +336,26 @@ describe('rate-limit service', () => {
       expect(result.projectedCount).toBe(510);
       expect(result.remainingBudget).toBe(40);
       expect(result.monthStartUtc).toEqual(new Date('2026-04-01T00:00:00Z'));
+    });
+
+    it('propagates monthResetAtUtc through checkBulkBudgetWithDb (issue #35)', async () => {
+      // Mirror of the equivalent checkTwitterBudgetWithDb propagation test —
+      // the bulk-upload path is the LIMIT-05 surface and uses the same
+      // monthResetAtUtc field for the "won't fit, retry after <date>" copy.
+      const db = createMockDb({
+        profileRows: [{ monthlyBudget: 500, warnThresholdPercent: 80 }],
+        countRows: [{ publishedCount: 100 }],
+      });
+      const now = new Date('2026-05-13T12:00:00Z');
+
+      const result = await checkBulkBudgetWithDb(db, {
+        profileId: 'profile-uuid',
+        additionalCount: 10,
+        now,
+      });
+
+      expect(result.monthResetAtUtc).toEqual(new Date('2026-06-01T00:00:00Z'));
+      expect(result.monthResetAtUtc.getTime()).toBeGreaterThan(now.getTime());
     });
 
     it('allows a bulk batch that fits exactly inside the remaining budget', async () => {

--- a/packages/api/src/services/rate-limit.service.ts
+++ b/packages/api/src/services/rate-limit.service.ts
@@ -62,8 +62,11 @@ export async function loadTwitterUsage(
     now === undefined
       ? DateTime.utc()
       : DateTime.fromJSDate(now, { zone: 'utc' });
-  const monthStartUtc = nowUtc.startOf('month').toJSDate();
-  const monthResetAtUtc = nowUtc.startOf('month').plus({ months: 1 }).toJSDate();
+  // Anchor both boundaries to the same instant so reset is guaranteed to be
+  // exactly one month after start (invariant the issue-#35 tests assert).
+  const monthStart = nowUtc.startOf('month');
+  const monthStartUtc = monthStart.toJSDate();
+  const monthResetAtUtc = monthStart.plus({ months: 1 }).toJSDate();
 
   const [profileRow] = await db
     .select({
@@ -420,6 +423,7 @@ export async function checkPlatformBudgetWithDb(
     const result = await checkTwitterBudgetWithDb(db, {
       profileId: args.profileId,
       additionalPostCount: args.additionalCount,
+      now: args.now, // parity with the linkedin/facebook branches below
     });
     return {
       blockThresholdHit: result.wouldExceed,

--- a/packages/api/src/services/rate-limit.service.ts
+++ b/packages/api/src/services/rate-limit.service.ts
@@ -32,6 +32,13 @@ export interface UsageSnapshot {
   monthlyBudget: number;
   warnThresholdPercent: number;
   monthStartUtc: Date;
+  /**
+   * Start of the NEXT UTC calendar month — the moment the Twitter monthly
+   * budget resets. Always strictly in the future relative to `now`. The
+   * dashboard's "Resets …" row reads this, NOT `monthStartUtc` (which is the
+   * start of the current window and would always render in the past).
+   */
+  monthResetAtUtc: Date;
 }
 
 /**
@@ -41,12 +48,22 @@ export interface UsageSnapshot {
  * Throws if the profile does not exist. Callers that already verified
  * ownership can let the error propagate to the 404 handler; other callers
  * should catch and map it.
+ *
+ * `now` is injectable for deterministic unit tests; when omitted we read
+ * the clock via Luxon so existing tests that pin `Settings.now` keep
+ * working (production reads the wall clock).
  */
 export async function loadTwitterUsage(
   db: Db,
   profileId: string,
+  now?: Date,
 ): Promise<UsageSnapshot> {
-  const monthStartUtc = DateTime.utc().startOf('month').toJSDate();
+  const nowUtc =
+    now === undefined
+      ? DateTime.utc()
+      : DateTime.fromJSDate(now, { zone: 'utc' });
+  const monthStartUtc = nowUtc.startOf('month').toJSDate();
+  const monthResetAtUtc = nowUtc.startOf('month').plus({ months: 1 }).toJSDate();
 
   const [profileRow] = await db
     .select({
@@ -76,6 +93,7 @@ export async function loadTwitterUsage(
     monthlyBudget: profileRow.monthlyBudget,
     warnThresholdPercent: profileRow.warnThresholdPercent,
     monthStartUtc,
+    monthResetAtUtc,
   };
 }
 
@@ -85,16 +103,20 @@ export async function loadTwitterUsage(
  */
 export async function checkTwitterBudgetWithDb(
   db: Db,
-  args: { profileId: string; additionalPostCount: number },
-): Promise<BudgetCheckResult & { monthStartUtc: Date }> {
-  const snapshot = await loadTwitterUsage(db, args.profileId);
+  args: { profileId: string; additionalPostCount: number; now?: Date },
+): Promise<BudgetCheckResult & { monthStartUtc: Date; monthResetAtUtc: Date }> {
+  const snapshot = await loadTwitterUsage(db, args.profileId, args.now);
   const result = checkTwitterBudget({
     currentUsage: snapshot.currentUsage,
     monthlyBudget: snapshot.monthlyBudget,
     warnThresholdPercent: snapshot.warnThresholdPercent,
     additionalCount: args.additionalPostCount,
   });
-  return { ...result, monthStartUtc: snapshot.monthStartUtc };
+  return {
+    ...result,
+    monthStartUtc: snapshot.monthStartUtc,
+    monthResetAtUtc: snapshot.monthResetAtUtc,
+  };
 }
 
 /**
@@ -105,16 +127,20 @@ export async function checkTwitterBudgetWithDb(
  */
 export async function checkBulkBudgetWithDb(
   db: Db,
-  args: { profileId: string; additionalCount: number },
-): Promise<BudgetCheckResult & { monthStartUtc: Date }> {
-  const snapshot = await loadTwitterUsage(db, args.profileId);
+  args: { profileId: string; additionalCount: number; now?: Date },
+): Promise<BudgetCheckResult & { monthStartUtc: Date; monthResetAtUtc: Date }> {
+  const snapshot = await loadTwitterUsage(db, args.profileId, args.now);
   const result = checkBulkBudget({
     currentUsage: snapshot.currentUsage,
     monthlyBudget: snapshot.monthlyBudget,
     warnThresholdPercent: snapshot.warnThresholdPercent,
     additionalCount: args.additionalCount,
   });
-  return { ...result, monthStartUtc: snapshot.monthStartUtc };
+  return {
+    ...result,
+    monthStartUtc: snapshot.monthStartUtc,
+    monthResetAtUtc: snapshot.monthResetAtUtc,
+  };
 }
 
 // ============================================================================

--- a/packages/shared/src/schemas/rate-limit.ts
+++ b/packages/shared/src/schemas/rate-limit.ts
@@ -36,6 +36,10 @@ const twitterRateLimitState = z
     currentCount: z.number().int().nonnegative(),
     budget: z.number().int().positive(),
     monthStartUtc: z.string().datetime(),
+    // Start of the next UTC calendar month — the moment the Twitter monthly
+    // budget resets (issue #35). Required so typed consumers can rely on a
+    // future-dated reset boundary instead of formatting `monthStartUtc`.
+    windowResetAt: z.string().datetime(),
     ...sharedThresholds,
   })
   .strict();

--- a/packages/web/src/__tests__/RateLimitsCard.test.tsx
+++ b/packages/web/src/__tests__/RateLimitsCard.test.tsx
@@ -126,6 +126,43 @@ describe('<RateLimitsCard />', () => {
     expect(dot).toHaveClass('bg-destructive');
   });
 
+  // Issue #35: the Twitter row must render a FUTURE reset date. Before the
+  // fix, the row displayed `monthStartUtc` (start of the current window) and
+  // showed a date that was always in the past, e.g. "Resets Mar 31" on May 13.
+  it('renders a future reset date for Twitter rows (issue #35)', () => {
+    // `now` is wall-clock — pick a future ISO so the assertion is robust
+    // regardless of when the test runs.
+    const futureReset = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000); // +14 days
+    useAllProfilesRateLimitsMock.mockReturnValue({
+      data: [
+        {
+          profileId: 'p-twitter',
+          platform: 'twitter',
+          handle: 'tester',
+          currentCount: 10,
+          budget: 500,
+          windowResetAt: futureReset.toISOString(),
+          monthStartUtc: new Date(
+            futureReset.getFullYear(),
+            futureReset.getMonth() - 1,
+            1,
+          ).toISOString(),
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+    renderWithQuery(<RateLimitsCard />);
+
+    // The row should be present and reference the relative future window
+    // (e.g. "Resets in 14d"). The exact text comes from `formatResetTime`.
+    expect(screen.getByText(/resets in/i)).toBeInTheDocument();
+    // The previously-wrong "Resets <past-month-start>" formatting is gone:
+    // the Mar/Apr/May static label produced from monthStartUtc would have
+    // appeared under "Resets " (without "in"). Asserting the "in" variant
+    // pins us to the future-relative formatter.
+  });
+
   it('progress bar exposes role="progressbar" with aria-valuenow + aria-valuemax + aria-label', () => {
     useAllProfilesRateLimitsMock.mockReturnValue({
       data: [

--- a/packages/web/src/__tests__/RateLimitsCard.test.tsx
+++ b/packages/web/src/__tests__/RateLimitsCard.test.tsx
@@ -4,7 +4,7 @@
 // deterministic.
 
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RateLimitsCard } from '../components/dashboard/RateLimitsCard';
@@ -127,40 +127,44 @@ describe('<RateLimitsCard />', () => {
   });
 
   // Issue #35: the Twitter row must render a FUTURE reset date. Before the
-  // fix, the row displayed `monthStartUtc` (start of the current window) and
-  // showed a date that was always in the past, e.g. "Resets Mar 31" on May 13.
-  it('renders a future reset date for Twitter rows (issue #35)', () => {
-    // `now` is wall-clock — pick a future ISO so the assertion is robust
-    // regardless of when the test runs.
-    const futureReset = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000); // +14 days
-    useAllProfilesRateLimitsMock.mockReturnValue({
-      data: [
-        {
-          profileId: 'p-twitter',
-          platform: 'twitter',
-          handle: 'tester',
-          currentCount: 10,
-          budget: 500,
-          windowResetAt: futureReset.toISOString(),
-          monthStartUtc: new Date(
-            futureReset.getFullYear(),
-            futureReset.getMonth() - 1,
-            1,
-          ).toISOString(),
-        },
-      ],
-      isLoading: false,
-      isError: false,
+  // fix the row displayed `monthStartUtc` and showed a past date like
+  // "Resets Mar 31" on May 13. Pin the clock so the relative-time assertion
+  // is deterministic and so we can also assert the buggy past-date label
+  // is gone.
+  describe('Twitter reset date (issue #35)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-13T12:00:00Z'));
     });
-    renderWithQuery(<RateLimitsCard />);
+    afterEach(() => {
+      vi.useRealTimers();
+    });
 
-    // The row should be present and reference the relative future window
-    // (e.g. "Resets in 14d"). The exact text comes from `formatResetTime`.
-    expect(screen.getByText(/resets in/i)).toBeInTheDocument();
-    // The previously-wrong "Resets <past-month-start>" formatting is gone:
-    // the Mar/Apr/May static label produced from monthStartUtc would have
-    // appeared under "Resets " (without "in"). Asserting the "in" variant
-    // pins us to the future-relative formatter.
+    it('renders the relative future reset and not the past month-start', () => {
+      useAllProfilesRateLimitsMock.mockReturnValue({
+        data: [
+          {
+            profileId: 'p-twitter',
+            platform: 'twitter',
+            handle: 'tester',
+            currentCount: 10,
+            budget: 500,
+            // Start of next UTC month relative to pinned now (= 18d ahead).
+            windowResetAt: '2026-06-01T00:00:00.000Z',
+            monthStartUtc: '2026-05-01T00:00:00.000Z',
+          },
+        ],
+        isLoading: false,
+        isError: false,
+      });
+      renderWithQuery(<RateLimitsCard />);
+
+      // Positive: deterministic relative copy from formatResetTime.
+      expect(screen.getByText(/Resets in 18d/)).toBeInTheDocument();
+      // Negative: the buggy "Resets May 1" label (monthStartUtc-as-reset)
+      // must not render. Anchors the assertion to the actual bug shape.
+      expect(screen.queryByText(/Resets May 1\b/)).not.toBeInTheDocument();
+    });
   });
 
   it('progress bar exposes role="progressbar" with aria-valuenow + aria-valuemax + aria-label', () => {

--- a/packages/web/src/components/dashboard/RateLimitsCard.tsx
+++ b/packages/web/src/components/dashboard/RateLimitsCard.tsx
@@ -188,12 +188,7 @@ export function RateLimitsCard() {
               const percent =
                 limit > 0 ? Math.round((row.currentCount / limit) * 100) : 0;
               const band = resolveBand(percent);
-              // Issue #35: every platform (including Twitter) must display
-              // the FUTURE reset boundary. Previously the Twitter row read
-              // `monthStartUtc` (start of the current window — always in the
-              // past) and rendered a stale "Resets Mar 31". Route the Twitter
-              // row through `formatResetTime` on `windowResetAt` (= start of
-              // next UTC month) like the other platforms.
+              // fix #35 — Twitter's windowResetAt is the future month boundary; no platform branch needed.
               const reset = row.windowResetAt
                 ? formatResetTime(row.windowResetAt, row.platform)
                 : { relative: '', absolute: '' };

--- a/packages/web/src/components/dashboard/RateLimitsCard.tsx
+++ b/packages/web/src/components/dashboard/RateLimitsCard.tsx
@@ -188,20 +188,15 @@ export function RateLimitsCard() {
               const percent =
                 limit > 0 ? Math.round((row.currentCount / limit) * 100) : 0;
               const band = resolveBand(percent);
-              const reset =
-                row.platform === 'twitter'
-                  ? {
-                      relative: '',
-                      absolute: row.monthStartUtc
-                        ? new Date(row.monthStartUtc).toLocaleDateString(
-                            undefined,
-                            { month: 'short', day: 'numeric' },
-                          )
-                        : '1st of next month',
-                    }
-                  : row.windowResetAt
-                  ? formatResetTime(row.windowResetAt, row.platform)
-                  : { relative: '', absolute: '' };
+              // Issue #35: every platform (including Twitter) must display
+              // the FUTURE reset boundary. Previously the Twitter row read
+              // `monthStartUtc` (start of the current window — always in the
+              // past) and rendered a stale "Resets Mar 31". Route the Twitter
+              // row through `formatResetTime` on `windowResetAt` (= start of
+              // next UTC month) like the other platforms.
+              const reset = row.windowResetAt
+                ? formatResetTime(row.windowResetAt, row.platform)
+                : { relative: '', absolute: '' };
 
               const profileLabel = row.handle ?? row.profileId.slice(0, 8);
 


### PR DESCRIPTION
## Summary
- Twitter rate-limit row on the dashboard rendered a stale past date (e.g. "Resets Mar 31" on May 13) because the API set `windowResetAt = monthStartUtc` (start of the **current** window — always in the past) and the dashboard component bypassed `formatResetTime` for Twitter rows.
- Adds `monthResetAtUtc` (start of next UTC calendar month) to the Twitter usage snapshot, threads it through the service + route layers, and routes every platform — Twitter included — through `formatResetTime` so the displayed reset is always a future boundary.
- Time source is injectable via `now?: Date` (mirrors the LinkedIn/Facebook loaders) for deterministic tests.

## Test plan
- [x] Unit (vitest): `loadTwitterUsage` returns `monthResetAtUtc > now` for mid-month, last-day-of-month, just-past-prior-boundary, and Dec→Jan year rollover.
- [x] Unit (vitest): `checkTwitterBudgetWithDb` + `checkBulkBudgetWithDb` propagate `monthResetAtUtc` to callers.
- [x] Route (vitest+supertest): `GET /api/rate-limit/:profileId` returns `windowResetAt = monthResetAtUtc.toISOString()` and `windowResetAt !== monthStartUtc` (issue-#35 regression guard).
- [x] Component (vitest+RTL): `RateLimitsCard` renders "Resets in 18d" for a Twitter row with a future `windowResetAt`, and does NOT render the buggy "Resets May 1" past-date label.
- [x] Full gate: `pnpm test` passes — 1079 tests across api/web/worker/shared/db packages.
- [x] Manual UAT via agent-browser against the running dev stack at `http://localhost:5173/dashboard` — both Twitter rows display "Resets in 18d (Jun 1)" which parses to `2026-06-01T00:00:00.000Z`, strictly after now (`2026-05-13T20:46:46Z`).

Closes #35