### PR TITLE
fix(infra): trust proxy + nginx X-Forwarded-Proto passthrough (closes #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ including `/api/auth/setup`, blocking initial account creation.
 ### Fixed
 
 - **Trust-proxy + X-Forwarded-Proto passthrough** (#50) — `packages/api/src/app.ts`
-  now calls `app.set('trust proxy', 1)` so Express honors `X-Forwarded-Proto`
-  set by the immediately-upstream nginx; secure session and CSRF cookies
-  now actually get set in production. `nginx/nginx.conf` no longer
-  overwrites `X-Forwarded-Proto` with `$scheme` — it passes through what
-  the external reverse proxy (Cloudflare Tunnel / Caddy / Traefik /
-  external nginx) already forwarded, falling back to `$scheme` only when
-  the upstream chain didn't send the header at all (direct LAN access).
+  now trusts only loopback and Docker's private proxy range so Express
+  honors `X-Forwarded-Proto` from the bundled nginx without accepting
+  spoofed forwarded headers from arbitrary clients. Secure session and
+  CSRF cookies now actually get set in production. `nginx/nginx.conf`
+  overwrites `X-Forwarded-For` with `$remote_addr` and accepts only
+  `http` / `https` `X-Forwarded-Proto` values from the external reverse
+  proxy, falling back to `$scheme` otherwise.
   Regression tests in `packages/api/src/__tests__/middleware.test.ts`
   pin the configuration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to the Social Media Scheduler are recorded here. Format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] — 2026-05-14
+
+Hotfix for the first-deploy CSRF / session-cookie failure surfaced by
+the v1.0.0 production deploy. Without this patch, ANY POST behind a
+TLS-terminating reverse proxy returns `403 invalid csrf token` —
+including `/api/auth/setup`, blocking initial account creation.
+
+### Fixed
+
+- **Trust-proxy + X-Forwarded-Proto passthrough** (#50) — `packages/api/src/app.ts`
+  now calls `app.set('trust proxy', 1)` so Express honors `X-Forwarded-Proto`
+  set by the immediately-upstream nginx; secure session and CSRF cookies
+  now actually get set in production. `nginx/nginx.conf` no longer
+  overwrites `X-Forwarded-Proto` with `$scheme` — it passes through what
+  the external reverse proxy (Cloudflare Tunnel / Caddy / Traefik /
+  external nginx) already forwarded, falling back to `$scheme` only when
+  the upstream chain didn't send the header at all (direct LAN access).
+  Regression tests in `packages/api/src/__tests__/middleware.test.ts`
+  pin the configuration.
+
+### Operator note for v1.0.0 → v1.0.1
+
+External reverse proxies in front of the LXC should already be setting
+`X-Forwarded-Proto: https` — Cloudflare Tunnel, Caddy, and Traefik do
+this by default. Custom nginx LAN reverse proxies need:
+
+```nginx
+proxy_set_header X-Forwarded-Proto $scheme;
+```
+
+To upgrade in place: `git pull && git checkout v1.0.1 && docker compose up -d --build`.
+
 ## [1.0.0] — 2026-05-14
 
 First production release. Brings the self-hosted scheduler from empty
@@ -138,4 +170,5 @@ Initial deployment guidance:
 4. Back up `ENCRYPTION_KEY` out-of-band: losing it bricks every
    connected social profile.
 
+[1.0.1]: https://github.com/joshgk00/social-media-scheduler/releases/tag/v1.0.1
 [1.0.0]: https://github.com/joshgk00/social-media-scheduler/releases/tag/v1.0.0

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,15 +26,14 @@ http {
     access_log /dev/stdout main;
     error_log /dev/stderr warn;
 
-    # X-Forwarded-Proto passthrough (issue #50). The bundled nginx is almost
-    # always behind a TLS-terminating reverse proxy (Cloudflare Tunnel,
-    # external Caddy/nginx, Traefik) — honor whatever scheme the upstream
-    # already forwarded so the API can recognize HTTPS requests and set
-    # secure cookies. Fall back to `$scheme` (= http here, since we listen
-    # on port 80) only when the upstream chain didn't send the header at
-    # all (direct LAN access for local testing).
+    # X-Forwarded-Proto passthrough (issue #50). Honor only known scheme
+    # values from an upstream TLS-terminating proxy, otherwise fall back to
+    # this nginx hop's scheme so clients cannot force secure-cookie behavior
+    # by sending arbitrary X-Forwarded-Proto values over plain HTTP.
     map $http_x_forwarded_proto $forwarded_proto {
-        default $http_x_forwarded_proto;
+        default $scheme;
+        "http"  http;
+        "https" https;
         ""      $scheme;
     }
 
@@ -50,7 +49,7 @@ http {
             proxy_pass http://api_backend/health;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $forwarded_proto;
         }
 
@@ -58,7 +57,7 @@ http {
             proxy_pass http://api_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Request-ID $request_id;
 
@@ -71,7 +70,7 @@ http {
             proxy_pass http://api_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Request-ID $request_id;
         }
@@ -80,7 +79,7 @@ http {
             proxy_pass http://api_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Request-ID $request_id;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -26,6 +26,18 @@ http {
     access_log /dev/stdout main;
     error_log /dev/stderr warn;
 
+    # X-Forwarded-Proto passthrough (issue #50). The bundled nginx is almost
+    # always behind a TLS-terminating reverse proxy (Cloudflare Tunnel,
+    # external Caddy/nginx, Traefik) — honor whatever scheme the upstream
+    # already forwarded so the API can recognize HTTPS requests and set
+    # secure cookies. Fall back to `$scheme` (= http here, since we listen
+    # on port 80) only when the upstream chain didn't send the header at
+    # all (direct LAN access for local testing).
+    map $http_x_forwarded_proto $forwarded_proto {
+        default $http_x_forwarded_proto;
+        ""      $scheme;
+    }
+
     upstream api_backend {
         server api:3000;
     }
@@ -39,7 +51,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
         }
 
         location /api/ {
@@ -47,7 +59,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Request-ID $request_id;
 
             proxy_http_version 1.1;
@@ -60,7 +72,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Request-ID $request_id;
         }
 
@@ -69,7 +81,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header X-Request-ID $request_id;
 
             proxy_http_version 1.1;

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -37,7 +37,7 @@ http {
             proxy_pass http://api_backend/health;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
@@ -45,7 +45,7 @@ http {
             proxy_pass http://api_backend/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Request-ID $request_id;
 
@@ -58,7 +58,7 @@ http {
             proxy_pass http://api_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Request-ID $request_id;
         }
@@ -67,7 +67,7 @@ http {
             proxy_pass http://api_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Request-ID $request_id;
 
@@ -80,7 +80,7 @@ http {
             proxy_pass http://web:5173;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-For $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
 
             proxy_http_version 1.1;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sms/api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/api/src/__tests__/helpers/mock-sql.ts
+++ b/packages/api/src/__tests__/helpers/mock-sql.ts
@@ -1,0 +1,8 @@
+import { vi } from 'vitest';
+
+export function createMockSql() {
+  return Object.assign(
+    (_strings: TemplateStringsArray) => Promise.resolve([{ '?column?': 1 }]),
+    { end: vi.fn() },
+  );
+}

--- a/packages/api/src/__tests__/middleware.test.ts
+++ b/packages/api/src/__tests__/middleware.test.ts
@@ -1,14 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { createApp } from '../app.js';
 import { createMockRedis } from './helpers/mock-redis.js';
-
-function createMockSql() {
-  return Object.assign(
-    (strings: TemplateStringsArray) => Promise.resolve([{ '?column?': 1 }]),
-    { end: vi.fn() },
-  );
-}
+import { createMockSql } from './helpers/mock-sql.js';
 
 function createTestApp() {
   return createApp({
@@ -21,9 +16,40 @@ function createTestApp() {
   });
 }
 
+function appWithCleanRedis(appFactory = createApp) {
+  return appFactory({
+    redis: createMockRedis(),
+    sql: createMockSql(),
+    db: {} as any,
+    sessionSecret: 'test-secret-that-is-long-enough-for-session',
+  });
+}
+
+async function appWithFreshEnv(nodeEnv: 'development' | 'production') {
+  vi.resetModules();
+  vi.stubEnv('NODE_ENV', nodeEnv);
+  vi.stubEnv('CSRF_SECRET', 'a'.repeat(64));
+  const { createApp: createFreshApp } = await import('../app.js');
+  return appWithCleanRedis(createFreshApp);
+}
+
+function getSetCookies(res: { headers: Record<string, string | string[] | undefined> }) {
+  const setCookies = res.headers['set-cookie'];
+  if (!setCookies) return [];
+  return Array.isArray(setCookies) ? setCookies : [setCookies];
+}
+
+function findCookie(cookies: string[], name: string) {
+  return cookies.find((cookie) => cookie.startsWith(`${name}=`));
+}
+
 describe('Middleware', () => {
   beforeEach(() => {
-    process.env.CSRF_SECRET = 'a'.repeat(64);
+    vi.stubEnv('CSRF_SECRET', 'a'.repeat(64));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('responses include X-Request-Id header with UUID format', async () => {
@@ -72,13 +98,13 @@ describe('Middleware', () => {
 
 describe('trust proxy (issue #50)', () => {
   beforeEach(() => {
-    process.env.CSRF_SECRET = 'a'.repeat(64);
+    vi.stubEnv('CSRF_SECRET', 'a'.repeat(64));
   });
 
-  // Express stores `trust proxy` as a settings key. The exact value depends
-  // on how it's set: `1` becomes a function that trusts one hop and the
-  // setting key `'trust proxy fn'` becomes truthy. We assert the setting
-  // exists rather than coupling to the internal representation.
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('enables `trust proxy` so X-Forwarded-Proto is honored behind a reverse proxy', () => {
     const app = createTestApp();
     // Express normalizes any non-false `trust proxy` setting into a function
@@ -89,69 +115,49 @@ describe('trust proxy (issue #50)', () => {
     expect(typeof app.get('trust proxy fn')).toBe('function');
   });
 
-  it('trust-proxy fn accepts the immediately-upstream proxy', () => {
+  it('trust-proxy fn accepts only loopback and the bundled Docker proxy range', () => {
     // Express stores trust-proxy as a compiled function `(addr, hopIdx) => boolean`.
-    // With `app.set('trust proxy', 1)`, the function trusts ONE hop — i.e.
-    // returns true at hopIdx=0 regardless of the address, so req.protocol /
-    // req.secure / req.ip are read from X-Forwarded-* headers set by the
-    // first proxy upstream of Express. This is the API behavior on which
-    // the session and CSRF cookie-secure logic depends; without trust proxy
-    // configured, this function would always return false.
+    // The bundled nginx reaches the API from Docker's private 172.16/12
+    // range; arbitrary LAN or sidecar sources should not be able to forge
+    // X-Forwarded-* and affect req.ip/rate-limit keys.
     const app = createTestApp();
     const trustFn = app.get('trust proxy fn') as (
       addr: string,
       hopIdx: number,
     ) => boolean;
     expect(typeof trustFn).toBe('function');
-    expect(trustFn('10.0.0.1', 0)).toBe(true);
-    // Past the first hop, trust is denied — guards against header spoofing
-    // through additional unknown proxies.
-    expect(trustFn('10.0.0.1', 1)).toBe(false);
+    expect(trustFn('127.0.0.1', 0)).toBe(true);
+    expect(trustFn('172.18.0.5', 0)).toBe(true);
+    expect(trustFn('10.0.0.1', 0)).toBe(false);
+    expect(trustFn('192.168.1.10', 0)).toBe(false);
   });
 
-  // End-to-end coverage of the production failure mode (Copilot review #51):
-  // it's not enough to verify that `trust proxy` is set — we need to confirm
-  // that a request with `X-Forwarded-Proto: https` actually causes the
-  // session cookie to be issued with the `Secure` attribute. Without trust
-  // proxy, Express would treat the request as insecure and emit the cookie
-  // WITHOUT the Secure flag (or, with secure:true and saveUninitialized:true,
-  // the cookie still gets written but the browser would reject it on the
-  // next non-HTTPS request because we'd be in an inconsistent state). Either
-  // way, `Secure` in the Set-Cookie header is the load-bearing observable.
-  // Helper: build an app with a clean Redis mock so the session middleware
-  // can actually create + persist sessions (the shared `createTestApp` helper
-  // overrides `redis.get` to a non-JSON value, which prevents connect-redis
-  // from issuing the session cookie).
-  function appWithCleanRedis() {
-    return createApp({
-      redis: createMockRedis(),
-      sql: createMockSql(),
-      db: {} as any,
-      sessionSecret: 'test-secret-that-is-long-enough-for-session',
-    });
-  }
+  it('nginx overwrites spoofable forwarded headers before proxying to the API', () => {
+    const prodConfig = readFileSync(new URL('../../../../nginx/nginx.conf', import.meta.url), 'utf8');
+    const devConfig = readFileSync(new URL('../../../../nginx/nginx.dev.conf', import.meta.url), 'utf8');
 
-  it('issues session cookie with Secure flag when X-Forwarded-Proto: https in production', async () => {
-    const prevNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
-    try {
-      const app = appWithCleanRedis();
-      const res = await request(app)
-        .get('/health')
-        .set('X-Forwarded-Proto', 'https');
-      // saveUninitialized:true in session middleware means EVERY first
-      // request gets a sms.sid cookie set in the response, even if no
-      // session data is mutated.
-      const setCookies = res.headers['set-cookie'];
-      expect(setCookies).toBeDefined();
-      const cookieArray = Array.isArray(setCookies) ? setCookies : [setCookies];
-      const sessionCookie = cookieArray.find((c) => c.startsWith('sms.sid='));
-      expect(sessionCookie).toBeDefined();
-      // The smoking-gun observable: Secure attribute is present.
-      expect(sessionCookie).toMatch(/;\s*Secure(?:;|$)/);
-    } finally {
-      process.env.NODE_ENV = prevNodeEnv;
-    }
+    expect(prodConfig).not.toContain('$proxy_add_x_forwarded_for');
+    expect(devConfig).not.toContain('$proxy_add_x_forwarded_for');
+    expect(prodConfig.match(/proxy_set_header X-Forwarded-For \$remote_addr;/g)).toHaveLength(4);
+    expect(devConfig.match(/proxy_set_header X-Forwarded-For \$remote_addr;/g)).toHaveLength(5);
+    expect(prodConfig).toContain('default $scheme;');
+    expect(prodConfig).toContain('"http"  http;');
+    expect(prodConfig).toContain('"https" https;');
+  });
+
+  it('issues session and CSRF cookies with Secure flag when X-Forwarded-Proto: https in production', async () => {
+    const app = await appWithFreshEnv('production');
+    const res = await request(app)
+      .get('/api/auth/csrf-token')
+      .set('X-Forwarded-Proto', 'https');
+    const cookies = getSetCookies(res);
+    const sessionCookie = findCookie(cookies, 'sms.sid');
+    const csrfCookie = findCookie(cookies, '__csrf');
+
+    expect(sessionCookie).toBeDefined();
+    expect(csrfCookie).toBeDefined();
+    expect(sessionCookie).toMatch(/;\s*Secure(?:;|$)/);
+    expect(csrfCookie).toMatch(/;\s*Secure(?:;|$)/);
   });
 
   it('does NOT issue the secure session cookie over plain HTTP in production (no leak)', async () => {
@@ -162,25 +168,33 @@ describe('trust proxy (issue #50)', () => {
     // X-Forwarded-Proto: https for cookies to flow. This test pins the safety
     // semantic so a misconfigured proxy never silently exposes the cookie
     // over plain HTTP.
-    const prevNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
-    try {
-      const app = appWithCleanRedis();
-      const res = await request(app)
-        .get('/health')
-        .set('X-Forwarded-Proto', 'http');
-      const setCookies = res.headers['set-cookie'];
-      const cookieArray = Array.isArray(setCookies)
-        ? setCookies
-        : setCookies
-        ? [setCookies]
-        : [];
-      const sessionCookie = cookieArray.find(
-        (c) => typeof c === 'string' && c.startsWith('sms.sid='),
-      );
-      expect(sessionCookie).toBeUndefined();
-    } finally {
-      process.env.NODE_ENV = prevNodeEnv;
-    }
+    const app = await appWithFreshEnv('production');
+    const res = await request(app)
+      .get('/health')
+      .set('X-Forwarded-Proto', 'http');
+    const sessionCookie = findCookie(getSetCookies(res), 'sms.sid');
+    expect(sessionCookie).toBeUndefined();
+  });
+
+  it('does NOT issue the secure session cookie in production when X-Forwarded-Proto is absent', async () => {
+    const app = await appWithFreshEnv('production');
+    const res = await request(app).get('/health');
+    const sessionCookie = findCookie(getSetCookies(res), 'sms.sid');
+    expect(sessionCookie).toBeUndefined();
+  });
+
+  it('issues non-Secure session and CSRF cookies in development even when X-Forwarded-Proto is https', async () => {
+    const app = await appWithFreshEnv('development');
+    const res = await request(app)
+      .get('/api/auth/csrf-token')
+      .set('X-Forwarded-Proto', 'https');
+    const cookies = getSetCookies(res);
+    const sessionCookie = findCookie(cookies, 'sms.sid');
+    const csrfCookie = findCookie(cookies, '__csrf');
+
+    expect(sessionCookie).toBeDefined();
+    expect(csrfCookie).toBeDefined();
+    expect(sessionCookie).not.toMatch(/;\s*Secure(?:;|$)/);
+    expect(csrfCookie).not.toMatch(/;\s*Secure(?:;|$)/);
   });
 });

--- a/packages/api/src/__tests__/middleware.test.ts
+++ b/packages/api/src/__tests__/middleware.test.ts
@@ -108,4 +108,79 @@ describe('trust proxy (issue #50)', () => {
     // through additional unknown proxies.
     expect(trustFn('10.0.0.1', 1)).toBe(false);
   });
+
+  // End-to-end coverage of the production failure mode (Copilot review #51):
+  // it's not enough to verify that `trust proxy` is set — we need to confirm
+  // that a request with `X-Forwarded-Proto: https` actually causes the
+  // session cookie to be issued with the `Secure` attribute. Without trust
+  // proxy, Express would treat the request as insecure and emit the cookie
+  // WITHOUT the Secure flag (or, with secure:true and saveUninitialized:true,
+  // the cookie still gets written but the browser would reject it on the
+  // next non-HTTPS request because we'd be in an inconsistent state). Either
+  // way, `Secure` in the Set-Cookie header is the load-bearing observable.
+  // Helper: build an app with a clean Redis mock so the session middleware
+  // can actually create + persist sessions (the shared `createTestApp` helper
+  // overrides `redis.get` to a non-JSON value, which prevents connect-redis
+  // from issuing the session cookie).
+  function appWithCleanRedis() {
+    return createApp({
+      redis: createMockRedis(),
+      sql: createMockSql(),
+      db: {} as any,
+      sessionSecret: 'test-secret-that-is-long-enough-for-session',
+    });
+  }
+
+  it('issues session cookie with Secure flag when X-Forwarded-Proto: https in production', async () => {
+    const prevNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const app = appWithCleanRedis();
+      const res = await request(app)
+        .get('/health')
+        .set('X-Forwarded-Proto', 'https');
+      // saveUninitialized:true in session middleware means EVERY first
+      // request gets a sms.sid cookie set in the response, even if no
+      // session data is mutated.
+      const setCookies = res.headers['set-cookie'];
+      expect(setCookies).toBeDefined();
+      const cookieArray = Array.isArray(setCookies) ? setCookies : [setCookies];
+      const sessionCookie = cookieArray.find((c) => c.startsWith('sms.sid='));
+      expect(sessionCookie).toBeDefined();
+      // The smoking-gun observable: Secure attribute is present.
+      expect(sessionCookie).toMatch(/;\s*Secure(?:;|$)/);
+    } finally {
+      process.env.NODE_ENV = prevNodeEnv;
+    }
+  });
+
+  it('does NOT issue the secure session cookie over plain HTTP in production (no leak)', async () => {
+    // Negative case for the original production bug: with X-Forwarded-Proto:
+    // http and cookie.secure:true, express-session refuses to set the cookie
+    // at all — exactly the production failure mode that motivated issue #50.
+    // The fix is upstream: an external reverse proxy MUST forward
+    // X-Forwarded-Proto: https for cookies to flow. This test pins the safety
+    // semantic so a misconfigured proxy never silently exposes the cookie
+    // over plain HTTP.
+    const prevNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const app = appWithCleanRedis();
+      const res = await request(app)
+        .get('/health')
+        .set('X-Forwarded-Proto', 'http');
+      const setCookies = res.headers['set-cookie'];
+      const cookieArray = Array.isArray(setCookies)
+        ? setCookies
+        : setCookies
+        ? [setCookies]
+        : [];
+      const sessionCookie = cookieArray.find(
+        (c) => typeof c === 'string' && c.startsWith('sms.sid='),
+      );
+      expect(sessionCookie).toBeUndefined();
+    } finally {
+      process.env.NODE_ENV = prevNodeEnv;
+    }
+  });
 });

--- a/packages/api/src/__tests__/middleware.test.ts
+++ b/packages/api/src/__tests__/middleware.test.ts
@@ -69,3 +69,43 @@ describe('Middleware', () => {
     expect(res.headers['x-request-id']).toBe(customId);
   });
 });
+
+describe('trust proxy (issue #50)', () => {
+  beforeEach(() => {
+    process.env.CSRF_SECRET = 'a'.repeat(64);
+  });
+
+  // Express stores `trust proxy` as a settings key. The exact value depends
+  // on how it's set: `1` becomes a function that trusts one hop and the
+  // setting key `'trust proxy fn'` becomes truthy. We assert the setting
+  // exists rather than coupling to the internal representation.
+  it('enables `trust proxy` so X-Forwarded-Proto is honored behind a reverse proxy', () => {
+    const app = createTestApp();
+    // Express normalizes any non-false `trust proxy` setting into a function
+    // and stores the original at `'trust proxy'` plus the resolved fn at
+    // `'trust proxy fn'`. Both must be set when trust-proxy is enabled.
+    expect(app.get('trust proxy')).not.toBe(false);
+    expect(app.get('trust proxy fn')).toBeDefined();
+    expect(typeof app.get('trust proxy fn')).toBe('function');
+  });
+
+  it('trust-proxy fn accepts the immediately-upstream proxy', () => {
+    // Express stores trust-proxy as a compiled function `(addr, hopIdx) => boolean`.
+    // With `app.set('trust proxy', 1)`, the function trusts ONE hop — i.e.
+    // returns true at hopIdx=0 regardless of the address, so req.protocol /
+    // req.secure / req.ip are read from X-Forwarded-* headers set by the
+    // first proxy upstream of Express. This is the API behavior on which
+    // the session and CSRF cookie-secure logic depends; without trust proxy
+    // configured, this function would always return false.
+    const app = createTestApp();
+    const trustFn = app.get('trust proxy fn') as (
+      addr: string,
+      hopIdx: number,
+    ) => boolean;
+    expect(typeof trustFn).toBe('function');
+    expect(trustFn('10.0.0.1', 0)).toBe(true);
+    // Past the first hop, trust is denied — guards against header spoofing
+    // through additional unknown proxies.
+    expect(trustFn('10.0.0.1', 1)).toBe(false);
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -63,6 +63,18 @@ export function createApp({
 }: AppDependencies) {
   const app = express();
 
+  // Trust the immediately-upstream proxy (the bundled nginx in the docker
+  // network) so Express reads `req.secure` and `req.ip` from the X-Forwarded-*
+  // headers it sets. Required for production deployments behind a TLS-
+  // terminating reverse proxy — without this, the session and CSRF cookies
+  // (both `cookie.secure: true` in production) silently never get set,
+  // every request gets a fresh session, and CSRF double-submit verification
+  // always fails. The value `1` trusts exactly one hop (nginx); the bundled
+  // nginx is responsible for honoring/passing whatever the external reverse
+  // proxy already forwarded, so this stays correct under chained proxies
+  // (Cloudflare → LAN reverse proxy → bundled nginx → api). See issue #50.
+  app.set('trust proxy', 1);
+
   app.use(correlationId);
   app.use(httpLogger);
   app.use(securityHeaders);

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -50,6 +50,8 @@ interface AppDependencies {
   transcodeQueue?: Queue;
 }
 
+const TRUSTED_PROXY_CIDRS = ['loopback', '172.16.0.0/12'];
+
 export function createApp({
   redis,
   sql,
@@ -63,17 +65,12 @@ export function createApp({
 }: AppDependencies) {
   const app = express();
 
-  // Trust the immediately-upstream proxy (the bundled nginx in the docker
-  // network) so Express reads `req.secure` and `req.ip` from the X-Forwarded-*
-  // headers it sets. Required for production deployments behind a TLS-
-  // terminating reverse proxy — without this, the session and CSRF cookies
-  // (both `cookie.secure: true` in production) silently never get set,
-  // every request gets a fresh session, and CSRF double-submit verification
-  // always fails. The value `1` trusts exactly one hop (nginx); the bundled
-  // nginx is responsible for honoring/passing whatever the external reverse
-  // proxy already forwarded, so this stays correct under chained proxies
-  // (Cloudflare → LAN reverse proxy → bundled nginx → api). See issue #50.
-  app.set('trust proxy', 1);
+  // Trust only loopback test/dev callers and the Docker private range where
+  // the bundled nginx reaches the API. This lets Express honor nginx's
+  // X-Forwarded-* headers for secure-cookie detection while avoiding the
+  // "trust any immediate hop" behavior that lets arbitrary clients spoof
+  // req.ip and bypass per-IP rate limiters. See issue #50.
+  app.set('trust proxy', TRUSTED_PROXY_CIDRS);
 
   app.use(correlationId);
   app.use(httpLogger);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sms/db",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sms/shared",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sms/web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sms/worker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Hotfix for the v1.0.0 first-deploy blocker (issue #50). Without this patch, ANY POST behind a TLS-terminating reverse proxy returns `403 invalid csrf token` — including `/api/auth/setup`, so no one can create the initial account.

## Root cause (two compounding bugs, single fix)

1. **`packages/api/src/app.ts` never set `trust proxy`.** Express read `req.protocol` from the raw TCP socket (always `http` inside the docker network), so `req.secure === false`, so the session and CSRF cookies (both `cookie.secure: true` in production) silently never got set. Every request got a fresh session → CSRF double-submit always failed.

2. **`nginx/nginx.conf` overwrote upstream `X-Forwarded-Proto` with `$scheme`.** The bundled nginx listens on port 80, so `$scheme = http`. Any external reverse proxy that correctly forwarded `X-Forwarded-Proto: https` had its value clobbered before reaching the API.

## What changed

- `packages/api/src/app.ts:65` — added `app.set('trust proxy', 1)` immediately after `const app = express()`. Trusts exactly one hop (the bundled nginx). Chained proxies upstream of nginx stay clean — nginx forwards what it received, Express trusts nginx, and the hop count never inflates regardless of how many external proxies are in front.

- `nginx/nginx.conf` — added a `map` block at http scope that prefers upstream `X-Forwarded-Proto` and falls back to `$scheme` only when no upstream header is present. All four `location` blocks (`/health`, `/api/`, `/media/`, `/admin/`) now use the mapped variable.

- `packages/api/src/__tests__/middleware.test.ts` — added a `describe('trust proxy (issue #50)')` block with two regression tests pinning the trust-proxy configuration and hop-1 acceptance behavior.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` — chained exit 0, **1085 tests passing** (api +2: `trust-proxy fn` is configured, accepts hop 1 / rejects hop 2)
- [x] Confirmed in-place on production LXC: same patch applied as a hotfix, account creation now succeeds, browser session and CSRF cookie persist across requests

## Operator note for v1.0.0 → v1.0.1

External reverse proxies should already be setting `X-Forwarded-Proto: https`. Cloudflare Tunnel, Caddy, and Traefik do this by default. Custom nginx LAN reverse proxies need:

```nginx
proxy_set_header X-Forwarded-Proto \$scheme;
```

Upgrade in place: `git pull && git checkout v1.0.1 && docker compose up -d --build`.

Closes #50.