### PR TITLE
[codex] Fix profile delete cleanup

### DIFF
--- a/packages/api/src/__tests__/error-handler.test.ts
+++ b/packages/api/src/__tests__/error-handler.test.ts
@@ -51,6 +51,26 @@ describe('errorHandler middleware', () => {
     expect(res.body.error).toBe('This post was modified elsewhere.');
   });
 
+  it('includes AppError subclass code when present', async () => {
+    class TestServiceError extends AppError {
+      public readonly code = 'profile_delete_failed';
+    }
+
+    const app = createTestApp();
+    app.get('/fail', (_req, _res, next) => {
+      next(new TestServiceError('Could not delete profile.', 500));
+    });
+    app.use(errorHandler);
+
+    const res = await request(app).get('/fail');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toMatchObject({
+      error: 'Could not delete profile.',
+      code: 'profile_delete_failed',
+    });
+  });
+
   it('returns 500 for generic errors', async () => {
     const app = createTestApp();
     app.get('/fail', (_req, _res, next) => {

--- a/packages/api/src/__tests__/routes/profiles.test.ts
+++ b/packages/api/src/__tests__/routes/profiles.test.ts
@@ -322,6 +322,22 @@ describe('profiles routes', () => {
       expect(res.status).toBe(409);
       expect(res.body.error).toContain('in-flight posts');
     });
+
+    it('returns a stable error code and correlation id for unexpected delete failures', async () => {
+      mockDeleteProfile.mockRejectedValueOnce(new Error('foreign key violation'));
+      const agent = await authenticatedAgent();
+
+      const res = await agent
+        .delete(`/api/profiles/${PROFILE_UUID}`)
+        .set('x-request-id', 'delete-profile-request-id');
+
+      expect(res.status).toBe(500);
+      expect(res.body).toMatchObject({
+        error: 'Could not delete profile. Try again or contact support with this request ID.',
+        code: 'profile_delete_failed',
+        correlationId: 'delete-profile-request-id',
+      });
+    });
   });
 
   // Phase 7 Plan 05 — PATCH metadata + delete-preview + extended GET list

--- a/packages/api/src/__tests__/routes/profiles.test.ts
+++ b/packages/api/src/__tests__/routes/profiles.test.ts
@@ -11,11 +11,19 @@ const mockDeleteProfile = vi.fn();
 const mockUpdateProfileMetadata = vi.fn();
 const mockGetDeletePreview = vi.fn();
 
-vi.mock('../../services/profile.service.js', () => {
-  class ProfileServiceError extends Error {
-    constructor(message: string, public readonly statusCode: number) {
-      super(message);
-      this.name = 'ProfileServiceError';
+vi.mock('../../services/profile.service.js', async () => {
+  const { AppError } = await vi.importActual<typeof import('@sms/shared')>('@sms/shared');
+
+  class ProfileServiceError extends AppError {
+    public readonly code?: string;
+
+    constructor(
+      message: string,
+      statusCode: number,
+      code?: string,
+    ) {
+      super(message, statusCode);
+      this.code = code;
     }
   }
   return {
@@ -326,16 +334,17 @@ describe('profiles routes', () => {
     it('returns a stable error code and correlation id for unexpected delete failures', async () => {
       mockDeleteProfile.mockRejectedValueOnce(new Error('foreign key violation'));
       const agent = await authenticatedAgent();
+      const requestId = '550e8400-e29b-41d4-a716-446655440000';
 
       const res = await agent
         .delete(`/api/profiles/${PROFILE_UUID}`)
-        .set('x-request-id', 'delete-profile-request-id');
+        .set('x-request-id', requestId);
 
       expect(res.status).toBe(500);
       expect(res.body).toMatchObject({
         error: 'Could not delete profile. Try again or contact support with this request ID.',
         code: 'profile_delete_failed',
-        correlationId: 'delete-profile-request-id',
+        correlationId: requestId,
       });
     });
   });
@@ -490,7 +499,7 @@ describe('profiles routes', () => {
       mockGetDeletePreview.mockResolvedValueOnce({
         drafts: 3,
         scheduled: 5,
-        queueMemberships: 2,
+        ownedQueues: 2,
         tagsLosingLastUse: 1,
         inFlight: 0,
       });
@@ -502,7 +511,7 @@ describe('profiles routes', () => {
       expect(res.body).toEqual({
         drafts: 3,
         scheduled: 5,
-        queueMemberships: 2,
+        ownedQueues: 2,
         tagsLosingLastUse: 1,
         inFlight: 0,
       });

--- a/packages/api/src/__tests__/services/profile.test.ts
+++ b/packages/api/src/__tests__/services/profile.test.ts
@@ -395,8 +395,10 @@ describe('profile.service', () => {
       expect(updateChain.set).toHaveBeenCalledWith({
         profileId: null,
         queueId: null,
-        updatedAt: expect.any(Date),
       });
+      expect(tx.select.mock.invocationCallOrder[0]).toBeLessThan(
+        tx.update.mock.invocationCallOrder[0],
+      );
       expect(tx.delete).toHaveBeenNthCalledWith(1, mockQueues);
       expect(queueDeleteChain.returning).toHaveBeenCalledWith({ id: mockQueues.id });
       expect(tx.delete).toHaveBeenNthCalledWith(2, mockSocialProfiles);
@@ -408,9 +410,11 @@ describe('profile.service', () => {
       await expect(deleteProfile(db, USER_ID, PROFILE_ID)).resolves.toBe(false);
     });
 
-    it('blocks deletion when the profile has in-flight posts', async () => {
+    it('blocks deletion before partial cleanup when any in-flight post exists', async () => {
       const { db, tx } = createDeleteProfileDb({
-        inFlightPosts: [{ id: 'post-1' }],
+        inFlightPosts: [{ id: 'queued-post' }],
+        detachedPosts: [{ id: 'scheduled-post' }],
+        deletedQueues: [{ id: 'queue-1' }],
       });
 
       await expect(deleteProfile(db, USER_ID, PROFILE_ID)).rejects.toMatchObject({

--- a/packages/api/src/__tests__/services/profile.test.ts
+++ b/packages/api/src/__tests__/services/profile.test.ts
@@ -22,9 +22,15 @@ const socialProfileColumns = [
 ];
 
 const mockSocialProfiles = makeTableStub('social_profiles', socialProfileColumns);
+const mockPosts = makeTableStub('posts', [
+  'id', 'userId', 'profileId', 'queueId', 'status', 'updatedAt',
+]);
+const mockQueues = makeTableStub('queues', ['id', 'userId', 'profileId']);
 
 vi.mock('@sms/db', () => ({
   socialProfiles: mockSocialProfiles,
+  posts: mockPosts,
+  queues: mockQueues,
 }));
 
 const mockEncrypt = vi.fn().mockReturnValue({
@@ -77,6 +83,8 @@ const SAFE_PROFILE = {
   connectedAt: new Date(),
   lastPublishedAt: null,
 };
+const USER_ID = 'user-1';
+const PROFILE_ID = 'profile-uuid-1';
 
 function createMockDb(overrides: {
   selectResult?: unknown[];
@@ -109,6 +117,50 @@ function createMockDb(overrides: {
   } as any;
 }
 
+function chainReturning(result: unknown[]) {
+  const chain: Record<string, any> = {};
+  for (const method of ['from', 'where', 'limit', 'set', 'returning']) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+function createDeleteProfileDb(overrides: {
+  inFlightPosts?: unknown[];
+  detachedPosts?: unknown[];
+  deletedQueues?: unknown[];
+  deletedProfiles?: unknown[];
+} = {}) {
+  const inFlightChain = chainReturning(overrides.inFlightPosts ?? []);
+  const updateChain = chainReturning(overrides.detachedPosts ?? []);
+  const queueDeleteChain = chainReturning(overrides.deletedQueues ?? []);
+  const profileDeleteChain = chainReturning(
+    overrides.deletedProfiles ?? [{ id: 'profile-uuid-1' }],
+  );
+
+  const tx = {
+    select: vi.fn().mockReturnValue(inFlightChain),
+    update: vi.fn().mockReturnValue(updateChain),
+    delete: vi.fn()
+      .mockReturnValueOnce(queueDeleteChain)
+      .mockReturnValueOnce(profileDeleteChain),
+  };
+
+  const db = {
+    transaction: vi.fn(async (callback: (tx: unknown) => unknown) => callback(tx)),
+  };
+
+  return {
+    db: db as any,
+    tx,
+    inFlightChain,
+    updateChain,
+    queueDeleteChain,
+    profileDeleteChain,
+  };
+}
+
 const TEST_CREDENTIALS = {
   consumerKey: 'ck-test-value-abc123',
   consumerSecret: 'cs-test-value-def456',
@@ -120,6 +172,7 @@ describe('profile.service', () => {
   let createProfile: typeof import('../../services/profile.service.js').createProfile;
   let getProfiles: typeof import('../../services/profile.service.js').getProfiles;
   let validateTwitterCredentials: typeof import('../../services/profile.service.js').validateTwitterCredentials;
+  let deleteProfile: typeof import('../../services/profile.service.js').deleteProfile;
 
   beforeEach(async () => {
     mockEncrypt.mockClear();
@@ -156,6 +209,7 @@ describe('profile.service', () => {
     createProfile = mod.createProfile;
     getProfiles = mod.getProfiles;
     validateTwitterCredentials = mod.validateTwitterCredentials;
+    deleteProfile = mod.deleteProfile;
   });
 
   describe('createProfile', () => {
@@ -326,7 +380,44 @@ describe('profile.service', () => {
   });
 
   describe('deleteProfile', () => {
-    it.todo('deletes profile by id and userId');
-    it.todo('returns false when profile does not exist');
+    it('detaches related posts, deletes queues, and deletes the profile in one transaction', async () => {
+      const { db, tx, updateChain, queueDeleteChain } = createDeleteProfileDb({
+        detachedPosts: [{ id: 'post-1' }],
+        deletedQueues: [{ id: 'queue-1' }],
+        deletedProfiles: [{ id: PROFILE_ID }],
+      });
+
+      const result = await deleteProfile(db, USER_ID, PROFILE_ID);
+
+      expect(result).toBe(true);
+      expect(db.transaction).toHaveBeenCalledTimes(1);
+      expect(tx.update).toHaveBeenCalledWith(mockPosts);
+      expect(updateChain.set).toHaveBeenCalledWith({
+        profileId: null,
+        queueId: null,
+        updatedAt: expect.any(Date),
+      });
+      expect(tx.delete).toHaveBeenNthCalledWith(1, mockQueues);
+      expect(queueDeleteChain.returning).toHaveBeenCalledWith({ id: mockQueues.id });
+      expect(tx.delete).toHaveBeenNthCalledWith(2, mockSocialProfiles);
+    });
+
+    it('returns false when profile does not exist', async () => {
+      const { db } = createDeleteProfileDb({ deletedProfiles: [] });
+
+      await expect(deleteProfile(db, USER_ID, PROFILE_ID)).resolves.toBe(false);
+    });
+
+    it('blocks deletion when the profile has in-flight posts', async () => {
+      const { db, tx } = createDeleteProfileDb({
+        inFlightPosts: [{ id: 'post-1' }],
+      });
+
+      await expect(deleteProfile(db, USER_ID, PROFILE_ID)).rejects.toMatchObject({
+        statusCode: 409,
+      });
+      expect(tx.update).not.toHaveBeenCalled();
+      expect(tx.delete).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/api/src/middleware/error-handler.ts
+++ b/packages/api/src/middleware/error-handler.ts
@@ -7,7 +7,12 @@ export function errorHandler(err: Error, req: Request, res: Response, _next: Nex
   logger.error({ err, correlationId }, 'Unhandled error');
 
   if (err instanceof AppError) {
-    res.status(err.statusCode).json({ error: err.message, correlationId });
+    const code = (err as { code?: unknown }).code;
+    res.status(err.statusCode).json({
+      error: err.message,
+      ...(typeof code === 'string' ? { code } : {}),
+      correlationId,
+    });
     return;
   }
 

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -7,6 +7,7 @@ import {
 } from '@sms/shared';
 import type { Db } from '@sms/db';
 import { socialProfiles } from '@sms/db';
+import { createLogger } from '@sms/shared/logger';
 
 import {
   createProfile,
@@ -21,6 +22,8 @@ import { checkTwitterBudgetWithDb } from '../services/rate-limit.service.js';
 import { requireAuth } from '../middleware/auth-guard.js';
 import { profileLimiter } from '../middleware/rate-limiter.js';
 import { validateUuidParam } from '../middleware/validation.js';
+
+const logger = createLogger('profiles-router');
 
 interface ProfilesDependencies {
   db: Db;
@@ -65,8 +68,9 @@ export function createProfilesRouter({ db }: ProfilesDependencies) {
 
   router.delete('/api/profiles/:id', requireAuth, async (req, res) => {
     const profileId = validateUuidParam(req.params.id as string);
+    const userId = req.session.userId!;
     try {
-      const isDeleted = await deleteProfile(db, req.session.userId!, profileId);
+      const isDeleted = await deleteProfile(db, userId, profileId);
       if (!isDeleted) {
         res.status(404).json({ error: 'Profile not found' });
         return;
@@ -77,7 +81,16 @@ export function createProfilesRouter({ db }: ProfilesDependencies) {
         res.status(err.statusCode).json({ error: err.message });
         return;
       }
-      throw err;
+      const correlationId = (req as { id?: string }).id ?? 'unknown';
+      logger.error(
+        { err, profileId, userId, correlationId },
+        'Profile delete failed',
+      );
+      res.status(500).json({
+        error: 'Could not delete profile. Try again or contact support with this request ID.',
+        code: 'profile_delete_failed',
+        correlationId,
+      });
     }
   });
 

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -1,4 +1,5 @@
-import { Router } from 'express';
+import { randomUUID } from 'node:crypto';
+import { Router, type NextFunction } from 'express';
 import { and, eq } from 'drizzle-orm';
 import {
   createProfileSchema,
@@ -24,6 +25,11 @@ import { profileLimiter } from '../middleware/rate-limiter.js';
 import { validateUuidParam } from '../middleware/validation.js';
 
 const logger = createLogger('profiles-router');
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function requestCorrelationId(req: { id?: string }): string {
+  return req.id && UUID_PATTERN.test(req.id) ? req.id : randomUUID();
+}
 
 interface ProfilesDependencies {
   db: Db;
@@ -66,7 +72,7 @@ export function createProfilesRouter({ db }: ProfilesDependencies) {
     res.json(profile);
   });
 
-  router.delete('/api/profiles/:id', requireAuth, async (req, res) => {
+  router.delete('/api/profiles/:id', requireAuth, async (req, res, next: NextFunction) => {
     const profileId = validateUuidParam(req.params.id as string);
     const userId = req.session.userId!;
     try {
@@ -81,16 +87,17 @@ export function createProfilesRouter({ db }: ProfilesDependencies) {
         res.status(err.statusCode).json({ error: err.message });
         return;
       }
-      const correlationId = (req as { id?: string }).id ?? 'unknown';
+      const correlationId = requestCorrelationId(req as { id?: string });
+      (req as { id?: string }).id = correlationId;
       logger.error(
         { err, profileId, userId, correlationId },
         'Profile delete failed',
       );
-      res.status(500).json({
-        error: 'Could not delete profile. Try again or contact support with this request ID.',
-        code: 'profile_delete_failed',
-        correlationId,
-      });
+      next(new ProfileServiceError(
+        'Could not delete profile. Try again or contact support with this request ID.',
+        500,
+        'profile_delete_failed',
+      ));
     }
   });
 

--- a/packages/api/src/services/__tests__/profile.service.test.ts
+++ b/packages/api/src/services/__tests__/profile.service.test.ts
@@ -627,18 +627,23 @@ describe('getDeletePreview', () => {
 
   /**
    * Builds a mock db whose select().from(posts).where(...) resolves to a
-   * list of count rows — one per COUNT query. Queue counts hit the same
-   * `posts` table (via queueId IS NOT NULL) so one sequence is sufficient.
+   * list of count rows — one per COUNT query. Owned queue counts hit the
+   * `queues` table, but the fluent count stub can return them in sequence.
    * The tagsLosingLastUse query uses db.execute with raw SQL.
    */
   function setupCounts(counts: {
     drafts: number;
     scheduled: number;
-    queueMemberships: number;
+    ownedQueues: number;
     inFlight: number;
     tagsLosingLastUse: number;
   }) {
-    const sequence: number[] = [counts.drafts, counts.scheduled, counts.queueMemberships, counts.inFlight];
+    const sequence: number[] = [
+      counts.drafts,
+      counts.scheduled,
+      counts.ownedQueues,
+      counts.inFlight,
+    ];
     const db = createMockDb();
     let selectCallIndex = 0;
 
@@ -659,7 +664,7 @@ describe('getDeletePreview', () => {
     const db = setupCounts({
       drafts: 3,
       scheduled: 5,
-      queueMemberships: 2,
+      ownedQueues: 2,
       inFlight: 1,
       tagsLosingLastUse: 4,
     });
@@ -669,7 +674,7 @@ describe('getDeletePreview', () => {
     expect(preview).toEqual({
       drafts: 3,
       scheduled: 5,
-      queueMemberships: 2,
+      ownedQueues: 2,
       inFlight: 1,
       tagsLosingLastUse: 4,
     });
@@ -679,7 +684,7 @@ describe('getDeletePreview', () => {
     const db = setupCounts({
       drafts: 0,
       scheduled: 0,
-      queueMemberships: 0,
+      ownedQueues: 0,
       inFlight: 0,
       tagsLosingLastUse: 0,
     });
@@ -689,7 +694,7 @@ describe('getDeletePreview', () => {
     expect(preview).toEqual({
       drafts: 0,
       scheduled: 0,
-      queueMemberships: 0,
+      ownedQueues: 0,
       inFlight: 0,
       tagsLosingLastUse: 0,
     });
@@ -699,7 +704,7 @@ describe('getDeletePreview', () => {
     const db = setupCounts({
       drafts: 0,
       scheduled: 0,
-      queueMemberships: 0,
+      ownedQueues: 0,
       inFlight: 0,
       tagsLosingLastUse: 1,
     });

--- a/packages/api/src/services/profile.service.ts
+++ b/packages/api/src/services/profile.service.ts
@@ -3,7 +3,7 @@ import { encrypt, validateEncryptionKey } from '@sms/shared/encryption';
 import { AppError } from '@sms/shared';
 import { createLogger } from '@sms/shared/logger';
 import type { Db } from '@sms/db';
-import { socialProfiles, posts } from '@sms/db';
+import { socialProfiles, posts, queues } from '@sms/db';
 import { TwitterApi } from 'twitter-api-v2';
 import { OAuthServiceError, MismatchedAccountError } from './oauth.service.js';
 
@@ -41,6 +41,7 @@ export interface DeletePreview {
 }
 
 const logger = createLogger('profile-service');
+const IN_FLIGHT_STATES = ['queued', 'publishing', 'auto_destructing'] as const;
 
 // Subclass exists so structured logs show 'ProfileServiceError' instead of 'AppError'.
 // All behavior comes from AppError; the subclass adds no fields or methods.
@@ -304,8 +305,6 @@ export async function getProfileById(db: Db, userId: string, profileId: string) 
 }
 
 export async function deleteProfile(db: Db, userId: string, profileId: string): Promise<boolean> {
-  const IN_FLIGHT_STATES = ['queued', 'publishing', 'auto_destructing'] as const;
-
   return db.transaction(async (tx) => {
     const inFlightPosts = await tx
       .select({ id: posts.id })
@@ -328,6 +327,27 @@ export async function deleteProfile(db: Db, userId: string, profileId: string): 
       );
     }
 
+    const detachedPosts = await tx
+      .update(posts)
+      .set({ profileId: null, queueId: null, updatedAt: new Date() })
+      .where(
+        and(
+          eq(posts.profileId, profileId),
+          eq(posts.userId, userId),
+        ),
+      )
+      .returning({ id: posts.id });
+
+    const deletedQueues = await tx
+      .delete(queues)
+      .where(
+        and(
+          eq(queues.profileId, profileId),
+          eq(queues.userId, userId),
+        ),
+      )
+      .returning({ id: queues.id });
+
     const deleted = await tx
       .delete(socialProfiles)
       .where(
@@ -337,6 +357,18 @@ export async function deleteProfile(db: Db, userId: string, profileId: string): 
         ),
       )
       .returning({ id: socialProfiles.id });
+
+    if (deleted.length > 0) {
+      logger.info(
+        {
+          profileId,
+          userId,
+          detachedPostCount: detachedPosts.length,
+          deletedQueueCount: deletedQueues.length,
+        },
+        'Profile deleted',
+      );
+    }
 
     return deleted.length > 0;
   });
@@ -648,8 +680,6 @@ export async function updateProfileMetadata(
   return refreshed;
 }
 
-const IN_FLIGHT_STATES = ['queued', 'publishing', 'auto_destructing'] as const;
-
 // GET /api/profiles/:id/delete-preview handler path. Counts are all
 // ownership-scoped via user_id in the WHERE clause. Returns zeros (never
 // throws) when no matches — the endpoint is idempotent and safe to call
@@ -681,17 +711,15 @@ export async function getDeletePreview(
       ),
     );
 
-  // Queue membership is modeled as posts.queueId IS NOT NULL (no separate
-  // queue_posts join table). We count distinct queue rows so a queue holding
-  // many posts shows as a single "queue membership".
+  // Queue ownership is modeled by queues.profileId. Count queue definitions
+  // directly so empty queues are visible in the destructive-action preview.
   const [queueMembershipsRow] = await db
-    .select({ count: sql<number>`count(DISTINCT ${posts.queueId})::int` })
-    .from(posts)
+    .select({ count: sql<number>`count(*)::int` })
+    .from(queues)
     .where(
       and(
-        eq(posts.profileId, profileId),
-        eq(posts.userId, userId),
-        sql`${posts.queueId} IS NOT NULL`,
+        eq(queues.profileId, profileId),
+        eq(queues.userId, userId),
       ),
     );
 

--- a/packages/api/src/services/profile.service.ts
+++ b/packages/api/src/services/profile.service.ts
@@ -34,7 +34,7 @@ export interface ProfileListItem {
 export interface DeletePreview {
   drafts: number;
   scheduled: number;
-  queueMemberships: number;
+  ownedQueues: number;
   tagsLosingLastUse: number;
   // inFlight > 0 blocks deletion in the existing deleteProfile transaction.
   inFlight: number;
@@ -44,10 +44,13 @@ const logger = createLogger('profile-service');
 const IN_FLIGHT_STATES = ['queued', 'publishing', 'auto_destructing'] as const;
 
 // Subclass exists so structured logs show 'ProfileServiceError' instead of 'AppError'.
-// All behavior comes from AppError; the subclass adds no fields or methods.
+// Optional codes let route-level fallbacks return stable support identifiers.
 export class ProfileServiceError extends AppError {
-  constructor(message: string, statusCode: number) {
+  public readonly code?: string;
+
+  constructor(message: string, statusCode: number, code?: string) {
     super(message, statusCode);
+    this.code = code;
   }
 }
 
@@ -327,9 +330,13 @@ export async function deleteProfile(db: Db, userId: string, profileId: string): 
       );
     }
 
+    // Do this explicitly rather than relying solely on FK side effects so the
+    // application owns the full disconnect semantics: posts are preserved, their
+    // now-deleted queue links are cleared, and empty queue definitions are
+    // removed in the same transaction as the profile row.
     const detachedPosts = await tx
       .update(posts)
-      .set({ profileId: null, queueId: null, updatedAt: new Date() })
+      .set({ profileId: null, queueId: null })
       .where(
         and(
           eq(posts.profileId, profileId),
@@ -713,7 +720,7 @@ export async function getDeletePreview(
 
   // Queue ownership is modeled by queues.profileId. Count queue definitions
   // directly so empty queues are visible in the destructive-action preview.
-  const [queueMembershipsRow] = await db
+  const [ownedQueuesRow] = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(queues)
     .where(
@@ -759,7 +766,7 @@ export async function getDeletePreview(
   return {
     drafts: Number(draftsRow?.count ?? 0),
     scheduled: Number(scheduledRow?.count ?? 0),
-    queueMemberships: Number(queueMembershipsRow?.count ?? 0),
+    ownedQueues: Number(ownedQueuesRow?.count ?? 0),
     inFlight: Number(inFlightRow?.count ?? 0),
     tagsLosingLastUse,
   };

--- a/packages/web/src/components/profiles/DeleteProfileDialog.tsx
+++ b/packages/web/src/components/profiles/DeleteProfileDialog.tsx
@@ -37,8 +37,8 @@ function buildCascadeLines(preview: DeletePreview): CascadeLine[] {
       copy: `${preview.scheduled} scheduled posts will be deleted`,
     },
     {
-      count: preview.queueMemberships,
-      copy: `${preview.queueMemberships} queues will be deleted`,
+      count: preview.ownedQueues,
+      copy: `${preview.ownedQueues} queues will be deleted`,
     },
     {
       count: preview.tagsLosingLastUse,

--- a/packages/web/src/components/profiles/DeleteProfileDialog.tsx
+++ b/packages/web/src/components/profiles/DeleteProfileDialog.tsx
@@ -38,7 +38,7 @@ function buildCascadeLines(preview: DeletePreview): CascadeLine[] {
     },
     {
       count: preview.queueMemberships,
-      copy: `${preview.queueMemberships} queue memberships will be removed`,
+      copy: `${preview.queueMemberships} queues will be deleted`,
     },
     {
       count: preview.tagsLosingLastUse,

--- a/packages/web/src/components/profiles/__tests__/DeleteProfileDialog.test.tsx
+++ b/packages/web/src/components/profiles/__tests__/DeleteProfileDialog.test.tsx
@@ -72,7 +72,7 @@ describe('DeleteProfileDialog', () => {
     const preview: DeletePreview = {
       drafts: 2,
       scheduled: 1,
-      queueMemberships: 3,
+      ownedQueues: 3,
       tagsLosingLastUse: 0,
       inFlight: 0,
     };
@@ -93,7 +93,7 @@ describe('DeleteProfileDialog', () => {
     mockPreview({
       drafts: 0,
       scheduled: 0,
-      queueMemberships: 0,
+      ownedQueues: 0,
       tagsLosingLastUse: 0,
       inFlight: 0,
     });
@@ -107,7 +107,7 @@ describe('DeleteProfileDialog', () => {
     mockPreview({
       drafts: 0,
       scheduled: 0,
-      queueMemberships: 0,
+      ownedQueues: 0,
       tagsLosingLastUse: 0,
       inFlight: 2,
     });
@@ -124,7 +124,7 @@ describe('DeleteProfileDialog', () => {
     mockPreview({
       drafts: 0,
       scheduled: 0,
-      queueMemberships: 0,
+      ownedQueues: 0,
       tagsLosingLastUse: 0,
       inFlight: 0,
     });
@@ -152,7 +152,7 @@ describe('DeleteProfileDialog', () => {
     mockPreview({
       drafts: 0,
       scheduled: 0,
-      queueMemberships: 0,
+      ownedQueues: 0,
       tagsLosingLastUse: 0,
       inFlight: 0,
     });

--- a/packages/web/src/components/profiles/__tests__/DeleteProfileDialog.test.tsx
+++ b/packages/web/src/components/profiles/__tests__/DeleteProfileDialog.test.tsx
@@ -82,9 +82,7 @@ describe('DeleteProfileDialog', () => {
 
     await screen.findByText('2 draft posts will be deleted');
     expect(screen.getByText('1 scheduled posts will be deleted')).toBeInTheDocument();
-    expect(
-      screen.getByText('3 queue memberships will be removed'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('3 queues will be deleted')).toBeInTheDocument();
     // Tags line hidden (zero count).
     expect(
       screen.queryByText(/tags will have no remaining profile/),

--- a/packages/web/src/hooks/use-profiles.ts
+++ b/packages/web/src/hooks/use-profiles.ts
@@ -7,7 +7,7 @@ export type Platform = 'twitter' | 'linkedin' | 'facebook';
 export interface DeletePreview {
   drafts: number;
   scheduled: number;
-  queueMemberships: number;
+  ownedQueues: number;
   tagsLosingLastUse: number;
   inFlight: number;
 }


### PR DESCRIPTION
## Summary

Fixes profile deletion on the Profiles page by making the cleanup explicit instead of relying only on database FK side effects.

- blocks deletion when posts are in in-flight states
- detaches the profile and queue references from owned posts before deleting the profile
- deletes owned queue definitions before deleting the profile
- updates the delete preview/copy so empty owned queues are represented correctly
- adds structured delete failure logging with the request correlation ID

## Root Cause

The previous delete path went straight from the in-flight post check to deleting `social_profiles`. That left the behavior dependent on FK cascades/set-null behavior and missed application-level cleanup details such as queue references on preserved posts and empty queue definitions. When the database threw unexpectedly, the route re-threw to the generic 500 handler without delete-specific context.

## Validation

- `pnpm --filter @sms/api test -- --run src/__tests__/services/profile.test.ts src/__tests__/routes/profiles.test.ts` passed; this command ran the full API suite: 500 passed.
- `pnpm --filter @sms/web test -- --run src/components/profiles/__tests__/DeleteProfileDialog.test.tsx` passed; this command ran the full web suite: 181 passed.
- `pnpm --filter @sms/api typecheck` passed.
- `pnpm --filter @sms/web typecheck` passed.
- Verified the real app UI flow in Chrome against a disposable local profile: delete modal confirmed, green `Profile deleted.` toast shown, card removed, and DB row count was 0.

Closes #53.
