### PR TITLE
fix(profiles): harden PATCH 500 path; log route on errors (closes #54)

### DIFF
--- a/.planning/debug/gh-54-profile-edit-returns-500.md
+++ b/.planning/debug/gh-54-profile-edit-returns-500.md
@@ -1,0 +1,75 @@
+---
+slug: gh-54-profile-edit-returns-500
+status: resolved
+trigger: 'gh#54: Profile edit returns 500 "Couldn''t save profile: Internal server error". PATCH /api/profiles/:id fails with a catch-all 500. Likely an unhandled exception inside the UPDATE/SELECT in updateProfileMetadata (packages/api/src/services/profile.service.ts:609-649). Investigation pointers in the issue body include schema drift between live social_profiles table and Drizzle definition, or a constraint violation on displayName/notes. Acceptance: edit persists + refreshes card; unhandled exceptions emit a structured log entry with correlation id, route, and error class.'
+github_issue: 54
+worktree: .claude/worktrees/54-profile-edit-returns-500-couldn-t-save-profile-int
+created: 2026-05-15
+updated: 2026-05-15
+---
+
+# Debug: gh#54 — Profile edit returns 500
+
+## Symptoms (pre-filled from issue body)
+
+- **Expected:** `PATCH /api/profiles/:id` returns 200 with the refreshed profile. Toast confirms save. Card on the Profiles list shows the new display name.
+- **Actual:** Server responded 500. UI toast: *"Couldn't save profile: Internal server error"*. Edit dialog stayed open. Card still showed the old display name.
+- **Error messages:** Generic 500 from the catch-all in `routes/profiles.ts`. No specific error surfaced to the client.
+- **Timeline:** Reported alongside gh#53 (profile delete 500, merged in `cbde4a0`).
+- **Reproduction:**
+  1. Sign in, navigate to Profiles
+  2. Kebab menu on the connected Twitter/X profile (`@JS9429587142272`)
+  3. Choose Edit
+  4. Change Display name (e.g., `JS (deprecated)`)
+  5. Leave Notes empty
+  6. Click Save changes → 500 (no longer reproducible against current `develop`)
+
+## Code references (from issue body)
+
+- `packages/api/src/routes/profiles.ts:90-118` — PATCH handler. Zod validates 400 path via `updateProfileMetadataSchema.strict()`. Known business errors throw `ProfileServiceError`. Anything else re-throws → catch-all 500.
+- `packages/api/src/services/profile.service.ts:609-649` — `updateProfileMetadata()`. Only declared throw paths:
+  - `no_fields_to_update` (400) — both `displayName` and `notes` undefined
+  - `profile_not_found` (404) — UPDATE matched zero rows, or post-update SELECT missed
+- `packages/shared/src/schemas/profiles.ts:23` — `updateProfileMetadataSchema` (strict, rejects unknown keys)
+
+## Acceptance criteria
+
+- Editing a profile's display name persists and refreshes the card ✅ verified live
+- Unhandled exceptions are caught by the API error middleware, return a generic 500, AND emit a structured log entry containing the correlation ID, route, and underlying error class ✅ now implemented
+
+## Current Focus
+
+- hypothesis: PATCH error visibility gap — runtime exceptions were swallowed by the catch-all error handler without route context, so the original 500 couldn't be diagnosed from logs
+- test: against the running dev stack, PATCH /api/profiles/cbd8901b-5218-4f37-a5e7-f107eb69178b with `{"displayName":"JS (deprecated)"}` as the owner user
+- expecting: 200 with refreshed body
+- next_action: closed — fix applied + tests + verification
+
+## Evidence
+
+- 2026-05-15T21:43:25 — built workspace and ran `pnpm --filter @sms/api test`. 501 passed / 50 todo / 5 skipped. PATCH coverage exists (lines 374-495 of `__tests__/routes/profiles.test.ts`) but only covers business-error paths; no test asserted what happens when `updateProfileMetadata` rejects with a non-`ProfileServiceError`.
+- 2026-05-15T21:43:50 — inspected live `social_profiles` schema via psql. Columns and constraints exactly match the Drizzle schema (`packages/db/src/schema/social-profiles.ts`). No NOT NULL drift, no triggers, no check constraints. `display_name varchar(255)`, `notes text`, both nullable. Constraint #3 from the issue body (schema drift) is **eliminated**.
+- 2026-05-15T21:45:10 — reproduced as the actual owner of `@JS9429587142272` (`codex-local@example.com` after password reset). `PATCH /api/profiles/cbd8901b-...` with `{"displayName":"JS (deprecated)"}` returned **200** with the refreshed profile. The originally reported 500 is not currently reproducible on `develop`. Constraint #1 (FK/constraint violation) and #2 (driver-level error) are both effectively eliminated for the steady-state stack.
+- 2026-05-15T21:46:00 — compared with the `cbde4a0` fix for gh#53. That commit hardened the DELETE handler with `next(new ProfileServiceError('Could not delete profile...', 500, 'profile_delete_failed'))`, structured logging at the handler with `{err, profileId, userId, correlationId}`, and a stable `code` field on the JSON response. The companion PATCH handler still uses bare `throw err` (line 136 of `profiles.ts`) — same shape of bug, not fixed in cbde4a0. This is the **persistent acceptance-criterion-2 gap** even though the symptom is currently quiescent.
+- 2026-05-15T21:46:30 — inspected `packages/api/src/middleware/error-handler.ts`. Logs `{err, correlationId}`. `err` is pino-serialized so error class and stack are present. `correlationId` is present. **Route is NOT logged.** Acceptance criterion #2 (correlation id, route, AND error class) is unmet for any unhandled exception across the API, not just profiles.
+
+## Eliminated
+
+- **Schema drift** (issue body candidate #3) — live `social_profiles` matches `packages/db/src/schema/social-profiles.ts` byte-for-byte at the column/constraint level.
+- **Driver-level error** (candidate #2) — no PG errors visible in api container logs; freshly issued PATCH succeeds.
+- **FK / NOT NULL / check constraint violation** (candidate #1) — only varchar length limits exist on `display_name (255)` and `notes` (text, no limit). Zod caps `notes` at 5000 chars; `displayName` at 255. Bypass impossible via the strict schema.
+
+## Resolution
+
+- **root_cause:** Two coupled issues. (a) The originally reported 500 symptom on `@JS9429587142272` is not currently reproducible — it was either a transient/environmental anomaly or has already been masked by the cbde4a0 cleanup. (b) The persistent, in-scope acceptance gap is that the PATCH handler used bare `throw err` for unhandled exceptions and the central error handler did not log the request route. If the original symptom recurs, logs alone can't pinpoint which handler swallowed it.
+- **fix:** Mirror the cbde4a0 DELETE handler hardening on the PATCH handler — handler-level structured log (`{err, profileId, userId, correlationId}` with message `'Profile update failed'`) plus `next(new ProfileServiceError('Could not save profile...', 500, 'profile_update_failed'))`. Augment the central `errorHandler` to include `{method, route}` in the structured log line so the route is captured for **every** unhandled exception across the API, not just profile routes.
+- **verification:**
+  - `pnpm --filter @sms/api test` → green (added 3 tests)
+  - Built workspace, ran the live stack, PATCH succeeded with 200 ✅
+  - `pnpm typecheck` from repo root → green
+  - `pnpm lint` from repo root → green
+  - `pnpm test` from repo root → green
+- **files_changed:**
+  - `packages/api/src/routes/profiles.ts` — PATCH catch-block hardened
+  - `packages/api/src/middleware/error-handler.ts` — log now includes `method` + `route`
+  - `packages/api/src/__tests__/routes/profiles.test.ts` — new test asserts stable code/correlationId on PATCH 500
+  - `packages/api/src/__tests__/error-handler.test.ts` — new test asserts route + method appear in the log line

--- a/packages/api/src/__tests__/error-handler.test.ts
+++ b/packages/api/src/__tests__/error-handler.test.ts
@@ -156,4 +156,30 @@ describe('errorHandler middleware', () => {
 
     expect(res.body.correlationId).toBe(customId);
   });
+
+  it('logs request method and route alongside correlationId (gh#54 acceptance)', async () => {
+    const logSpy = vi.spyOn(await import('../middleware/logger.js').then(m => m.logger), 'error');
+    const app = createTestApp();
+    app.patch('/api/profiles/:id', (_req, _res, next) => {
+      next(new Error('boom'));
+    });
+    app.use(errorHandler);
+
+    const customId = '550e8400-e29b-41d4-a716-446655440000';
+    await request(app)
+      .patch('/api/profiles/abc-123')
+      .set('X-Request-Id', customId);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        correlationId: customId,
+        method: 'PATCH',
+        route: '/api/profiles/abc-123',
+        err: expect.any(Error),
+      }),
+      'Unhandled error',
+    );
+    logSpy.mockRestore();
+  });
+
 });

--- a/packages/api/src/__tests__/error-handler.test.ts
+++ b/packages/api/src/__tests__/error-handler.test.ts
@@ -170,15 +170,49 @@ describe('errorHandler middleware', () => {
       .patch('/api/profiles/abc-123')
       .set('X-Request-Id', customId);
 
+    // Codex PR review (#77): the structured log records the matched route
+    // PATTERN, not the concrete URL — so capability tokens or UUIDs carried
+    // in path params never reach logs while the endpoint stays identifiable.
     expect(logSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         correlationId: customId,
         method: 'PATCH',
-        route: '/api/profiles/abc-123',
+        route: '/api/profiles/:id',
         err: expect.any(Error),
       }),
       'Unhandled error',
     );
+    logSpy.mockRestore();
+  });
+
+  it('logs the route pattern, not concrete path params — prevents URL-param secret leakage', async () => {
+    const logSpy = vi.spyOn(await import('../middleware/logger.js').then(m => m.logger), 'error');
+    const app = createTestApp();
+    app.get('/api/oauth/pending/:tempToken', (_req, _res, next) => {
+      next(new Error('redis down'));
+    });
+    app.use(errorHandler);
+
+    await request(app).get('/api/oauth/pending/SECRET-TOKEN-DO-NOT-LEAK');
+
+    const callArg = logSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArg.route).toBe('/api/oauth/pending/:tempToken');
+    expect(String(callArg.route)).not.toContain('SECRET-TOKEN-DO-NOT-LEAK');
+    logSpy.mockRestore();
+  });
+
+  it('logs <unrouted> when no route matched, so 404 paths cannot leak secrets', async () => {
+    const logSpy = vi.spyOn(await import('../middleware/logger.js').then(m => m.logger), 'error');
+    const app = createTestApp();
+    // No routes defined; middleware throws before any route matches.
+    app.use((_req, _res, next) => next(new Error('boom from middleware')));
+    app.use(errorHandler);
+
+    await request(app).get('/some/random/path/with/maybe-a-secret');
+
+    const callArg = logSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArg.route).toBe('<unrouted>');
+    expect(String(callArg.route)).not.toContain('maybe-a-secret');
     logSpy.mockRestore();
   });
 

--- a/packages/api/src/__tests__/routes/profiles.test.ts
+++ b/packages/api/src/__tests__/routes/profiles.test.ts
@@ -483,6 +483,24 @@ describe('profiles routes', () => {
       expect(res.status).toBe(401);
     });
 
+    it('returns 500 with stable code and correlation id for unexpected update failures (gh#54)', async () => {
+      mockUpdateProfileMetadata.mockRejectedValueOnce(new Error('underlying driver failure'));
+      const agent = await authenticatedAgent();
+      const requestId = '550e8400-e29b-41d4-a716-446655440000';
+
+      const res = await agent
+        .patch(`/api/profiles/${PROFILE_UUID}`)
+        .set('x-request-id', requestId)
+        .send({ displayName: 'JS (deprecated)' });
+
+      expect(res.status).toBe(500);
+      expect(res.body).toMatchObject({
+        error: 'Could not save profile. Try again or contact support with this request ID.',
+        code: 'profile_update_failed',
+        correlationId: requestId,
+      });
+    });
+
     it('returns 400 when :id is not a valid UUID', async () => {
       const agent = await authenticatedAgent();
 

--- a/packages/api/src/middleware/error-handler.ts
+++ b/packages/api/src/middleware/error-handler.ts
@@ -2,13 +2,28 @@ import type { Request, Response, NextFunction } from 'express';
 import { AppError } from '@sms/shared';
 import { logger } from './logger.js';
 
+// Prefer the matched route pattern (e.g. `/api/oauth/pending/:tempToken`) over
+// the concrete URL — concrete URLs may carry capability tokens or other
+// secrets in path params, while the pattern preserves endpoint identity for
+// log analysis without recording the secret material itself. Falls back to
+// `<unrouted>` when no route matched (404, or error from middleware before
+// routing); the concrete URL would still leak secrets there and the
+// surrounding pino-http request log line carries the original path if
+// operators truly need it.
+function getRouteLabel(req: Request): string {
+  if (req.route?.path) {
+    return `${req.baseUrl}${req.route.path}`;
+  }
+  return '<unrouted>';
+}
+
 export function errorHandler(err: Error, req: Request, res: Response, _next: NextFunction) {
   const correlationId = (req as any).id || 'unknown';
   // gh#54 acceptance: structured log MUST carry correlationId, route, and the
   // underlying error class. `err` is serialized by pino's default error
   // serializer (name, message, stack); `method` + `route` are explicit so
   // grep-by-endpoint works without re-instrumenting.
-  const route = req.originalUrl || req.url;
+  const route = getRouteLabel(req);
   logger.error({ err, correlationId, method: req.method, route }, 'Unhandled error');
 
   if (err instanceof AppError) {

--- a/packages/api/src/middleware/error-handler.ts
+++ b/packages/api/src/middleware/error-handler.ts
@@ -4,7 +4,12 @@ import { logger } from './logger.js';
 
 export function errorHandler(err: Error, req: Request, res: Response, _next: NextFunction) {
   const correlationId = (req as any).id || 'unknown';
-  logger.error({ err, correlationId }, 'Unhandled error');
+  // gh#54 acceptance: structured log MUST carry correlationId, route, and the
+  // underlying error class. `err` is serialized by pino's default error
+  // serializer (name, message, stack); `method` + `route` are explicit so
+  // grep-by-endpoint works without re-instrumenting.
+  const route = req.originalUrl || req.url;
+  logger.error({ err, correlationId, method: req.method, route }, 'Unhandled error');
 
   if (err instanceof AppError) {
     const code = (err as { code?: unknown }).code;

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -107,7 +107,7 @@ export function createProfilesRouter({ db }: ProfilesDependencies) {
   // Ownership lives in the UPDATE WHERE clause inside updateProfileMetadata
   // (no read-before-write race, T-07-06). CSRF is enforced by the
   // `doubleCsrfProtection` middleware already mounted in app.ts.
-  router.patch('/api/profiles/:id', requireAuth, async (req, res) => {
+  router.patch('/api/profiles/:id', requireAuth, async (req, res, next: NextFunction) => {
     const profileId = validateUuidParam(req.params.id as string);
     const userId = req.session.userId!;
 
@@ -133,7 +133,21 @@ export function createProfilesRouter({ db }: ProfilesDependencies) {
         res.status(err.statusCode).json({ error: err.message });
         return;
       }
-      throw err;
+      // Mirror the DELETE handler: capture a correlationId, emit a structured
+      // log entry with the original error so future repros are diagnosable
+      // from logs alone (gh#54), then forward a typed 500 with a stable code
+      // so the client can surface a request-id to the user.
+      const correlationId = requestCorrelationId(req as { id?: string });
+      (req as { id?: string }).id = correlationId;
+      logger.error(
+        { err, profileId, userId, correlationId },
+        'Profile update failed',
+      );
+      next(new ProfileServiceError(
+        'Could not save profile. Try again or contact support with this request ID.',
+        500,
+        'profile_update_failed',
+      ));
     }
   });
 


### PR DESCRIPTION
## Why

gh#54 reports the profile-edit dialog returning a generic 500 (`Couldn't save profile: Internal server error`). The companion gh#53 (profile delete 500) was fixed in `cbde4a0` with the same root shape — bare `throw err` in `routes/profiles.ts` hitting the catch-all — but only the DELETE handler was hardened. PATCH was left bare, and the central error-handler log doesn't capture the route, so any recurrence is invisible to logs.

Acceptance criterion 2 on gh#54 demands an unhandled exception emit a structured log line carrying correlation id, route, and error class so future repros are diagnosable without re-instrumenting.

## Investigation

Reproducing on current `develop` with the actual owner of the reported profile returned 200, not 500. The original symptom is not currently reproducible — likely transient at report time or masked by `cbde4a0`. The remaining in-scope work is acceptance criterion 2.

Eliminated candidate root causes:

- **Schema drift** between live `social_profiles` and Drizzle — columns match byte-for-byte
- **FK / NOT NULL / check constraint violation** — only varchar length limits exist; Zod caps tighter
- **Driver-level error** — no PG errors in container logs; PATCH succeeds

Full audit trail in `.planning/debug/gh-54-profile-edit-returns-500.md`.

## What changed

**`packages/api/src/routes/profiles.ts`** — PATCH handler's catch block now mirrors the DELETE handler from `cbde4a0`. Generates a `correlationId`, emits a handler-level structured log `{err, profileId, userId, correlationId}` with message `Profile update failed`, forwards via `next(new ProfileServiceError('Could not save profile...', 500, 'profile_update_failed'))`. Clients now get a stable `code` field to distinguish profile-specific failures.

**`packages/api/src/middleware/error-handler.ts`** — Central error-handler structured log gains `method` and `route` for every unhandled exception. Satisfies acceptance criterion 2 for the whole API surface, not just profile routes.

**`packages/api/src/__tests__/routes/profiles.test.ts`** — New test: PATCH 500 returns stable `code: 'profile_update_failed'` plus a correlationId.

**`packages/api/src/__tests__/error-handler.test.ts`** — New test: unhandled-exception log line contains `method`, `route`, `correlationId`, and `err`.

## Test plan

1. From repo root, run `pnpm typecheck && pnpm lint && pnpm test` — verify all three pass.
2. Live happy path: sign in as the owner of a connected Twitter profile, open the Edit dialog, change Display name, save. Verify the PATCH returns 200 and the card refreshes.
3. Synthetic 500: temporarily make `updateProfileMetadata` throw a non-`ProfileServiceError`. Verify:
   - Response body contains `{ "error": "Could not save profile...", "code": "profile_update_failed", "correlationId": "<uuid>" }`
   - Container log line emitted by the central error handler contains `method: "PATCH"`, `route: "/api/profiles/:id"`, a `correlationId` UUID, and an `err.type` set to the underlying error class
4. Regression: confirm gh#53's DELETE 500 shape (response + log) is unchanged.

## Notes

- Base is `develop` (`d874217`). This branch was cut from `02615d5`, so it's 1 commit behind develop; rebase or merge before squash.
- Branch name has an awkward mid-word truncation (`...save-profile-int`). That bug surfaced the slug fix in `d874217`; future PRs from `/next-from-backlog` produce clean names.
- During investigation, a dev fixture user's password was reset to its documented dev value to enable repro. No code change.

Closes #54.