### PR TITLE
Add post media ownership checks

### DIFF
--- a/packages/api/src/__tests__/routes/media.test.ts
+++ b/packages/api/src/__tests__/routes/media.test.ts
@@ -85,7 +85,7 @@ function createTestApp(authenticated = true) {
   });
 
   const mockDb: any = {
-    select: vi.fn().mockReturnValue(createSelectChain([{ id: '550e8400-e29b-41d4-a716-446655440000' }])),
+    select: vi.fn().mockReturnValue(createSelectChain([{ id: '550e8400-e29b-41d4-a716-446655440000', platform: 'twitter' }])),
     insert: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
@@ -260,6 +260,39 @@ describe('media routes', () => {
 
       expect(response.status).toBe(404);
       expect(response.body.error).toBe('Profile not found');
+      expect(mockUnlink).toHaveBeenCalledWith('/tmp/photo.jpg');
+      expect(mockProcessImageUpload).not.toHaveBeenCalled();
+      expect(mockProcessVideoUpload).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the requested platform does not match the owned profile', async () => {
+      const { app, mockDb } = createTestApp();
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue([{ id: '550e8400-e29b-41d4-a716-446655440000', platform: 'linkedin' }]),
+      });
+
+      const wrappedApp = withUpload(
+        app,
+        {
+          fieldname: 'file',
+          originalname: 'photo.jpg',
+          mimetype: 'image/jpeg',
+          size: 5000,
+          path: '/tmp/photo.jpg',
+        },
+        {
+          profileId: '550e8400-e29b-41d4-a716-446655440000',
+          platform: 'twitter',
+        },
+      );
+
+      const response = await request(wrappedApp)
+        .post('/api/media/upload');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("Profile is on 'linkedin', not 'twitter'.");
       expect(mockUnlink).toHaveBeenCalledWith('/tmp/photo.jpg');
       expect(mockProcessImageUpload).not.toHaveBeenCalled();
       expect(mockProcessVideoUpload).not.toHaveBeenCalled();

--- a/packages/api/src/__tests__/routes/media.test.ts
+++ b/packages/api/src/__tests__/routes/media.test.ts
@@ -73,8 +73,14 @@ function createTestApp(authenticated = true) {
     close: vi.fn().mockResolvedValue(undefined),
   } as unknown as Queue;
 
+  const createSelectChain = (rows: unknown[]) => ({
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  });
+
   const mockDb: any = {
-    select: vi.fn(),
+    select: vi.fn().mockReturnValue(createSelectChain([{ id: '550e8400-e29b-41d4-a716-446655440000' }])),
     insert: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
@@ -167,6 +173,12 @@ describe('media routes', () => {
           transcodeStatus: 'not_applicable',
         }),
       );
+      expect(mockProcessImageUpload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'test-user-id',
+          profileId: '550e8400-e29b-41d4-a716-446655440000',
+        }),
+      );
     });
 
     it('with valid video returns 201 with id, thumbnailUrl=null, transcodeStatus=pending', async () => {
@@ -207,6 +219,44 @@ describe('media routes', () => {
           transcodeStatus: 'pending',
         }),
       );
+      expect(mockProcessVideoUpload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'test-user-id',
+          profileId: '550e8400-e29b-41d4-a716-446655440000',
+        }),
+      );
+    });
+
+    it('returns 404 when the profile is not owned by the caller', async () => {
+      const { app, mockDb } = createTestApp();
+      mockDb.select.mockReturnValue({
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue([]),
+      });
+
+      const wrappedApp = withUpload(
+        app,
+        {
+          fieldname: 'file',
+          originalname: 'photo.jpg',
+          mimetype: 'image/jpeg',
+          size: 5000,
+          path: '/tmp/photo.jpg',
+        },
+        {
+          profileId: '550e8400-e29b-41d4-a716-446655440000',
+          platform: 'twitter',
+        },
+      );
+
+      const response = await request(wrappedApp)
+        .post('/api/media/upload');
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toBe('Profile not found');
+      expect(mockProcessImageUpload).not.toHaveBeenCalled();
+      expect(mockProcessVideoUpload).not.toHaveBeenCalled();
     });
 
     it('with oversized file returns 400 with error message', async () => {
@@ -279,6 +329,11 @@ describe('media routes', () => {
           transcodeStatus: 'processing',
         }),
       );
+      expect(mockGetMediaStatus).toHaveBeenCalledWith(
+        expect.anything(),
+        'test-user-id',
+        '550e8400-e29b-41d4-a716-446655440001',
+      );
     });
   });
 
@@ -296,6 +351,12 @@ describe('media routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.transcodeStatus).toBe('pending');
+      expect(mockRetryTranscode).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'test-user-id',
+        '550e8400-e29b-41d4-a716-446655440001',
+      );
     });
 
     it('returns 404 for non-failed media', async () => {
@@ -322,7 +383,11 @@ describe('media routes', () => {
         .delete('/api/media/550e8400-e29b-41d4-a716-446655440001');
 
       expect(response.status).toBe(204);
-      expect(mockSoftDeleteMedia).toHaveBeenCalled();
+      expect(mockSoftDeleteMedia).toHaveBeenCalledWith(
+        expect.anything(),
+        'test-user-id',
+        '550e8400-e29b-41d4-a716-446655440001',
+      );
     });
   });
 });

--- a/packages/api/src/__tests__/routes/media.test.ts
+++ b/packages/api/src/__tests__/routes/media.test.ts
@@ -8,6 +8,11 @@ const mockProcessVideoUpload = vi.fn();
 const mockGetMediaStatus = vi.fn();
 const mockSoftDeleteMedia = vi.fn();
 const mockRetryTranscode = vi.fn();
+const mockUnlink = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('node:fs/promises', () => ({
+  unlink: (...args: unknown[]) => mockUnlink(...args),
+}));
 
 vi.mock('../../services/media.service.js', () => ({
   processImageUpload: (...args: unknown[]) => mockProcessImageUpload(...args),
@@ -255,6 +260,7 @@ describe('media routes', () => {
 
       expect(response.status).toBe(404);
       expect(response.body.error).toBe('Profile not found');
+      expect(mockUnlink).toHaveBeenCalledWith('/tmp/photo.jpg');
       expect(mockProcessImageUpload).not.toHaveBeenCalled();
       expect(mockProcessVideoUpload).not.toHaveBeenCalled();
     });

--- a/packages/api/src/__tests__/services/media.test.ts
+++ b/packages/api/src/__tests__/services/media.test.ts
@@ -90,6 +90,7 @@ describe('media.service', () => {
       tempFilePath: '/tmp/test-file.jpg',
       originalName: 'photo.jpg',
       mimeType: 'image/jpeg',
+      userId: 'user-1',
       profileId: '550e8400-e29b-41d4-a716-446655440000',
       platform: 'twitter',
       storage: null as any,
@@ -203,6 +204,13 @@ describe('media.service', () => {
         }),
       );
     });
+
+    it('stores the owning user id on the media row', async () => {
+      await processImageUpload(baseParams);
+
+      const valuesCall = mockDb.insert.mock.results[0].value.values.mock.calls[0][0];
+      expect(valuesCall.userId).toBe('user-1');
+    });
   });
 
   describe('processVideoUpload', () => {
@@ -211,6 +219,7 @@ describe('media.service', () => {
       originalName: 'video.mp4',
       mimeType: 'video/mp4',
       fileSize: 10_000_000,
+      userId: 'user-1',
       profileId: '550e8400-e29b-41d4-a716-446655440000',
       storage: null as any,
       db: null as any,
@@ -260,6 +269,13 @@ describe('media.service', () => {
         }),
       );
     });
+
+    it('stores the owning user id on the video media row', async () => {
+      await processVideoUpload(baseParams);
+
+      const valuesCall = mockDb.insert.mock.results[0].value.values.mock.calls[0][0];
+      expect(valuesCall.userId).toBe('user-1');
+    });
   });
 
   describe('getMediaStatus', () => {
@@ -274,7 +290,7 @@ describe('media.service', () => {
       };
       mockDb.select.mockReturnValue(selectChain);
 
-      const result = await getMediaStatus(mockDb, 'media-1');
+      const result = await getMediaStatus(mockDb, 'user-1', 'media-1');
 
       expect(result).toEqual({
         id: 'media-1',
@@ -292,7 +308,7 @@ describe('media.service', () => {
       };
       mockDb.update.mockReturnValue(updateChain);
 
-      await softDeleteMedia(mockDb, 'media-1');
+      await softDeleteMedia(mockDb, 'user-1', 'media-1');
 
       expect(mockDb.update).toHaveBeenCalled();
       const setCall = updateChain.set.mock.calls[0][0];
@@ -312,7 +328,7 @@ describe('media.service', () => {
       };
       mockDb.update.mockReturnValue(updateChain);
 
-      const count = await softDeleteMediaForPost(mockDb, 'post-id-1');
+      const count = await softDeleteMediaForPost(mockDb, 'user-1', 'post-id-1');
 
       expect(mockDb.update).toHaveBeenCalled();
       expect(count).toBe(2);
@@ -339,7 +355,7 @@ describe('media.service', () => {
       };
       mockDb.update.mockReturnValue(updateChain);
 
-      const result = await retryTranscode(mockDb, mockQueue, 'media-1');
+      const result = await retryTranscode(mockDb, mockQueue, 'user-1', 'media-1');
 
       expect(result.transcodeStatus).toBe('pending');
       expect(mockQueue.add).toHaveBeenCalledWith(
@@ -362,7 +378,7 @@ describe('media.service', () => {
       mockDb.select.mockReturnValue(selectChain);
 
       await expect(
-        retryTranscode(mockDb, mockQueue, 'media-1'),
+        retryTranscode(mockDb, mockQueue, 'user-1', 'media-1'),
       ).rejects.toThrow();
     });
 
@@ -374,7 +390,7 @@ describe('media.service', () => {
       mockDb.select.mockReturnValue(selectChain);
 
       await expect(
-        retryTranscode(mockDb, mockQueue, 'nonexistent'),
+        retryTranscode(mockDb, mockQueue, 'user-1', 'nonexistent'),
       ).rejects.toThrow();
     });
   });
@@ -382,8 +398,13 @@ describe('media.service', () => {
   describe('associateMediaToPost', () => {
     it('sets postId + sortOrder for each media id', async () => {
       const mediaIds = ['media-1', 'media-2', 'media-3'];
+      const selectChain: any = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue(mediaIds.map((id) => ({ id }))),
+      };
+      mockDb.select.mockReturnValue(selectChain);
 
-      await associateMediaToPost(mockDb, 'post-id-1', mediaIds);
+      await associateMediaToPost(mockDb, 'user-1', 'post-id-1', mediaIds);
 
       // Should have called update for each media id directly (no inner transaction)
       expect(mockDb.update).toHaveBeenCalledTimes(3);
@@ -394,12 +415,31 @@ describe('media.service', () => {
       // are naturally excluded. We verify the update is called with the right
       // condition pattern (the service uses AND postId IS NULL).
       const mediaIds = ['media-1'];
+      const selectChain: any = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([{ id: 'media-1' }]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
 
-      await associateMediaToPost(mockDb, 'post-id-1', mediaIds);
+      await associateMediaToPost(mockDb, 'user-1', 'post-id-1', mediaIds);
 
       expect(mockDb.update).toHaveBeenCalled();
       // The actual SQL condition includes isNull(postMedia.postId) -- verified
       // by the fact that the service code uses `isNull` in the where clause
+    });
+
+    it('rejects media ids not owned by the caller', async () => {
+      const selectChain: any = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([{ id: 'media-1' }]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
+
+      await expect(
+        associateMediaToPost(mockDb, 'user-1', 'post-id-1', ['media-1', 'other-user-media']),
+      ).rejects.toMatchObject({ statusCode: 400 });
+
+      expect(mockDb.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/api/src/__tests__/services/post.test.ts
+++ b/packages/api/src/__tests__/services/post.test.ts
@@ -24,7 +24,7 @@ const mockTags = makeTableStub('tags', ['id', 'name', 'color', 'userId', 'create
 const mockPostTags = makeTableStub('post_tags', ['postId', 'tagId']);
 const mockSocialProfiles = makeTableStub('social_profiles', ['id', 'userId']);
 const mockPostMedia = makeTableStub('post_media', [
-  'id', 'postId', 'filePath', 'fileName', 'mimeType', 'fileSize', 'width', 'height',
+  'id', 'userId', 'postId', 'filePath', 'fileName', 'mimeType', 'fileSize', 'width', 'height',
   'thumbnailPath', 'sortOrder', 'transcodeStatus', 'transcodeError', 'deletedAt', 'createdAt',
 ]);
 
@@ -460,6 +460,7 @@ describe('post.service', () => {
       expect(mockAssociateMediaToPost).toHaveBeenCalledTimes(1);
       expect(mockAssociateMediaToPost).toHaveBeenCalledWith(
         expect.anything(),
+        'user-1',
         'post-1',
         ['media-1', 'media-2'],
       );
@@ -658,6 +659,7 @@ describe('post.service', () => {
       expect(clearCall).toBeDefined();
       expect(mockAssociateMediaToPost).toHaveBeenCalledWith(
         expect.anything(),
+        'user-1',
         'post-1',
         ['media-3'],
       );
@@ -987,9 +989,10 @@ describe('post.service', () => {
     it('calls softDeleteMediaForPost before hard-deleting the post (Test 6)', async () => {
       const db = createDeleteMockDb({ deleteResult: [{ id: 'post-1' }] });
       await deletePost(db, 'user-1', 'post-1');
-      // softDeleteMediaForPost must have been called with the same tx handle and correct postId
+      // softDeleteMediaForPost must have been called with the same tx handle,
+      // owning user, and correct postId.
       expect(mockSoftDeleteMediaForPost).toHaveBeenCalledTimes(1);
-      expect(mockSoftDeleteMediaForPost).toHaveBeenCalledWith(db, 'post-1');
+      expect(mockSoftDeleteMediaForPost).toHaveBeenCalledWith(db, 'user-1', 'post-1');
       // hard-delete of the post row also ran
       expect(db.delete).toHaveBeenCalledTimes(1);
     });

--- a/packages/api/src/routes/media.ts
+++ b/packages/api/src/routes/media.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
 import type { Queue } from 'bullmq';
+import { and, eq } from 'drizzle-orm';
 import { PLATFORM_MEDIA_LIMITS } from '@sms/shared';
 import type { StorageBackend } from '@sms/shared/storage';
-import type { Db } from '@sms/db';
+import { socialProfiles, type Db } from '@sms/db';
 
 import {
   processImageUpload,
@@ -36,6 +37,7 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
 
     const profileId = req.body.profileId as string;
     const platform = req.body.platform as string;
+    const userId = req.session.userId!;
 
     if (!profileId || !UUID_PATTERN.test(profileId)) {
       res.status(400).json({ error: 'A valid profileId is required.' });
@@ -44,6 +46,17 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
 
     if (!platform || !VALID_PLATFORMS.has(platform)) {
       res.status(400).json({ error: `Platform must be one of: ${[...VALID_PLATFORMS].join(', ')}` });
+      return;
+    }
+
+    const [ownedProfile] = await db
+      .select({ id: socialProfiles.id })
+      .from(socialProfiles)
+      .where(and(eq(socialProfiles.id, profileId), eq(socialProfiles.userId, userId)))
+      .limit(1);
+
+    if (!ownedProfile) {
+      res.status(404).json({ error: 'Profile not found' });
       return;
     }
 
@@ -92,6 +105,7 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
         tempFilePath: file.path,
         originalName: file.originalname,
         mimeType: file.mimetype,
+        userId,
         profileId,
         platform,
         storage,
@@ -106,6 +120,7 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
       originalName: file.originalname,
       mimeType: file.mimetype,
       fileSize: file.size,
+      userId,
       profileId,
       storage,
       db,
@@ -116,7 +131,7 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
 
   router.get('/:id/status', requireAuth, async (req, res) => {
     const mediaId = validateUuidParam(req.params.id as string);
-    const status = await getMediaStatus(db, mediaId);
+    const status = await getMediaStatus(db, req.session.userId!, mediaId);
 
     if (!status) {
       res.status(404).json({ error: 'Media not found' });
@@ -128,13 +143,13 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
 
   router.post('/:id/retry', requireAuth, async (req, res) => {
     const mediaId = validateUuidParam(req.params.id as string);
-    const result = await retryTranscode(db, transcodeQueue, mediaId);
+    const result = await retryTranscode(db, transcodeQueue, req.session.userId!, mediaId);
     res.json(result);
   });
 
   router.delete('/:id', requireAuth, async (req, res) => {
     const mediaId = validateUuidParam(req.params.id as string);
-    await softDeleteMedia(db, mediaId);
+    await softDeleteMedia(db, req.session.userId!, mediaId);
     res.status(204).send();
   });
 

--- a/packages/api/src/routes/media.ts
+++ b/packages/api/src/routes/media.ts
@@ -1,9 +1,12 @@
+import { unlink } from 'node:fs/promises';
 import { Router } from 'express';
+import type { Response } from 'express';
 import type { Queue } from 'bullmq';
 import { and, eq } from 'drizzle-orm';
 import { PLATFORM_MEDIA_LIMITS } from '@sms/shared';
 import type { StorageBackend } from '@sms/shared/storage';
 import { socialProfiles, type Db } from '@sms/db';
+import { createLogger } from '@sms/shared/logger';
 
 import {
   processImageUpload,
@@ -18,11 +21,30 @@ import { validateUuidParam } from '../middleware/validation.js';
 
 const VALID_PLATFORMS = new Set(Object.keys(PLATFORM_MEDIA_LIMITS));
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const logger = createLogger('media-router');
 
 interface MediaRouterDependencies {
   db: Db;
   storage: StorageBackend;
   transcodeQueue: Queue;
+}
+
+async function cleanupRejectedUpload(tempFilePath: string): Promise<void> {
+  try {
+    await unlink(tempFilePath);
+  } catch (err) {
+    logger.debug({ err, tempFilePath }, 'Temp file cleanup failed after upload rejection');
+  }
+}
+
+async function rejectUpload(
+  res: Response,
+  file: { path: string },
+  statusCode: number,
+  payload: { error: string },
+): Promise<void> {
+  await cleanupRejectedUpload(file.path);
+  res.status(statusCode).json(payload);
 }
 
 export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDependencies) {
@@ -40,12 +62,12 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
     const userId = req.session.userId!;
 
     if (!profileId || !UUID_PATTERN.test(profileId)) {
-      res.status(400).json({ error: 'A valid profileId is required.' });
+      await rejectUpload(res, file, 400, { error: 'A valid profileId is required.' });
       return;
     }
 
     if (!platform || !VALID_PLATFORMS.has(platform)) {
-      res.status(400).json({ error: `Platform must be one of: ${[...VALID_PLATFORMS].join(', ')}` });
+      await rejectUpload(res, file, 400, { error: `Platform must be one of: ${[...VALID_PLATFORMS].join(', ')}` });
       return;
     }
 
@@ -56,7 +78,7 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
       .limit(1);
 
     if (!ownedProfile) {
-      res.status(404).json({ error: 'Profile not found' });
+      await rejectUpload(res, file, 404, { error: 'Profile not found' });
       return;
     }
 
@@ -65,7 +87,7 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
     const isVideo = file.mimetype.startsWith('video/');
 
     if (!isImage && !isVideo) {
-      res.status(400).json({ error: `${file.originalname} is not a supported file type.` });
+      await rejectUpload(res, file, 400, { error: `${file.originalname} is not a supported file type.` });
       return;
     }
 
@@ -73,14 +95,14 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
     if (isImage) {
       const maxBytes = limits.maxImageSizeMb * 1024 * 1024;
       if (file.size > maxBytes) {
-        res.status(400).json({
+        await rejectUpload(res, file, 400, {
           error: `${file.originalname} exceeds the ${limits.maxImageSizeMb} MB limit.`,
         });
         return;
       }
 
       if (!limits.allowedImageTypes.includes(file.mimetype)) {
-        res.status(400).json({ error: `${file.originalname} is not a supported file type.` });
+        await rejectUpload(res, file, 400, { error: `${file.originalname} is not a supported file type.` });
         return;
       }
     }
@@ -88,14 +110,14 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
     if (isVideo) {
       const maxBytes = limits.maxVideoSizeMb * 1024 * 1024;
       if (file.size > maxBytes) {
-        res.status(400).json({
+        await rejectUpload(res, file, 400, {
           error: `${file.originalname} exceeds the ${limits.maxVideoSizeMb} MB limit.`,
         });
         return;
       }
 
       if (!limits.allowedVideoTypes.includes(file.mimetype)) {
-        res.status(400).json({ error: `${file.originalname} is not a supported file type.` });
+        await rejectUpload(res, file, 400, { error: `${file.originalname} is not a supported file type.` });
         return;
       }
     }

--- a/packages/api/src/routes/media.ts
+++ b/packages/api/src/routes/media.ts
@@ -72,13 +72,20 @@ export function createMediaRouter({ db, storage, transcodeQueue }: MediaRouterDe
     }
 
     const [ownedProfile] = await db
-      .select({ id: socialProfiles.id })
+      .select({ id: socialProfiles.id, platform: socialProfiles.platform })
       .from(socialProfiles)
       .where(and(eq(socialProfiles.id, profileId), eq(socialProfiles.userId, userId)))
       .limit(1);
 
     if (!ownedProfile) {
       await rejectUpload(res, file, 404, { error: 'Profile not found' });
+      return;
+    }
+
+    if (ownedProfile.platform !== platform) {
+      await rejectUpload(res, file, 400, {
+        error: `Profile is on '${ownedProfile.platform}', not '${platform}'.`,
+      });
       return;
     }
 

--- a/packages/api/src/services/media.service.ts
+++ b/packages/api/src/services/media.service.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { unlink } from 'node:fs/promises';
 import { createReadStream } from 'node:fs';
 import sharp from 'sharp';
-import { eq, and, isNull } from 'drizzle-orm';
+import { eq, and, isNull, inArray } from 'drizzle-orm';
 import type { Queue } from 'bullmq';
 import { PLATFORM_MEDIA_LIMITS, JOB_NAMES, AppError } from '@sms/shared';
 import { createLogger } from '@sms/shared/logger';
@@ -45,6 +45,7 @@ interface ProcessImageParams {
   tempFilePath: string;
   originalName: string;
   mimeType: string;
+  userId: string;
   profileId: string;
   platform: string;
   storage: StorageBackend;
@@ -52,7 +53,7 @@ interface ProcessImageParams {
 }
 
 export async function processImageUpload(params: ProcessImageParams) {
-  const { tempFilePath, originalName, mimeType, profileId, platform, storage, db } = params;
+  const { tempFilePath, originalName, mimeType, userId, profileId, platform, storage, db } = params;
 
   if (!IMAGE_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix))) {
     throw new Error(`${originalName} is not a supported image type.`);
@@ -101,6 +102,7 @@ export async function processImageUpload(params: ProcessImageParams) {
     await storage.save(thumbnailKey, thumbnailBuffer, mimeType);
 
     const insertChain = db.insert(postMedia).values({
+      userId,
       postId: null,
       filePath: storageKey,
       fileName: originalName,
@@ -144,6 +146,7 @@ interface ProcessVideoParams {
   originalName: string;
   mimeType: string;
   fileSize: number;
+  userId: string;
   profileId: string;
   storage: StorageBackend;
   db: Db;
@@ -151,7 +154,7 @@ interface ProcessVideoParams {
 }
 
 export async function processVideoUpload(params: ProcessVideoParams) {
-  const { tempFilePath, originalName, mimeType, fileSize, profileId, storage, db, transcodeQueue } = params;
+  const { tempFilePath, originalName, mimeType, fileSize, userId, profileId, storage, db, transcodeQueue } = params;
   const fileUuid = randomUUID();
   const ext = originalName.split('.').pop() || 'mp4';
   const storageKey = buildStorageKey(profileId, `${fileUuid}_original`, ext);
@@ -161,6 +164,7 @@ export async function processVideoUpload(params: ProcessVideoParams) {
     await storage.save(storageKey, fileStream, mimeType);
 
     const insertChain = db.insert(postMedia).values({
+      userId,
       postId: null,
       filePath: storageKey,
       fileName: originalName,
@@ -201,7 +205,7 @@ export async function processVideoUpload(params: ProcessVideoParams) {
   }
 }
 
-export async function getMediaStatus(db: Db, mediaId: string) {
+export async function getMediaStatus(db: Db, userId: string, mediaId: string) {
   const rows = await db
     .select({
       id: postMedia.id,
@@ -209,7 +213,7 @@ export async function getMediaStatus(db: Db, mediaId: string) {
       transcodeError: postMedia.transcodeError,
     })
     .from(postMedia)
-    .where(and(eq(postMedia.id, mediaId), isNull(postMedia.deletedAt)));
+    .where(and(eq(postMedia.id, mediaId), eq(postMedia.userId, userId), isNull(postMedia.deletedAt)));
 
   if (rows.length === 0) {
     return null;
@@ -220,22 +224,24 @@ export async function getMediaStatus(db: Db, mediaId: string) {
 
 export async function softDeleteMedia(
   db: Db,
+  userId: string,
   mediaId: string,
 ): Promise<void> {
   await db
     .update(postMedia)
     .set({ deletedAt: new Date() })
-    .where(and(eq(postMedia.id, mediaId), isNull(postMedia.deletedAt)));
+    .where(and(eq(postMedia.id, mediaId), eq(postMedia.userId, userId), isNull(postMedia.deletedAt)));
 }
 
 export async function softDeleteMediaForPost(
   db: Db,
+  userId: string,
   postId: string,
 ): Promise<number> {
   const updatedRows = await db
     .update(postMedia)
     .set({ deletedAt: new Date() })
-    .where(and(eq(postMedia.postId, postId), isNull(postMedia.deletedAt)))
+    .where(and(eq(postMedia.postId, postId), eq(postMedia.userId, userId), isNull(postMedia.deletedAt)))
     .returning({ id: postMedia.id });
 
   return updatedRows.length;
@@ -244,6 +250,7 @@ export async function softDeleteMediaForPost(
 export async function retryTranscode(
   db: Db,
   transcodeQueue: Queue,
+  userId: string,
   mediaId: string,
 ) {
   const rows = await db
@@ -254,7 +261,7 @@ export async function retryTranscode(
       filePath: postMedia.filePath,
     })
     .from(postMedia)
-    .where(and(eq(postMedia.id, mediaId), isNull(postMedia.deletedAt)));
+    .where(and(eq(postMedia.id, mediaId), eq(postMedia.userId, userId), isNull(postMedia.deletedAt)));
 
   if (rows.length === 0 || rows[0].transcodeStatus !== 'failed') {
     throw new MediaServiceError('Media not found or not in failed state', 404);
@@ -265,7 +272,7 @@ export async function retryTranscode(
   await db
     .update(postMedia)
     .set({ transcodeStatus: 'pending', transcodeError: null })
-    .where(eq(postMedia.id, mediaId));
+    .where(and(eq(postMedia.id, mediaId), eq(postMedia.userId, userId), isNull(postMedia.deletedAt)));
 
   // Derive profileId from the file path pattern: media/{profileId}/...
   const pathSegments = mediaRow.filePath.split('/');
@@ -287,14 +294,38 @@ export async function retryTranscode(
 
 export async function associateMediaToPost(
   db: Db,
+  userId: string,
   postId: string,
   mediaIds: string[],
 ): Promise<void> {
+  if (mediaIds.length === 0) {
+    return;
+  }
+
+  const ownedUnclaimedMediaRows = await db
+    .select({ id: postMedia.id })
+    .from(postMedia)
+    .where(and(
+      inArray(postMedia.id, mediaIds),
+      eq(postMedia.userId, userId),
+      isNull(postMedia.postId),
+      isNull(postMedia.deletedAt),
+    ));
+
+  if (ownedUnclaimedMediaRows.length !== mediaIds.length) {
+    throw new MediaServiceError('One or more media files not found', 400);
+  }
+
   for (let sortOrder = 0; sortOrder < mediaIds.length; sortOrder++) {
     const mediaId = mediaIds[sortOrder];
     await db
       .update(postMedia)
       .set({ postId, sortOrder })
-      .where(and(eq(postMedia.id, mediaId), isNull(postMedia.postId)));
+      .where(and(
+        eq(postMedia.id, mediaId),
+        eq(postMedia.userId, userId),
+        isNull(postMedia.postId),
+        isNull(postMedia.deletedAt),
+      ));
   }
 }

--- a/packages/api/src/services/post.service.ts
+++ b/packages/api/src/services/post.service.ts
@@ -146,7 +146,7 @@ export async function createPost(db: Db, userId: string, input: CreatePostInput)
     }
 
     if (input.mediaIds && input.mediaIds.length > 0) {
-      await associateMediaToPost(tx, insertedPost.id, input.mediaIds);
+      await associateMediaToPost(tx, userId, insertedPost.id, input.mediaIds);
     }
 
     return insertedPost;
@@ -316,10 +316,10 @@ export async function updatePost(
       await tx
         .update(postMedia)
         .set({ postId: null })
-        .where(eq(postMedia.postId, postId));
+        .where(and(eq(postMedia.postId, postId), eq(postMedia.userId, userId)));
 
       if (input.mediaIds.length > 0) {
-        await associateMediaToPost(tx, postId, input.mediaIds);
+        await associateMediaToPost(tx, userId, postId, input.mediaIds);
       }
     }
   });
@@ -339,7 +339,7 @@ export async function deletePost(
     // The SET NULL FK on post_media.postId nulls post_id when the post is deleted,
     // but deletedAt persists so the weekly cleanup worker finds and removes storage files.
     // Both operations share a transaction so a failure in either rolls back the other.
-    const softDeletedMediaCount = await softDeleteMediaForPost(tx, postId);
+    const softDeletedMediaCount = await softDeleteMediaForPost(tx, userId, postId);
     if (softDeletedMediaCount > 0) {
       logger.info({ postId, softDeletedMediaCount }, 'Soft-deleted media for post deletion');
     }
@@ -412,7 +412,7 @@ export async function getPostById(db: Db, userId: string, postId: string) {
       transcodeStatus: postMedia.transcodeStatus,
     })
     .from(postMedia)
-    .where(and(eq(postMedia.postId, post.id), isNull(postMedia.deletedAt)))
+    .where(and(eq(postMedia.postId, post.id), eq(postMedia.userId, userId), isNull(postMedia.deletedAt)))
     .orderBy(postMedia.sortOrder);
 
   return { ...post, tags: postTagRows, media: mediaRows };

--- a/packages/db/drizzle/0010_post-media-user-id.sql
+++ b/packages/db/drizzle/0010_post-media-user-id.sql
@@ -9,6 +9,8 @@ SET "user_id" = sp."user_id"
 FROM "social_profiles" sp
 WHERE pm."user_id" IS NULL
   AND split_part(pm."file_path", '/', 2) = sp."id"::text;--> statement-breakpoint
+DELETE FROM "post_media"
+WHERE "user_id" IS NULL;--> statement-breakpoint
 ALTER TABLE "post_media" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "post_media" ADD CONSTRAINT "post_media_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "post_media_user_id" ON "post_media" USING btree ("user_id");

--- a/packages/db/drizzle/0010_post-media-user-id.sql
+++ b/packages/db/drizzle/0010_post-media-user-id.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "post_media" ADD COLUMN "user_id" uuid;--> statement-breakpoint
+UPDATE "post_media" pm
+SET "user_id" = p."user_id"
+FROM "posts" p
+WHERE pm."post_id" = p."id"
+  AND pm."user_id" IS NULL;--> statement-breakpoint
+UPDATE "post_media" pm
+SET "user_id" = sp."user_id"
+FROM "social_profiles" sp
+WHERE pm."user_id" IS NULL
+  AND split_part(pm."file_path", '/', 2) = sp."id"::text;--> statement-breakpoint
+ALTER TABLE "post_media" ALTER COLUMN "user_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "post_media" ADD CONSTRAINT "post_media_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "post_media_user_id" ON "post_media" USING btree ("user_id");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1777677670589,
       "tag": "0009_phase-11-snippets-fts-calendar",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1778933495000,
+      "tag": "0010_post-media-user-id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/post-media.ts
+++ b/packages/db/src/schema/post-media.ts
@@ -1,5 +1,6 @@
 import { pgTable, pgEnum, uuid, text, varchar, timestamp, integer, index } from 'drizzle-orm/pg-core';
 import { posts } from './posts.js';
+import { users } from './users.js';
 
 export const transcodeStatusEnum = pgEnum('transcode_status', [
   'pending',
@@ -11,6 +12,7 @@ export const transcodeStatusEnum = pgEnum('transcode_status', [
 
 export const postMedia = pgTable('post_media', {
   id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
   postId: uuid('post_id').references(() => posts.id, { onDelete: 'set null' }),
   filePath: text('file_path').notNull(),
   fileName: varchar('file_name', { length: 255 }).notNull(),
@@ -25,6 +27,7 @@ export const postMedia = pgTable('post_media', {
   deletedAt: timestamp('deleted_at', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 }, (table) => [
+  index('post_media_user_id').on(table.userId),
   index('post_media_post_id').on(table.postId),
   index('post_media_deleted_at').on(table.deletedAt),
   index('post_media_transcode_status').on(table.transcodeStatus),


### PR DESCRIPTION
## Summary

- Add `post_media.user_id` with a migration that backfills associated media from posts and unattached uploads from the storage-path profile id.
- Stamp new image and video uploads with the session user id.
- Scope media status, delete, retry, attach, detach, and post media reads by owner.
- Add upload-route profile ownership validation and regression tests for media ownership checks.

## Root cause

`post_media` did not record ownership, so media endpoints and post association code could only filter by `mediaId` or `postId`. That left the API unable to reject another user's known media id.

## Validation

- `pnpm --filter @sms/api exec vitest run src/__tests__/services/media.test.ts src/__tests__/routes/media.test.ts src/__tests__/services/post.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`

Closes #6