### PR TITLE
fix(infra): run web container as non-root via nginx-unprivileged (closes #26)

### DIFF
--- a/.planning/quick/20260516-26-web-non-root/PLAN.md
+++ b/.planning/quick/20260516-26-web-non-root/PLAN.md
@@ -1,7 +1,7 @@
 ---
 slug: 26-web-non-root
 github_issue: 26
-status: in-progress
+status: complete
 created: 2026-05-16
 updated: 2026-05-16
 worktree: .claude/worktrees/26-security-web-production-docker-stage-runs-as-root

--- a/.planning/quick/20260516-26-web-non-root/PLAN.md
+++ b/.planning/quick/20260516-26-web-non-root/PLAN.md
@@ -1,0 +1,47 @@
+---
+slug: 26-web-non-root
+github_issue: 26
+status: in-progress
+created: 2026-05-16
+updated: 2026-05-16
+worktree: .claude/worktrees/26-security-web-production-docker-stage-runs-as-root
+---
+
+# Quick Task: gh#26 — Web-production Docker stage runs as non-root
+
+## Problem
+
+Docker's `web-production` stage in the root `Dockerfile` uses `nginx:1.27-alpine` as its base and never creates a non-root user or sets a `USER` directive. Both `api-production` and `worker-production` correctly create `appuser:appgroup` (UID 1001) and switch to it via `USER appuser`. Project convention (CLAUDE.md → API Package Standards → Docker & Infrastructure): *"Containers: non-root user via USER directive."* The web stage is the lone violator.
+
+## Decision
+
+Switch the web stage's base image to **`nginxinc/nginx-unprivileged:1.27-alpine`**.
+
+Considered three options surfaced in the GitHub issue:
+
+| Option | Choice? | Reasoning |
+|---|---|---|
+| (a) Change listen to 8080 + manual `addgroup`/`adduser`/`USER appuser`, chown nginx runtime dirs | rejected | Most consistent with the api/worker pattern, but requires manually chowning `/var/cache/nginx`, `/var/run`, etc., plus a `pid` directive in nginx.conf. Larger diff, more ways to be subtly wrong. |
+| **(b) Use `nginxinc/nginx-unprivileged` base image** | **chosen** | Official upstream-maintained variant. Pre-configures `USER nginx`, `listen 8080`, `pid /tmp/nginx.pid`, and the right ownership on cache/run dirs. Net Dockerfile change is smaller than (a) and there are no chmod/chown footguns. |
+| (c) Rewrite nginx config at build time (e.g., `envsubst`) | rejected | Solves only the port problem; non-root still requires (a)'s chown work. Strictly worse than (a) or (b). |
+
+The `appuser:appgroup` pattern in api/worker is right *for our code* — they're our binaries. The web container is `nginx` from upstream; using the upstream-blessed `nginx` user (UID 101) via the unprivileged variant is the cleaner match.
+
+## Change set
+
+1. **`nginx/nginx.conf`** — `listen 80` → `listen 8080`. No `pid` directive needed (the unprivileged base supplies `pid /tmp/nginx.pid` via its default, but since we're replacing nginx.conf entirely we explicitly set it too for safety).
+2. **`Dockerfile`** — `FROM nginxinc/nginx-unprivileged:1.27-alpine AS web-production`, `USER root` for the `apk add wget` step (healthcheck dep), `USER nginx` after, `EXPOSE 8080`.
+3. **`docker-compose.yml`** — `"${NGINX_PORT:-8080}:80"` → `"${NGINX_PORT:-8080}:8080"`. Host port stays at 8080 (no upstream caller change); container port matches nginx's new listen.
+
+## Verification plan
+
+- `pnpm typecheck` — should pass (no TS change, sanity check)
+- `pnpm lint` — should pass (no JS/TS change, sanity check)
+- `pnpm test` — should pass (no application code change)
+- Visual: `grep -E "USER|listen|EXPOSE" Dockerfile nginx/nginx.conf` confirms non-root, port 8080, expose 8080
+- Smoke check intent (not executed here, but noted for reviewer): `docker compose build nginx && docker compose run --rm -u nginx nginx whoami` should print `nginx` (UID 101), and `curl localhost:8080` should return the SPA index after the api service is up.
+
+## Acceptance (from gh#26)
+
+- ✅ Web container runs as non-root via `USER` directive
+- ✅ Still serves traffic correctly (container internal port 8080, host port stays 8080)

--- a/.planning/quick/20260516-26-web-non-root/SUMMARY.md
+++ b/.planning/quick/20260516-26-web-non-root/SUMMARY.md
@@ -11,7 +11,7 @@ worktree: .claude/worktrees/26-security-web-production-docker-stage-runs-as-root
 
 ## What changed
 
-Five files. Net diff: pure infra — no application code or test code touched.
+**Five infra/runtime files** (Dockerfile, both nginx configs, both compose files). The PR diff also includes this PLAN.md plus its sibling SUMMARY.md under `.planning/quick/` — those are the audit-trail artifacts, not part of the runtime change. Net runtime diff: pure infra — no application code or test code touched.
 
 | File | Change |
 |---|---|

--- a/.planning/quick/20260516-26-web-non-root/SUMMARY.md
+++ b/.planning/quick/20260516-26-web-non-root/SUMMARY.md
@@ -1,0 +1,60 @@
+---
+slug: 26-web-non-root
+github_issue: 26
+status: complete
+created: 2026-05-16
+updated: 2026-05-16
+worktree: .claude/worktrees/26-security-web-production-docker-stage-runs-as-root
+---
+
+# Summary: gh#26 — Web-production Docker stage runs as non-root
+
+## What changed
+
+Five files. Net diff: pure infra — no application code or test code touched.
+
+| File | Change |
+|---|---|
+| `Dockerfile` | `web-production` stage's base image switched from `nginx:1.27-alpine` to `nginxinc/nginx-unprivileged:1.27-alpine`. Added `USER root` for the `apk add wget` step (healthcheck dep), then `USER nginx` after. `EXPOSE 80` → `EXPOSE 8080`. Block-comment explains the deliberate deviation from the api/worker `appuser` pattern. |
+| `nginx/nginx.conf` | Added top-level `pid /tmp/nginx.pid;` (non-root nginx can't write to `/var/run/nginx.pid`). Changed `listen 80` → `listen 8080`. Inline comments explain the why. |
+| `nginx/nginx.dev.conf` | Same two changes — the dev nginx service reuses the production image, so it inherits non-root and needs the same adjustments. |
+| `docker-compose.yml` | `"${NGINX_PORT:-8080}:80"` → `"${NGINX_PORT:-8080}:8080"` (host port stays 8080 by default — external callers unaffected — only the container-internal port changed). Healthcheck `localhost:80` → `localhost:8080`. |
+| `docker-compose.dev.yml` | Dev `!override` port mapping `127.0.0.1:8080:80` → `127.0.0.1:8080:8080`. |
+
+## Why these choices
+
+- **`nginxinc/nginx-unprivileged` over manual `addgroup`/`adduser`** — The unprivileged variant is the official upstream-blessed non-root nginx. It pre-configures `USER nginx` (UID 101), pre-owns `/var/cache/nginx` and `/var/run`, and ships sensible defaults (`listen 8080`, `pid /tmp/nginx.pid`). The manual approach would have required ~5 extra Dockerfile lines to chown the right paths, plus the same nginx.conf edits — strictly more code and more ways to be subtly wrong. The deliberate deviation from the api/worker `appuser:appgroup` pattern is justified because the web image runs *upstream nginx*, not our code; using the upstream-blessed user is the cleaner match.
+- **Host port stays 8080** — external callers don't change. Only the container-internal port moved. This keeps any downstream Caddy/Traefik/reverse-proxy configs working as-is.
+- **Both nginx configs updated** — `nginx.conf` (production) and `nginx.dev.conf` (mounted via docker-compose.dev.yml's `!override`) needed the same change because they both run inside the now-non-root image.
+
+## Verification
+
+From the worktree root:
+
+| Gate | Result |
+|---|---|
+| `pnpm typecheck` | ✅ EXIT=0 (all 5 packages green) |
+| `pnpm lint` | ✅ EXIT=0 |
+| `pnpm test` | ✅ EXIT=0 — shared 181 / db 11 / web 181 / api 505 / worker 221 (1099 tests) |
+
+Acceptance from gh#26:
+
+- ✅ Web container runs as non-root via `USER` directive (set in `nginxinc/nginx-unprivileged` base image — UID 101, user `nginx`)
+- ✅ Still serves traffic correctly — host port mapping retained at 8080 by default; nginx config preserved (all `location` blocks, `proxy_pass` to api, gzip, log format, X-Forwarded-Proto map for issue #50)
+
+Manual smoke check (not executed in this session — for the reviewer/operator to run before merge):
+
+```bash
+docker compose build nginx
+docker compose run --rm --entrypoint sh nginx -c 'whoami && id'
+# Expect: nginx, uid=101(nginx) gid=101(nginx)
+docker compose up -d
+curl -fsS localhost:8080/health | head -5
+# Expect: 200 from api via the SPA's proxy_pass
+```
+
+## Notes
+
+- The healthcheck `wget --spider -q http://localhost:8080/health` runs INSIDE the container (nginx-side), so the port change matches the new internal listen.
+- `apk add --no-cache wget` is still needed for the healthcheck binary; that's why the `USER root` / `USER nginx` sandwich exists in the Dockerfile.
+- No new dependencies, no version bumps, no changes to any consumer's surface area.

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,22 @@ WORKDIR /app
 USER appuser
 CMD ["node", "dist/index.js"]
 
-# Web production image (nginx + built SPA assets)
-FROM nginx:1.27-alpine AS web-production
+# Web production image (nginx + built SPA assets).
+#
+# Uses the official non-root nginx variant (nginxinc/nginx-unprivileged)
+# rather than nginx:1.27-alpine + a manual addgroup/adduser. The variant
+# ships USER nginx (UID 101), listens on 8080 by default, writes pid to
+# /tmp/nginx.pid, and chowns runtime dirs for the nginx user — so the
+# manual chown footprint is gone.
+#
+# This deliberately deviates from the api/worker pattern (where we create
+# our own appuser:appgroup). The web container runs upstream nginx, not
+# our code, so using the upstream-blessed nginx user is the cleaner match.
+# gh#26 / CLAUDE.md "Containers: non-root user via USER directive."
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS web-production
+USER root
 RUN apk add --no-cache wget
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /app/packages/web/dist /usr/share/nginx/html
-EXPOSE 80
+USER nginx
+EXPOSE 8080

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -65,8 +65,11 @@ services:
   nginx:
     volumes:
       - ./nginx/nginx.dev.conf:/etc/nginx/nginx.conf:ro
+    # Dev reuses the production web image (nginxinc/nginx-unprivileged) which
+    # listens on 8080 inside the container, so the host:container mapping
+    # targets 8080, not 80. gh#26.
     ports: !override
-      - "127.0.0.1:8080:80"
+      - "127.0.0.1:8080:8080"
 
 volumes:
   web_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,12 +74,15 @@ services:
       context: .
       target: web-production
     ports:
-      - "${NGINX_PORT:-8080}:80"
+      # Container-internal port is 8080 (nginx runs as non-root and can't bind
+      # < 1024). Host-visible port stays 8080 by default so external callers
+      # are unaffected. gh#26.
+      - "${NGINX_PORT:-8080}:8080"
     depends_on:
       api:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:80/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
       interval: 15s
       timeout: 5s
       retries: 3

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,4 +1,8 @@
 worker_processes auto;
+# Pid file lives in /tmp because the container runs nginx as the non-root
+# `nginx` user (UID 101 via nginxinc/nginx-unprivileged). The default
+# /var/run/nginx.pid is only writable by root.
+pid /tmp/nginx.pid;
 
 events {
     worker_connections 1024;
@@ -42,7 +46,10 @@ http {
     }
 
     server {
-        listen 80;
+        # Container-internal port. Must be >= 1024 because the container runs
+        # nginx as a non-root user; the host-side port mapping in
+        # docker-compose.yml decouples this from the externally-visible port.
+        listen 8080;
         server_name _;
 
         location = /health {

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -1,4 +1,8 @@
 worker_processes auto;
+# Dev nginx uses the same web-production image (now nginxinc/nginx-unprivileged)
+# which runs as the non-root `nginx` user (UID 101) and can't write to the
+# default /var/run/nginx.pid. gh#26.
+pid /tmp/nginx.pid;
 
 events {
     worker_connections 1024;
@@ -30,7 +34,9 @@ http {
     }
 
     server {
-        listen 80;
+        # Container-internal port. Same reason as nginx.conf — non-root nginx
+        # can't bind < 1024; host port mapping decouples external visibility.
+        listen 8080;
         server_name _;
 
         location = /health {


### PR DESCRIPTION
## Why

The web-production Docker stage previously ran nginx as root, violating the project's standard *"Containers: non-root user via USER directive"* (CLAUDE.md → API Package Standards → Docker & Infrastructure). Both `api-production` and `worker-production` already follow the rule via manual `addgroup`/`adduser` + `USER appuser`; only the web stage was non-compliant.

## What changed

**`Dockerfile`** — Web-production base swapped from `nginx:1.27-alpine` to `nginxinc/nginx-unprivileged:1.27-alpine` (the official upstream non-root nginx variant). Added `USER root` for the `apk add wget` step (healthcheck dep), then `USER nginx` after. `EXPOSE 80` → `EXPOSE 8080`. A block-comment explains the deliberate deviation from the api/worker `appuser:appgroup` pattern: the web image runs *upstream nginx*, not our code, so using the upstream-blessed `nginx` user (UID 101) is the cleaner match.

**`nginx/nginx.conf`** — Added top-level `pid /tmp/nginx.pid;` (the default `/var/run/nginx.pid` is only writable by root). Changed `listen 80;` → `listen 8080;` (non-root can't bind below 1024). Inline comments explain each.

**`nginx/nginx.dev.conf`** — Same two changes. The dev nginx service reuses the production image (via docker-compose.dev.yml's volume mount), so it inherits the non-root user and needs the same adjustments.

**`docker-compose.yml`** — Production port mapping `"${NGINX_PORT:-8080}:80"` → `"${NGINX_PORT:-8080}:8080"`. **Host-visible port stays 8080 by default** — external callers and any upstream reverse proxy keep working unchanged. Only the container-internal port moved. Healthcheck `wget http://localhost:80/health` → `localhost:8080/health` (runs inside the container).

**`docker-compose.dev.yml`** — Dev `!override` port mapping `127.0.0.1:8080:80` → `127.0.0.1:8080:8080`. Same reason.

## Considered alternatives

The issue listed three options. Trade-offs in `.planning/quick/20260516-26-web-non-root/PLAN.md`:

- **(a) Manual `addgroup`/`adduser`/`USER appuser`, chown `/var/cache/nginx`, `/var/run`** — Most consistent with the api/worker pattern but requires several lines of chown + a `pid` directive. More ways to be subtly wrong.
- **(b) `nginxinc/nginx-unprivileged` base** *(chosen)* — Smaller diff, no chmod/chown footguns, officially maintained by nginx upstream.
- **(c) Rewrite nginx config at build time** — Solves only the port problem; non-root still needs (a)'s chown work. Strictly worse than (a) or (b).

## Test plan

1. From the repo root: `pnpm typecheck && pnpm lint && pnpm test` — verify all three green (no app code changed, so this is sanity).
2. Build the new web image: `docker compose build nginx`.
3. Confirm the container runs as nginx (UID 101), not root:
   ```bash
   docker compose run --rm --entrypoint sh nginx -c 'whoami && id'
   ```
   Expect: `nginx`, `uid=101(nginx) gid=101(nginx) groups=...`.
4. Bring up the stack and hit the health endpoint:
   ```bash
   docker compose up -d
   curl -fsS http://localhost:8080/health
   ```
   Expect: a 200 response (the SPA's nginx proxies `/health` to api).
5. Visit the SPA at `http://localhost:8080/` — verify the index loads and assets serve from `/usr/share/nginx/html`.
6. Dev mode regression: `docker compose -f docker-compose.yml -f docker-compose.dev.yml up nginx` should bring up the dev nginx with the mounted `nginx.dev.conf`, listening on host port 8080 (container 8080).

## Notes

- No application code touched. No dependency version changes. No surface-area changes for any consumer.
- Issue #50's `X-Forwarded-Proto` map in `nginx.conf` is preserved verbatim — the listen change is the only edit to the `server { ... }` block.
- Worktree path on this branch is awkwardly long (`26-security-web-production-docker-stage-runs-as-root`) because the issue title is verbose. Future cuts via `/next-from-backlog` already use the boundary-aware slug truncate from `d874217`.

Closes #26.