### PR TITLE
Add nginx security headers and rate limiting

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -28,7 +28,7 @@ Top-of-queue. An automated workflow should pull from here first.
 
 - [x] **gh#6** — Add `user_id` column to `post_media` to prevent IDOR *(merged in #81 / 293fc46)*
 - [x] **gh#26** — Web-production Docker stage runs as root *(merged in #82 / 8e32ee8)*
-- [~] **gh#25** — Add nginx security headers and rate limiting *(in worktree `.claude/worktrees/25-security-add-nginx-security-headers-and-rate/`)*
+- [x] **gh#25** — Add nginx security headers and rate limiting *(implemented in PR #83)*
 - [~] **gh#15** — Auto-destruct 401/403 should throw `UnrecoverableError` *(in worktree `.claude/worktrees/15-fix-auto-destruct-401-403-should-throw/`)*
 - [ ] **gh#18** — Media cleanup deletes storage before DB row (ordering risk)
 - [ ] **gh#36** — Dev images bake `packages/shared/dist` at build time, breaking after shared exports change

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,8 +20,12 @@ http {
     gzip_types application/json text/css application/javascript text/plain;
     gzip_min_length 1000;
     gzip_vary on;
+    gzip_proxied any;
 
     client_max_body_size 100m;
+    limit_req_status 429;
+    limit_req_zone $binary_remote_addr zone=api_per_ip:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=admin_per_ip:10m rate=2r/s;
 
     log_format main '$remote_addr - $remote_user [$time_local] '
                     '"$request" $status $body_bytes_sent '
@@ -52,6 +56,10 @@ http {
         listen 8080;
         server_name _;
 
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
         location = /health {
             proxy_pass http://api_backend/health;
             proxy_set_header Host $host;
@@ -61,6 +69,8 @@ http {
         }
 
         location /api/ {
+            limit_req zone=api_per_ip burst=20 nodelay;
+
             proxy_pass http://api_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -83,6 +93,8 @@ http {
         }
 
         location /admin/ {
+            limit_req zone=admin_per_ip burst=10 nodelay;
+
             proxy_pass http://api_backend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -98,13 +110,28 @@ http {
         location /assets/ {
             root /usr/share/nginx/html;
             expires 1y;
+            add_header X-Frame-Options "DENY" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
             add_header Cache-Control "public, immutable";
             access_log off;
+        }
+
+        location = /index.html {
+            root /usr/share/nginx/html;
+            add_header X-Frame-Options "DENY" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Cache-Control "no-cache";
         }
 
         location / {
             root /usr/share/nginx/html;
             try_files $uri $uri/ /index.html;
+            add_header X-Frame-Options "DENY" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Cache-Control "no-cache";
         }
     }
 }

--- a/packages/api/src/__tests__/middleware.test.ts
+++ b/packages/api/src/__tests__/middleware.test.ts
@@ -198,3 +198,28 @@ describe('trust proxy (issue #50)', () => {
     expect(csrfCookie).not.toMatch(/;\s*Secure(?:;|$)/);
   });
 });
+
+describe('production nginx security controls (issue #25)', () => {
+  const prodConfig = readFileSync(new URL('../../../../nginx/nginx.conf', import.meta.url), 'utf8');
+
+  it('adds security headers at the reverse proxy and static asset layers', () => {
+    expect(prodConfig.match(/add_header X-Frame-Options "DENY" always;/g)).toHaveLength(4);
+    expect(prodConfig.match(/add_header X-Content-Type-Options "nosniff" always;/g)).toHaveLength(4);
+    expect(prodConfig.match(/add_header Referrer-Policy "strict-origin-when-cross-origin" always;/g)).toHaveLength(4);
+  });
+
+  it('rate limits API and admin traffic with 429 responses', () => {
+    expect(prodConfig).toContain('limit_req_status 429;');
+    expect(prodConfig).toContain('limit_req_zone $binary_remote_addr zone=api_per_ip:10m rate=10r/s;');
+    expect(prodConfig).toContain('limit_req zone=api_per_ip burst=20 nodelay;');
+    expect(prodConfig).toContain('limit_req_zone $binary_remote_addr zone=admin_per_ip:10m rate=2r/s;');
+    expect(prodConfig).toContain('limit_req zone=admin_per_ip burst=10 nodelay;');
+  });
+
+  it('compresses proxied responses and prevents SPA index caching', () => {
+    expect(prodConfig).toContain('gzip_proxied any;');
+    expect(prodConfig).toContain('location = /index.html');
+    expect(prodConfig.match(/add_header Cache-Control "no-cache";/g)).toHaveLength(2);
+    expect(prodConfig).toContain('add_header Cache-Control "public, immutable";');
+  });
+});


### PR DESCRIPTION
## Summary

- Add production nginx security headers for proxied and static responses
- Add nginx rate limiting for `/api/` and `/admin/` with 429 responses
- Enable gzip for proxied responses and prevent SPA `index.html` caching
- Add API middleware regression coverage for the nginx production controls

Closes #25

## Validation

- `pnpm --filter @sms/api exec vitest --run src/__tests__/middleware.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Note: attempted `nginx -t` via `nginxinc/nginx-unprivileged:1.27-alpine`, but Docker credential/image resolution hung before the image could run.