### PR TITLE
fix(worker): throw UnrecoverableError on auto-destruct 401/403 (closes #15)

### DIFF
--- a/packages/worker/src/__tests__/auto-destruct-worker.test.ts
+++ b/packages/worker/src/__tests__/auto-destruct-worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Queue, Job } from 'bullmq';
+import { UnrecoverableError, type Queue, type Job } from 'bullmq';
 import type { WorkerDb } from '../db.js';
 
 vi.mock('@sms/shared/logger', () => ({
@@ -200,6 +200,63 @@ describe('Auto-Destruct System', () => {
       // Pitfall 1: Must use job payload platformPostId, not DB row's
       expect(callDelete).toHaveBeenCalledWith(profile, 'correct-tweet-from-job');
     });
+
+    it.each([401, 403] as const)(
+      'throws UnrecoverableError on HTTP %i so BullMQ skips remaining retries',
+      async (httpStatus) => {
+        const { autoDestructPost } = await import('../auto-destruct-lifecycle.service.js');
+        const profile = createMockProfile();
+
+        const txMock = {
+          execute: vi.fn().mockResolvedValue([{
+            id: 'post-1',
+            status: 'published',
+            profile_id: 'profile-1',
+          }]),
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([profile]),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue(undefined),
+            }),
+          }),
+        };
+
+        const updateSetWhere = vi.fn().mockResolvedValue(undefined);
+        const updateSet = vi.fn().mockReturnValue({ where: updateSetWhere });
+        const outerUpdate = vi.fn().mockReturnValue({ set: updateSet });
+
+        const db = {
+          transaction: vi.fn().mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(txMock)),
+          update: outerUpdate,
+        } as unknown as WorkerDb;
+
+        const credentialError = new MockApiResponseError(
+          `Authorization failure (HTTP ${httpStatus})`,
+          { code: httpStatus },
+        );
+        const callDelete = vi.fn().mockRejectedValue(credentialError);
+
+        const rejection = autoDestructPost(db, {
+          postId: 'post-1',
+          platformPostId: 'tweet-revoked',
+          correlationId: 'corr-revoked',
+          callDelete,
+        });
+
+        await expect(rejection).rejects.toBeInstanceOf(UnrecoverableError);
+        await expect(rejection).rejects.toMatchObject({
+          name: 'UnrecoverableError',
+          message: `Auto-destruct failed: credentials invalid or revoked (HTTP ${httpStatus})`,
+        });
+
+        // failureReason still persisted before the throw so operators see context
+        expect(outerUpdate).toHaveBeenCalled();
+      },
+    );
 
     it('sets failureReason and rethrows on delete failure', async () => {
       const { autoDestructPost } = await import('../auto-destruct-lifecycle.service.js');

--- a/packages/worker/src/auto-destruct-lifecycle.service.ts
+++ b/packages/worker/src/auto-destruct-lifecycle.service.ts
@@ -12,6 +12,7 @@
 // 'auto_destructing', rethrows for BullMQ retry (D-12).
 
 import { sql, eq } from 'drizzle-orm';
+import { UnrecoverableError } from 'bullmq';
 import { ApiResponseError } from 'twitter-api-v2';
 import { posts, socialProfiles } from '@sms/db';
 import { transitionPost, type PostStatus } from '@sms/shared';
@@ -123,12 +124,14 @@ export async function autoDestructPost(
     }
 
     // Error classification: 401/403 are credential failures that won't
-    // resolve on retry -- throw immediately so BullMQ treats it as a
-    // permanent failure. 429 and 5xx are transient -- rethrow to retry.
+    // resolve on retry -- throw UnrecoverableError so BullMQ skips the
+    // remaining retry attempts (D-12 cadence would otherwise burn ~36
+    // minutes before the failed listener fires). 429 and 5xx are
+    // transient -- rethrow to retry.
     if (deleteErr instanceof ApiResponseError) {
       const httpStatus = deleteErr.code;
       if (httpStatus === 401 || httpStatus === 403) {
-        throw new Error(
+        throw new UnrecoverableError(
           `Auto-destruct failed: credentials invalid or revoked (HTTP ${httpStatus})`,
         );
       }

--- a/packages/worker/src/auto-destruct-worker.ts
+++ b/packages/worker/src/auto-destruct-worker.ts
@@ -83,12 +83,16 @@ export function createAutoDestructWorker(
     },
   );
 
-  // Exhausted retries: emit notification (D-12)
+  // Exhausted retries OR UnrecoverableError: emit notification (D-12).
+  // Mirrors publish-worker: 401/403 are thrown as UnrecoverableError by the
+  // lifecycle service so BullMQ short-circuits the retry chain, and we still
+  // want the user-facing notification on first (and only) failure.
   worker.on('failed', async (job, err) => {
     if (!job) return;
 
     const attemptsCap = job.opts.attempts ?? AUTO_DESTRUCT_CONFIG.attempts;
-    const isFinalFailure = job.attemptsMade >= attemptsCap;
+    const isFinalFailure =
+      err.name === 'UnrecoverableError' || job.attemptsMade >= attemptsCap;
     if (!isFinalFailure) return;
 
     try {


### PR DESCRIPTION
## Why

gh#15 calls out that when Twitter delete fails with 401/403 (revoked credentials), `auto-destruct-lifecycle.service.ts` throws a plain `Error`. BullMQ has no way to know that retrying won't help, so it burns through the remaining attempts on the D-12 backoff cadence — 30s + 5min + 30min ≈ 36 minutes of wasted retries — before the `failed` listener finally fires the user-facing notification. The publish worker handles the same auth-revoked case via `UnrecoverableError` (see `publish-worker.ts:299`); auto-destruct was missing the parity.

## What changed

**`packages/worker/src/auto-destruct-lifecycle.service.ts`** — Imports `UnrecoverableError` from `bullmq`. The 401/403 branch inside the Phase 2 `catch` now throws `UnrecoverableError` instead of `Error`, with the same message shape. The 429/5xx rethrow path is untouched.

**`packages/worker/src/auto-destruct-worker.ts`** — The `failed` listener's `isFinalFailure` guard now also matches `err.name === 'UnrecoverableError'`, mirroring `publish-worker.ts:342`. Without this, BullMQ's `failed` event fires immediately for an `UnrecoverableError`, but `attemptsMade < attemptsCap`, so the operator notification would be skipped.

**`packages/worker/src/__tests__/auto-destruct-worker.test.ts`** — New `it.each([401, 403])` inside the `autoDestructPost lifecycle` describe. For each status, asserts the rejection is `instanceof UnrecoverableError`, the message is the exact `Auto-destruct failed: credentials invalid or revoked (HTTP NNN)`, and the `failureReason` persistence still fires before the throw.

## Test plan

1. From repo root run `pnpm typecheck && pnpm lint && pnpm test` — verify all three pass.
2. Run the focused worker suite: `pnpm --filter @sms/worker test`. Verify the new `throws UnrecoverableError on HTTP 401 ...` and `... on HTTP 403 ...` cases both pass, and the existing `sets failureReason and rethrows on delete failure` case (transient 500 path) still passes.
3. Synthetic walkthrough — temporarily make `deleteTweet` reject with a 401 `ApiResponseError`. With a queued auto-destruct job: verify BullMQ marks the job final-failed without further retries, the \`failed\` listener fires the \`auto_destruct_failed\` notification once, and the post row carries \`failureReason\` set to the credential-revoked message.
4. Regression: temporarily make \`deleteTweet\` reject with a 503 (transient). Verify all 4 attempts still run with the expected D-12 backoff cadence before the listener fires.

## Notes

- Pattern parity with publish-worker — same \`UnrecoverableError\` class, same \`err.name === 'UnrecoverableError'\` listener check.
- No surface-area change for consumers. No new deps.

Closes #15.