### PR TITLE
Hotfix schedule post CSRF retry

### DIFF
--- a/packages/web/src/components/posts/SharedPostFields.tsx
+++ b/packages/web/src/components/posts/SharedPostFields.tsx
@@ -24,6 +24,8 @@ interface SharedPostFieldsProps {
 
   scheduledAt: string | null;
   onScheduledAtChange: (utcIso: string | null, wasAdjusted: boolean) => void;
+  scheduledAtError?: string | null;
+  scheduleInputRef?: RefObject<HTMLInputElement | null>;
 
   tagIds: string[];
   onTagIdsChange: (ids: string[]) => void;
@@ -69,6 +71,8 @@ export function SharedPostFields({
   excludePostId,
   scheduledAt,
   onScheduledAtChange,
+  scheduledAtError,
+  scheduleInputRef,
   tagIds,
   onTagIdsChange,
   onOpenTagManagement,
@@ -109,13 +113,22 @@ export function SharedPostFields({
           <Label htmlFor="schedule-datetime">Schedule</Label>
           <Input
             id="schedule-datetime"
+            ref={scheduleInputRef}
             type="datetime-local"
             value={scheduledAt ? utcToLocalInput(scheduledAt, userTimezone) : ''}
             onChange={(event) => handleScheduledAtInputChange(event.target.value)}
+            aria-invalid={scheduledAtError ? 'true' : undefined}
+            aria-describedby={scheduledAtError ? 'schedule-datetime-error schedule-datetime-help' : 'schedule-datetime-help'}
+            className={scheduledAtError ? 'border-destructive focus-visible:ring-destructive' : undefined}
           />
-          <p className="text-xs text-muted-foreground">
+          <p id="schedule-datetime-help" className="text-xs text-muted-foreground">
             Times shown in {userTimezone.replace(/_/g, ' ')}
           </p>
+          {scheduledAtError && (
+            <p id="schedule-datetime-error" className="text-sm text-destructive">
+              {scheduledAtError}
+            </p>
+          )}
           {/* POST-CMN-07: conflict warning when another scheduled post exists at the same time */}
           {conflicts && conflicts.length > 0 && (
             <ScheduleConflictBanner conflicts={conflicts} />

--- a/packages/web/src/lib/__tests__/api-client.test.ts
+++ b/packages/web/src/lib/__tests__/api-client.test.ts
@@ -53,6 +53,96 @@ describe('apiClient cache directive contract', () => {
     expect(init.cache).toBeUndefined();
   });
 
+  it('post() refreshes the CSRF token and retries once after a generic production 403', async () => {
+    let tokenRequests = 0;
+    let postRequests = 0;
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      if (typeof input === 'string' && input === '/api/auth/csrf-token') {
+        tokenRequests += 1;
+        return new Response(JSON.stringify({ token: `csrf-refresh-${tokenRequests}` }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (typeof input === 'string' && input === '/api/posts') {
+        postRequests += 1;
+        if (postRequests === 1) {
+          return new Response(JSON.stringify({ error: 'Internal server error' }), {
+            status: 403,
+            statusText: 'Forbidden',
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ id: 'post-1' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    });
+
+    await expect(apiClient.post('/api/posts', { text: 'hello' })).resolves.toEqual({ id: 'post-1' });
+
+    const postCalls = fetchSpy.mock.calls.filter(
+      (call: [RequestInfo | URL, RequestInit | undefined]) =>
+        typeof call[0] === 'string' && call[0] === '/api/posts',
+    );
+    expect(postRequests).toBe(2);
+    expect(tokenRequests).toBeGreaterThanOrEqual(1);
+    expect((postCalls.at(-1)?.[1] as RequestInit).headers).toMatchObject({
+      'x-csrf-token': `csrf-refresh-${tokenRequests}`,
+    });
+  });
+
+  it('postFormData() refreshes the CSRF token and retries once after a generic production 403', async () => {
+    let tokenRequests = 0;
+    let uploadRequests = 0;
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      if (typeof input === 'string' && input === '/api/auth/csrf-token') {
+        tokenRequests += 1;
+        return new Response(JSON.stringify({ token: `csrf-upload-${tokenRequests}` }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (typeof input === 'string' && input === '/api/media') {
+        uploadRequests += 1;
+        if (uploadRequests === 1) {
+          return new Response(JSON.stringify({ error: 'Internal server error' }), {
+            status: 403,
+            statusText: 'Forbidden',
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ id: 'media-1' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    });
+
+    const formData = new FormData();
+    formData.append('file', new Blob(['hello']), 'hello.txt');
+
+    await expect(apiClient.postFormData('/api/media', formData)).resolves.toEqual({ id: 'media-1' });
+
+    const uploadCalls = fetchSpy.mock.calls.filter(
+      (call: [RequestInfo | URL, RequestInit | undefined]) =>
+        typeof call[0] === 'string' && call[0] === '/api/media',
+    );
+    expect(uploadRequests).toBe(2);
+    expect(tokenRequests).toBeGreaterThanOrEqual(1);
+    expect((uploadCalls.at(-1)?.[1] as RequestInit).headers).toMatchObject({
+      'x-csrf-token': `csrf-upload-${tokenRequests}`,
+    });
+    expect((uploadCalls.at(-1)?.[1] as RequestInit).headers).not.toHaveProperty('Content-Type');
+  });
+
   it("patch() does NOT pass cache: 'no-store'", async () => {
     await apiClient.patch('/api/users/me/notification-prefs', { rows: [] });
 

--- a/packages/web/src/lib/api-client.ts
+++ b/packages/web/src/lib/api-client.ts
@@ -34,47 +34,29 @@ function filenameFromContentDisposition(contentDisposition: string | null): stri
   return filenameMatch?.[1] ?? null;
 }
 
-function isCsrfError(status: number, body: Record<string, unknown>): boolean {
-  if (status !== 403) return false;
-  const msg = ((body.error as string) ?? '').toLowerCase();
-  return msg.includes('csrf') || msg.includes('token');
-}
-
 async function mutationRequest<T>(method: string, path: string, data?: unknown): Promise<T> {
-  const token = await getCsrfToken();
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    'x-csrf-token': token,
-  };
-
-  const res = await fetch(path, {
+  return csrfMutationRequest<T>(path, (token) => ({
     method,
     credentials: 'include',
-    headers,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-csrf-token': token,
+    },
     body: data ? JSON.stringify(data) : undefined,
-  });
+  }));
+}
+
+async function csrfMutationRequest<T>(
+  path: string,
+  buildInit: (csrfToken: string) => RequestInit,
+): Promise<T> {
+  const token = await getCsrfToken();
+  let res = await fetch(path, buildInit(token));
 
   if (res.status === 403) {
-    const body = await parseErrorBody(res);
-    if (isCsrfError(res.status, body)) {
-      csrfToken = null;
-      const newToken = await getCsrfToken();
-      const retryRes = await fetch(path, {
-        method,
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json', 'x-csrf-token': newToken },
-        body: data ? JSON.stringify(data) : undefined,
-      });
-      if (!retryRes.ok) {
-        const retryBody = await parseErrorBody(retryRes);
-        throw createError((retryBody.error as string) || retryRes.statusText, retryRes.status, retryBody);
-      }
-      if (retryRes.status === 204) {
-        return undefined as T;
-      }
-      return retryRes.json();
-    }
-    throw createError((body.error as string) || res.statusText, res.status, body);
+    csrfToken = null;
+    const newToken = await getCsrfToken();
+    res = await fetch(path, buildInit(newToken));
   }
 
   if (!res.ok) {
@@ -136,43 +118,12 @@ export const apiClient = {
   },
 
   async postFormData<T = unknown>(path: string, formData: FormData): Promise<T> {
-    const token = await getCsrfToken();
-    const res = await fetch(path, {
+    return csrfMutationRequest<T>(path, (token) => ({
       method: 'POST',
       credentials: 'include',
       headers: { 'x-csrf-token': token },
       body: formData,
-    });
-    if (res.status === 403) {
-      const body = await parseErrorBody(res);
-      if (isCsrfError(res.status, body)) {
-        csrfToken = null;
-        const newToken = await getCsrfToken();
-        const retryRes = await fetch(path, {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'x-csrf-token': newToken },
-          body: formData,
-        });
-        if (!retryRes.ok) {
-          const retryBody = await parseErrorBody(retryRes);
-          throw createError((retryBody.error as string) || retryRes.statusText, retryRes.status, retryBody);
-        }
-        if (retryRes.status === 204) {
-          return undefined as T;
-        }
-        return retryRes.json();
-      }
-      throw createError((body.error as string) || res.statusText, res.status, body);
-    }
-    if (!res.ok) {
-      const body = await parseErrorBody(res);
-      throw createError((body.error as string) || res.statusText, res.status, body);
-    }
-    if (res.status === 204) {
-      return undefined as T;
-    }
-    return res.json();
+    }));
   },
 
   async uploadCsv<T = unknown>(path: string, formData: FormData): Promise<T> {

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -82,6 +82,8 @@ export default function EditPostPage() {
   const [isFormInitialized, setIsFormInitialized] = useState(false);
   const [isRateLimitDialogOpen, setIsRateLimitDialogOpen] = useState(false);
   const postTextAreaRef = useRef<HTMLTextAreaElement>(null);
+  const scheduleInputRef = useRef<HTMLInputElement>(null);
+  const [scheduledAtError, setScheduledAtError] = useState<string | null>(null);
 
   const [mediaItems, setMediaItems] = useState<MediaItem[]>([]);
   const { upload, uploadingFiles, isUploading } = useMediaUpload();
@@ -390,6 +392,7 @@ export default function EditPostPage() {
 
   function handleScheduledAtChange(utcIso: string | null, wasAdjusted: boolean) {
     updateForm('scheduledAt', utcIso);
+    setScheduledAtError(null);
     if (utcIso && wasAdjusted) {
       const adjustedLocal = DateTime.fromISO(utcIso).setZone(userTimezone).toFormat('h:mm a');
       toast.info(`Adjusted to ${adjustedLocal} due to daylight saving time change.`);
@@ -441,10 +444,14 @@ export default function EditPostPage() {
 
     if (action === 'schedule') {
       if (!formState.scheduledAt) {
+        setScheduledAtError('Select a scheduled time before scheduling.');
+        scheduleInputRef.current?.focus();
         toast.error('Please select a scheduled time.');
         return;
       }
       if (DateTime.fromISO(formState.scheduledAt) <= DateTime.utc()) {
+        setScheduledAtError('Scheduled time must be in the future.');
+        scheduleInputRef.current?.focus();
         toast.error('Scheduled time must be in the future.');
         return;
       }
@@ -622,6 +629,8 @@ export default function EditPostPage() {
             excludePostId={postId}
             scheduledAt={formState.scheduledAt}
             onScheduledAtChange={handleScheduledAtChange}
+            scheduledAtError={scheduledAtError}
+            scheduleInputRef={scheduleInputRef}
             tagIds={formState.tagIds}
             onTagIdsChange={(ids) => updateForm('tagIds', ids)}
             onOpenTagManagement={() => setIsTagManageOpen(true)}

--- a/packages/web/src/pages/posts/NewPostPage.tsx
+++ b/packages/web/src/pages/posts/NewPostPage.tsx
@@ -91,6 +91,8 @@ export default function NewPostPage() {
   const [rateLimitBlockError, setRateLimitBlockError] = useState<RateLimitBlockErrorDetail | null>(null);
   const [isRateLimitDialogOpen, setIsRateLimitDialogOpen] = useState(false);
   const postTextAreaRef = useRef<HTMLTextAreaElement>(null);
+  const scheduleInputRef = useRef<HTMLInputElement>(null);
+  const [scheduledAtError, setScheduledAtError] = useState<string | null>(null);
 
   const [mediaItems, setMediaItems] = useState<MediaItem[]>([]);
   const { upload, uploadingFiles, isUploading } = useMediaUpload();
@@ -239,6 +241,7 @@ export default function NewPostPage() {
 
   function handleScheduledAtChange(utcIso: string | null, wasAdjusted: boolean) {
     updateForm('scheduledAt', utcIso);
+    setScheduledAtError(null);
     if (utcIso && wasAdjusted) {
       const adjustedLocal = DateTime.fromISO(utcIso).setZone(userTimezone).toFormat('h:mm a');
       toast.info(`Adjusted to ${adjustedLocal} due to daylight saving time change.`);
@@ -335,10 +338,14 @@ export default function NewPostPage() {
     if (action === 'schedule') {
       const scheduledAt = formState.scheduledAt;
       if (!scheduledAt) {
+        setScheduledAtError('Select a scheduled time before scheduling.');
+        scheduleInputRef.current?.focus();
         toast.error('Please select a scheduled time.');
         return;
       }
       if (DateTime.fromISO(scheduledAt) <= DateTime.utc()) {
+        setScheduledAtError('Scheduled time must be in the future.');
+        scheduleInputRef.current?.focus();
         toast.error('Scheduled time must be in the future.');
         return;
       }
@@ -545,6 +552,8 @@ export default function NewPostPage() {
             effectiveProfileId={effectiveProfileId}
             scheduledAt={formState.scheduledAt}
             onScheduledAtChange={handleScheduledAtChange}
+            scheduledAtError={scheduledAtError}
+            scheduleInputRef={scheduleInputRef}
             tagIds={formState.tagIds}
             onTagIdsChange={(ids) => updateForm('tagIds', ids)}
             onOpenTagManagement={() => setIsTagManageOpen(true)}

--- a/packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx
@@ -1,0 +1,195 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import NewPostPage from '../NewPostPage';
+
+const navigate = vi.fn();
+const createPostMutate = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  };
+});
+
+vi.mock('../../../hooks/use-auth', () => ({
+  useAuth: () => ({ data: { timezone: 'America/Detroit' } }),
+}));
+
+vi.mock('../../../hooks/use-profiles', () => ({
+  useProfiles: () => ({
+    data: [
+      {
+        id: '99999999-9999-4999-8999-999999999998',
+        platform: 'twitter',
+        displayName: 'Codex Repro Twitter',
+        handle: 'codexrepro',
+        avatarUrl: '',
+      },
+    ],
+  }),
+}));
+
+vi.mock('../../../hooks/use-posts', () => ({
+  useCreatePost: () => ({
+    mutate: createPostMutate,
+    isPending: false,
+  }),
+  useCheckConflicts: () => ({ data: [] }),
+}));
+
+vi.mock('../../../hooks/use-queues', () => ({
+  useQueue: () => ({ data: null }),
+}));
+
+vi.mock('../../../hooks/use-queue-posts', () => ({
+  useAddToQueue: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('../../../hooks/use-media-upload', () => ({
+  useMediaUpload: () => ({
+    upload: vi.fn(),
+    uploadingFiles: new Map(),
+    isUploading: false,
+  }),
+}));
+
+vi.mock('../../../hooks/use-media', () => ({
+  useDeleteMedia: () => ({ mutate: vi.fn() }),
+  useRetryTranscode: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('../../../hooks/use-tags', () => ({
+  useTags: () => ({ data: [] }),
+}));
+
+vi.mock('../../../components/posts/ProfilePicker', () => ({
+  ProfilePicker: ({
+    onValueChange,
+  }: {
+    onValueChange: (profileId: string, platform: 'twitter') => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onValueChange('99999999-9999-4999-8999-999999999998', 'twitter')
+      }
+    >
+      Use Twitter profile
+    </button>
+  ),
+}));
+
+vi.mock('../../../components/posts/TwitterPostFields', () => ({
+  TwitterPostFields: ({
+    text,
+    onTextChange,
+  }: {
+    text: string;
+    onTextChange: (value: string) => void;
+  }) => (
+    <textarea
+      aria-label="Tweet text"
+      value={text}
+      onChange={(event) => onTextChange(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock('../../../components/posts/TweetPreview', () => ({
+  TweetPreview: () => null,
+}));
+
+vi.mock('../../../components/posts/LinkedInPreview', () => ({
+  LinkedInPreview: () => null,
+}));
+
+vi.mock('../../../components/posts/FacebookPreview', () => ({
+  FacebookPreview: () => null,
+}));
+
+vi.mock('../../../components/posts/TagSelector', () => ({
+  TagSelector: () => <button type="button">Select tags...</button>,
+}));
+
+vi.mock('../../../components/posts/AutoDestructPicker', () => ({
+  AutoDestructPicker: () => <div>Auto-destruct</div>,
+}));
+
+vi.mock('../../../components/posts/TagManagementDialog', () => ({
+  TagManagementDialog: () => null,
+}));
+
+vi.mock('../../../components/posts/RateLimitBanner', () => ({
+  RateLimitBanner: () => null,
+}));
+
+vi.mock('../../../components/profiles/RateLimitSettingsDialog', () => ({
+  RateLimitSettingsDialog: () => null,
+}));
+
+vi.mock('../../../components/snippets/SnippetPicker', () => ({
+  SnippetPicker: () => <button type="button">Insert snippet</button>,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <NewPostPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('NewPostPage scheduling validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the user on the form and focuses an inline schedule error when schedule time is missing', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Use Twitter profile' }),
+    );
+    await user.type(screen.getByLabelText('Tweet text'), 'A test tweet');
+    await user.click(screen.getByRole('button', { name: 'Schedule Post' }));
+
+    expect(createPostMutate).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    expect(
+      screen.getByText('Select a scheduled time before scheduling.'),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Schedule')).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## Summary
- Cherry-picks the merged develop fix for scheduled post creation into `main`
- Retries mutating API requests once after refreshing CSRF/session state when production returns 403
- Preserves scheduled time validation UX so invalid or missing times surface inline instead of flashing and doing nothing

## Validation
- `pnpm --filter @sms/shared build`
- `pnpm --filter @sms/web test -- --run src/lib/__tests__/api-client.test.ts src/pages/posts/__tests__/NewPostPage.test.tsx`
- `pnpm --filter @sms/web typecheck`