### PR TITLE
fix(infra): add tsc -w sidecars for @sms/shared and @sms/db (closes #36)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,7 @@ services:
       - ./packages/shared/dist:/app/packages/shared/dist
       - ./packages/shared/tsconfig.json:/app/packages/shared/tsconfig.json:ro
       - ./packages/shared/package.json:/app/packages/shared/package.json:ro
+      - ./tsconfig.base.json:/app/tsconfig.base.json:ro
     command: ["pnpm", "--filter", "@sms/shared", "exec", "tsc", "--watch", "--preserveWatchOutput"]
 
   db-watch:
@@ -29,6 +30,7 @@ services:
       - ./packages/db/dist:/app/packages/db/dist
       - ./packages/db/tsconfig.json:/app/packages/db/tsconfig.json:ro
       - ./packages/db/package.json:/app/packages/db/package.json:ro
+      - ./tsconfig.base.json:/app/tsconfig.base.json:ro
     command: ["pnpm", "--filter", "@sms/db", "exec", "tsc", "--watch", "--preserveWatchOutput"]
 
   api:
@@ -49,7 +51,13 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
       - "127.0.0.1:9229:9229"
-    command: ["npx", "tsx", "watch", "packages/api/src/index.ts"]
+    # --include forces tsx to watch the shared/db dist outputs the sidecars
+    # write to. Without these, tsx-watch's default ignore list can skip dist
+    # updates and miss the rebuild-driven restart.
+    command: ["npx", "tsx", "watch",
+              "--include", "packages/shared/dist/**",
+              "--include", "packages/db/dist/**",
+              "packages/api/src/index.ts"]
 
   worker:
     build:
@@ -68,7 +76,11 @@ services:
       LOG_LEVEL: debug
     ports:
       - "127.0.0.1:9230:9229"
-    command: ["npx", "tsx", "watch", "packages/worker/src/index.ts"]
+    # See api service for --include rationale.
+    command: ["npx", "tsx", "watch",
+              "--include", "packages/shared/dist/**",
+              "--include", "packages/db/dist/**",
+              "packages/worker/src/index.ts"]
 
   web:
     image: node:22-alpine

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,36 @@
 services:
+  # Watch sidecars for the compile-to-dist workspace packages. Each runs
+  # `tsc --watch` against its package's `src/`, writing to `dist/` via the
+  # bind mount, so api/worker `tsx watch` picks up new exports without a
+  # manual host-side `pnpm --filter @sms/<pkg> build`. Closes the gh#36
+  # footgun where a freshly-added export crashed api/worker at startup
+  # against a stale baked-in `dist/index.js`.
+  #
+  # Dev startup ordering note: api/worker have no `depends_on` constraint
+  # because tsx-watch tolerates a transient resolution miss and restarts
+  # on dist changes. If you've never built shared/db on this host, run
+  # `pnpm --filter @sms/shared build && pnpm --filter @sms/db build`
+  # once before `docker compose up` to seed dist for the first attempt.
+  shared-watch:
+    build:
+      target: development
+    volumes:
+      - ./packages/shared/src:/app/packages/shared/src
+      - ./packages/shared/dist:/app/packages/shared/dist
+      - ./packages/shared/tsconfig.json:/app/packages/shared/tsconfig.json:ro
+      - ./packages/shared/package.json:/app/packages/shared/package.json:ro
+    command: ["pnpm", "--filter", "@sms/shared", "exec", "tsc", "--watch", "--preserveWatchOutput"]
+
+  db-watch:
+    build:
+      target: development
+    volumes:
+      - ./packages/db/src:/app/packages/db/src
+      - ./packages/db/dist:/app/packages/db/dist
+      - ./packages/db/tsconfig.json:/app/packages/db/tsconfig.json:ro
+      - ./packages/db/package.json:/app/packages/db/package.json:ro
+    command: ["pnpm", "--filter", "@sms/db", "exec", "tsc", "--watch", "--preserveWatchOutput"]
+
   api:
     build:
       target: development
@@ -8,6 +40,8 @@ services:
       - ./packages/shared/dist:/app/packages/shared/dist
       - ./packages/shared/package.json:/app/packages/shared/package.json:ro
       - ./packages/db/src:/app/packages/db/src
+      - ./packages/db/dist:/app/packages/db/dist
+      - ./packages/db/package.json:/app/packages/db/package.json:ro
       - ./data/media:/app/data/media
     environment:
       NODE_ENV: development
@@ -26,6 +60,8 @@ services:
       - ./packages/shared/dist:/app/packages/shared/dist
       - ./packages/shared/package.json:/app/packages/shared/package.json:ro
       - ./packages/db/src:/app/packages/db/src
+      - ./packages/db/dist:/app/packages/db/dist
+      - ./packages/db/package.json:/app/packages/db/package.json:ro
       - ./data/media:/app/data/media
     environment:
       NODE_ENV: development


### PR DESCRIPTION
## Why

Adding a new export to `@sms/shared` (or `@sms/db`) and restarting api/worker hits `SyntaxError: The requested module '@sms/shared' does not provide an export named 'X'` — because `tsx watch` resolves through `packages/shared/dist/index.js`, and that dist file goes stale the instant src changes if nobody manually re-runs `pnpm --filter @sms/shared build` on the host. gh#36 captures the concrete Phase 8 occurrence: added `checkLinkedInBudget` / `checkFacebookBudget`, both containers crashed at startup until the host-side build ran.

The dist is already bind-mounted from host into api/worker (`./packages/shared/dist:/app/packages/shared/dist`) — so the dist they see IS the host's. The remaining gap is keeping the host's copy fresh automatically while dev is running.

## What changed

**`docker-compose.dev.yml`** — two new sidecar services and two extra mounts on api/worker.

- **`shared-watch`** — runs `pnpm --filter @sms/shared exec tsc --watch --preserveWatchOutput`. Reads `./packages/shared/src` via bind mount, writes `./packages/shared/dist` via bind mount. api/worker pick up the fresh dist via their existing `shared/dist` volume and tsx-watch's dependency-change restart.

- **`db-watch`** — same shape, scoped to `@sms/db`. Both packages have the identical bug surface (`main: dist/index.js`, `build: tsc`, `outDir: dist`) — fixing both together avoids a repeat patch when the next schema export lands. The issue body itself flags this with "Any future shared/db/etc."

- **`api` / `worker` volumes** gain `./packages/db/dist:/app/packages/db/dist` and `./packages/db/package.json:/app/packages/db/package.json:ro`. Pre-existing gap: `db/dist` was never mounted into api/worker (only `db/src` was), so the `db-watch` sidecar's output couldn't reach them without these. Same commit because the sidecar is useless without the mount.

- **Inline comment block** above the new services documents the failure mode and the first-run seed step (`pnpm --filter @sms/shared build && pnpm --filter @sms/db build` if dist doesn't yet exist on the host).

Dev startup ordering: api/worker have no `depends_on` on the watchers. `tsx watch` tolerates a transient resolution miss and restarts when dist files update; `tsc --watch` runs a full compile before entering watch mode. First-run cost is one host build, documented inline.

## Test plan

1. From repo root: `pnpm typecheck && pnpm lint && pnpm test` — verify all three pass. (Done on this branch: 1112 tests across api/db/shared/web/worker.)
2. `docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet` — verify the merged YAML parses cleanly. (Done on this branch.)
3. Repro the original failure mode, then verify the fix:
   - `rm -rf packages/shared/dist packages/db/dist` to simulate a fresh clone.
   - `pnpm --filter @sms/shared build && pnpm --filter @sms/db build` to seed dist per the inline first-run note.
   - `docker compose -f docker-compose.yml -f docker-compose.dev.yml up shared-watch db-watch api worker postgres redis`.
   - Wait for api/worker to start successfully against the seeded dist.
   - **Add a new export to `packages/shared/src/index.ts`** (e.g., `export const __test_marker = true;`) and import it in `packages/api/src/index.ts`.
   - Watch container logs: `shared-watch` should compile within ~1s, api's `tsx watch` should restart, and the new import should resolve without the `does not provide an export named` error.
   - Repeat for `@sms/db` (add a schema export, import in api).
4. Regression: a vanilla `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` should bring up `shared-watch` + `db-watch` alongside everything else with no port conflicts or startup failures.

## Notes

- No application code touched. No `Dockerfile` change. No `package.json` / exports-map surgery. Production image paths unaffected.
- `@sms/shared` has subpath exports (`./encryption`, `./logger`, `./env`, `./storage`, `./lib/error-classifier`) — all resolve through `dist/*` and benefit from the same watch sidecar with zero per-subpath configuration.
- The current manual-rebuild workflow has been a known footgun since v1.0; gh#36 captured the concrete Phase 8 crash.

Closes #36.
