### PR TITLE
[codex] Improve Clawpatch overnight repair loop

### DIFF
--- a/.agents/skills/clawpatch-overnight/SKILL.md
+++ b/.agents/skills/clawpatch-overnight/SKILL.md
@@ -9,6 +9,8 @@ description: Starts and monitors the repo's overnight Clawpatch GitHub issue bat
 
 Run imported GitHub-backed Clawpatch findings in small timed batches. Default policy: one finding every 30 minutes, with one commit per fixed finding.
 
+The overnight runner is resilient by default: each finding gets one initial fix attempt plus three repair retries. If all attempts fail, the runner saves local failure artifacts, marks the finding `uncertain`, commits that Clawpatch status update, restores a clean worktree, and continues with the next open finding.
+
 ## Before Starting
 
 1. Confirm the repo root:
@@ -63,7 +65,7 @@ git status --short
 git log --oneline -8
 ```
 
-The loop stops on failed validation, failed revalidation, or a dirty worktree. That is expected safety behavior.
+The loop parks findings that exhaust their repair attempts and continues. It still stops on cleanup failures, stale locks, missing tools, or any condition that leaves the worktree dirty after parking.
 
 ## Stop
 

--- a/docs/clawpatch-github-issue-import.md
+++ b/docs/clawpatch-github-issue-import.md
@@ -64,6 +64,8 @@ pnpm clawpatch:overnight -- --runs 12 --background
 
 This starts one finding every 30 minutes for about six hours and logs to `logs/clawpatch-overnight.log`.
 
+By default the overnight loop gives each finding one initial fix attempt plus three repair retries. If all attempts fail, the runner saves local artifacts under `.clawpatch/reports/overnight-failures/`, marks the finding `uncertain`, commits that Clawpatch status update, restores a clean worktree, and continues with the next open finding. It still stops if it cannot restore a clean worktree.
+
 The runner performs:
 
 1. Select next imported GitHub finding in backlog order.
@@ -71,7 +73,9 @@ The runner performs:
 3. `clawpatch fix --finding`.
 4. `clawpatch revalidate --finding`.
 5. `pnpm typecheck`, `pnpm lint`, `pnpm test`.
-6. Commit the source changes unless `--no-commit` is set.
+6. Retry repair up to `--repair-attempts` times when fixing or validation fails.
+7. Commit the source changes unless `--no-commit` is set.
+8. Park exhausted findings as `uncertain` so the queue can continue overnight.
 
 Clawpatch's own `format` validation command is disabled in `.clawpatch/config.json`. Do not point it at `pnpm format`: that command writes across the whole repository and can create huge unrelated diffs during automated fixes. Use targeted formatting during implementation and rely on the runner's non-mutating validation gates for the batch.
 

--- a/scripts/clawpatch-fix-imported-github-issues.sh
+++ b/scripts/clawpatch-fix-imported-github-issues.sh
@@ -28,12 +28,24 @@ Flags:
 EOF
 }
 
+require_flag_value() {
+  local flag="$1"
+  local value="${2:-}"
+
+  if [[ -z "$value" ]]; then
+    echo "$flag requires a value" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --)
       shift
       ;;
     --max)
+      require_flag_value "$1" "${2:-}"
       MAX="${2:-}"
       shift 2
       ;;
@@ -50,6 +62,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --status)
+      require_flag_value "$1" "${2:-}"
       STATUS="${2:-}"
       shift 2
       ;;
@@ -58,6 +71,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --repair-attempts)
+      require_flag_value "$1" "${2:-}"
       REPAIR_ATTEMPTS="${2:-}"
       shift 2
       ;;
@@ -200,7 +214,7 @@ save_failure_artifacts() {
 
 restore_clean_worktree() {
   git reset --hard "$BASE_SHA" >/dev/null
-  git clean -fd >/dev/null
+  git clean -fd -e .clawpatch-nightly.lock >/dev/null
 }
 
 park_failed_finding() {

--- a/scripts/clawpatch-fix-imported-github-issues.sh
+++ b/scripts/clawpatch-fix-imported-github-issues.sh
@@ -5,6 +5,8 @@ MAX=1
 NO_COMMIT=0
 ALLOW_DIRTY=0
 STATUS="open"
+REPAIR_ATTEMPTS=3
+PARK_FAILED=0
 
 usage() {
   cat <<'EOF'
@@ -17,6 +19,11 @@ Flags:
   --no-commit      Leave successful fixes in the worktree
   --allow-dirty    Allow pre-existing source changes, only with --no-commit
   --status <s>     Queue status to process. Default: open
+  --repair-attempts <n>
+                   Repair retries after the initial fix attempt. Default: 3
+  --park-failed    After retries are exhausted, save artifacts, mark the
+                   finding uncertain, restore a clean worktree, commit the
+                   status update, and continue. Requires auto-commit mode.
   -h, --help       Show this help
 EOF
 }
@@ -50,6 +57,18 @@ while [[ $# -gt 0 ]]; do
       STATUS="${1#--status=}"
       shift
       ;;
+    --repair-attempts)
+      REPAIR_ATTEMPTS="${2:-}"
+      shift 2
+      ;;
+    --repair-attempts=*)
+      REPAIR_ATTEMPTS="${1#--repair-attempts=}"
+      shift
+      ;;
+    --park-failed)
+      PARK_FAILED=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -72,8 +91,19 @@ if [[ "$ALLOW_DIRTY" -eq 1 && "$NO_COMMIT" -eq 0 ]]; then
   exit 2
 fi
 
+if ! [[ "$REPAIR_ATTEMPTS" =~ ^[0-9]+$ ]]; then
+  echo "--repair-attempts must be a non-negative integer" >&2
+  exit 2
+fi
+
+if [[ "$PARK_FAILED" -eq 1 && "$NO_COMMIT" -eq 1 ]]; then
+  echo "--park-failed requires auto-commit mode so the worktree can stay clean before continuing" >&2
+  exit 2
+fi
+
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
+BASE_SHA=""
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -91,6 +121,121 @@ source_status() {
     ':!packages/web/.vite'
 }
 
+finding_title() {
+  local finding_id="$1"
+  clawpatch show --finding "$finding_id" --json | node -e "let s=''; process.stdin.on('data', d => s += d); process.stdin.on('end', () => { const parsed = JSON.parse(s); console.log(parsed.finding?.title ?? parsed.title ?? '$finding_id'); });"
+}
+
+issue_from_title() {
+  local title="$1"
+  local fallback="${2:-$title}"
+  local issue
+  issue="$(printf '%s\n' "$title" | sed -nE 's/^(gh#[0-9]+):.*/\1/p')"
+  if [[ -n "$issue" ]]; then
+    printf '%s\n' "$issue"
+  else
+    printf '%s\n' "$fallback"
+  fi
+}
+
+attempt_fix_once() {
+  local finding_id="$1"
+  local post_result
+  local post_outcome
+
+  clawpatch fix --finding "$finding_id" --json || return $?
+
+  post_result="$(clawpatch revalidate --finding "$finding_id" --json)" || return $?
+  post_outcome="$(printf '%s\n' "$post_result" | node -e "let s=''; process.stdin.on('data', d => s += d); process.stdin.on('end', () => console.log(JSON.parse(s).outcome ?? 'unknown'));")"
+  echo "post-fix revalidate: $post_outcome"
+
+  if [[ "$post_outcome" != "fixed" ]]; then
+    echo "finding did not revalidate as fixed: $finding_id => $post_outcome" >&2
+    return 6
+  fi
+
+  pnpm typecheck || return $?
+  pnpm lint || return $?
+  pnpm test || return $?
+}
+
+save_failure_artifacts() {
+  local finding_id="$1"
+  local title="$2"
+  local last_status="$3"
+  local exhausted_attempts="$4"
+  local stamp
+  local safe_id
+  local report_dir
+  local untracked_file
+
+  stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+  safe_id="$(printf '%s\n' "$finding_id" | sed -E 's/[^A-Za-z0-9_.-]+/-/g')"
+  report_dir=".clawpatch/reports/overnight-failures/${stamp}-${safe_id}"
+  mkdir -p "$report_dir"
+
+  {
+    echo "finding: $finding_id"
+    echo "title: $title"
+    echo "attempts: $exhausted_attempts"
+    echo "last_exit: $last_status"
+    echo "created_at: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  } >"$report_dir/summary.txt"
+
+  git status --short >"$report_dir/status.txt"
+
+  untracked_file="$report_dir/untracked-files.txt"
+  git ls-files --others --exclude-standard >"$untracked_file"
+  if [[ -s "$untracked_file" ]]; then
+    while IFS= read -r path; do
+      [[ -n "$path" ]] || continue
+      git add -N -- "$path" >/dev/null 2>&1 || true
+    done <"$untracked_file"
+  fi
+
+  git diff HEAD --binary >"$report_dir/diff.patch" || true
+  git diff --cached --binary >"$report_dir/staged.diff.patch" || true
+  printf '%s\n' "$report_dir"
+}
+
+restore_clean_worktree() {
+  git reset --hard "$BASE_SHA" >/dev/null
+  git clean -fd >/dev/null
+}
+
+park_failed_finding() {
+  local finding_id="$1"
+  local title="$2"
+  local last_status="$3"
+  local exhausted_attempts="$4"
+  local report_dir
+  local issue
+  local note
+
+  report_dir="$(save_failure_artifacts "$finding_id" "$title" "$last_status" "$exhausted_attempts")"
+  echo "parking failed finding after $exhausted_attempts attempt(s): $finding_id"
+  echo "failure artifacts: $report_dir"
+
+  restore_clean_worktree
+
+  note="Parked by overnight runner after $exhausted_attempts failed fix attempt(s), last exit $last_status. Local artifacts: $report_dir"
+  clawpatch triage --finding "$finding_id" --status uncertain --note "$note"
+
+  git add .clawpatch/findings
+  if git diff --cached --quiet; then
+    echo "no Clawpatch status changes staged after parking $finding_id"
+  else
+    issue="$(issue_from_title "$title" "$finding_id")"
+    git commit -m "Park ${issue}: failed Clawpatch repair" -m "Clawpatch finding: $finding_id" -m "$note"
+  fi
+
+  if [[ -n "$(source_status)" ]]; then
+    echo "worktree is still dirty after parking $finding_id; stopping" >&2
+    source_status >&2
+    exit 8
+  fi
+}
+
 require_command clawpatch
 require_command node
 require_command pnpm
@@ -104,6 +249,8 @@ fi
 completed=0
 
 while [[ "$completed" -lt "$MAX" ]]; do
+  BASE_SHA="$(git rev-parse HEAD)"
+
   if ! finding_id="$(node scripts/clawpatch-imported-queue.mjs next --plain --status "$STATUS")"; then
     echo "no imported GitHub issue findings with status '$STATUS'"
     break
@@ -125,27 +272,42 @@ while [[ "$completed" -lt "$MAX" ]]; do
     exit 6
   fi
 
-  clawpatch fix --finding "$finding_id" --json
+  title="$(finding_title "$finding_id")"
+  total_attempts=$((REPAIR_ATTEMPTS + 1))
+  fix_status=1
 
-  post_result="$(clawpatch revalidate --finding "$finding_id" --json)"
-  post_outcome="$(printf '%s\n' "$post_result" | node -e "let s=''; process.stdin.on('data', d => s += d); process.stdin.on('end', () => console.log(JSON.parse(s).outcome ?? 'unknown'));")"
-  echo "post-fix revalidate: $post_outcome"
+  for fix_attempt in $(seq 1 "$total_attempts"); do
+    if [[ "$fix_attempt" -eq 1 ]]; then
+      echo "fix attempt $fix_attempt/$total_attempts for $finding_id"
+    else
+      echo "repair attempt $((fix_attempt - 1))/$REPAIR_ATTEMPTS for $finding_id"
+    fi
 
-  if [[ "$post_outcome" != "fixed" ]]; then
-    echo "stopping because finding did not revalidate as fixed: $finding_id => $post_outcome" >&2
-    exit 6
+    set +e
+    attempt_fix_once "$finding_id"
+    fix_status=$?
+    set -e
+
+    if [[ "$fix_status" -eq 0 ]]; then
+      break
+    fi
+
+    echo "attempt $fix_attempt/$total_attempts failed for $finding_id with exit $fix_status" >&2
+  done
+
+  if [[ "$fix_status" -ne 0 ]]; then
+    if [[ "$PARK_FAILED" -eq 1 ]]; then
+      park_failed_finding "$finding_id" "$title" "$fix_status" "$total_attempts"
+      completed=$((completed + 1))
+      continue
+    fi
+
+    echo "stopping because all $total_attempts fix attempt(s) failed for $finding_id" >&2
+    exit "$fix_status"
   fi
 
-  pnpm typecheck
-  pnpm lint
-  pnpm test
-
   if [[ "$NO_COMMIT" -eq 0 ]]; then
-    title="$(clawpatch show --finding "$finding_id" --json | node -e "let s=''; process.stdin.on('data', d => s += d); process.stdin.on('end', () => { const parsed = JSON.parse(s); console.log(parsed.finding?.title ?? parsed.title ?? '$finding_id'); });")"
-    issue="$(printf '%s\n' "$title" | sed -nE 's/^(gh#[0-9]+):.*/\1/p')"
-    if [[ -z "$issue" ]]; then
-      issue="$finding_id"
-    fi
+    issue="$(issue_from_title "$title" "$finding_id")"
 
     git add -A -- \
       ':!/.agent' \

--- a/scripts/clawpatch-overnight-loop.sh
+++ b/scripts/clawpatch-overnight-loop.sh
@@ -6,6 +6,7 @@ RUNS=0
 MAX_PER_RUN=1
 LOG_FILE="logs/clawpatch-overnight.log"
 BACKGROUND=0
+REPAIR_ATTEMPTS=3
 
 usage() {
   cat <<'EOF'
@@ -17,6 +18,8 @@ Flags:
   --interval-seconds <n>  Seconds between attempts. Default: 1800
   --runs <n>              Number of attempts before stopping. Default: 0 (unlimited)
   --max-per-run <n>       Findings per attempt. Default: 1
+  --repair-attempts <n>   Repair retries after the initial fix attempt.
+                          Default: 3
   --log <path>            Log file. Default: logs/clawpatch-overnight.log
   --background            Start with nohup in the background and print the PID
   -h, --help              Show this help
@@ -50,6 +53,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --max-per-run=*)
       MAX_PER_RUN="${1#--max-per-run=}"
+      shift
+      ;;
+    --repair-attempts)
+      REPAIR_ATTEMPTS="${2:-}"
+      shift 2
+      ;;
+    --repair-attempts=*)
+      REPAIR_ATTEMPTS="${1#--repair-attempts=}"
       shift
       ;;
     --log)
@@ -91,6 +102,11 @@ if ! [[ "$MAX_PER_RUN" =~ ^[0-9]+$ ]] || [[ "$MAX_PER_RUN" -lt 1 ]]; then
   exit 2
 fi
 
+if ! [[ "$REPAIR_ATTEMPTS" =~ ^[0-9]+$ ]]; then
+  echo "--repair-attempts must be a non-negative integer" >&2
+  exit 2
+fi
+
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -100,6 +116,7 @@ if [[ "$BACKGROUND" -eq 1 ]]; then
     --interval-seconds "$INTERVAL_SECONDS" \
     --runs "$RUNS" \
     --max-per-run "$MAX_PER_RUN" \
+    --repair-attempts "$REPAIR_ATTEMPTS" \
     --log "$LOG_FILE" \
     >>"$LOG_FILE" 2>&1 &
   echo "$!"
@@ -120,7 +137,7 @@ while [[ "$RUNS" -eq 0 || "$attempt" -lt "$RUNS" ]]; do
   {
     echo "=== $(date -u '+%Y-%m-%dT%H:%M:%SZ') attempt=$attempt ==="
     pnpm clawpatch:queue-gh -- next --plain || true
-    pnpm clawpatch:fix-gh -- --max "$MAX_PER_RUN"
+    pnpm clawpatch:fix-gh -- --max "$MAX_PER_RUN" --repair-attempts "$REPAIR_ATTEMPTS" --park-failed
   } >>"$LOG_FILE" 2>&1
   status=$?
   set -e

--- a/scripts/clawpatch-overnight-loop.sh
+++ b/scripts/clawpatch-overnight-loop.sh
@@ -26,12 +26,24 @@ Flags:
 EOF
 }
 
+require_flag_value() {
+  local flag="$1"
+  local value="${2:-}"
+
+  if [[ -z "$value" ]]; then
+    echo "$flag requires a value" >&2
+    usage >&2
+    exit 2
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --)
       shift
       ;;
     --interval-seconds)
+      require_flag_value "$1" "${2:-}"
       INTERVAL_SECONDS="${2:-}"
       shift 2
       ;;
@@ -40,6 +52,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --runs)
+      require_flag_value "$1" "${2:-}"
       RUNS="${2:-}"
       shift 2
       ;;
@@ -48,6 +61,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --max-per-run)
+      require_flag_value "$1" "${2:-}"
       MAX_PER_RUN="${2:-}"
       shift 2
       ;;
@@ -56,6 +70,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --repair-attempts)
+      require_flag_value "$1" "${2:-}"
       REPAIR_ATTEMPTS="${2:-}"
       shift 2
       ;;
@@ -64,6 +79,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --log)
+      require_flag_value "$1" "${2:-}"
       LOG_FILE="${2:-}"
       shift 2
       ;;


### PR DESCRIPTION
## Summary
- default imported GitHub issue fixes to three repair attempts
- park unresolved findings instead of blocking the overnight loop forever
- pass the repair/parking behavior through the overnight wrapper and skill docs

## Why
The overnight loop previously stopped after a single failed patch/test path, which left unattended runs idle after one model mistake. This makes the loop more useful for unattended work while still preserving failures for later review.

## Validation
- bash -n scripts/clawpatch-fix-imported-github-issues.sh scripts/clawpatch-overnight-loop.sh