### PR TITLE
[codex] Fix CSV import templates and validation feedback

### DIFF
--- a/.clawpatch/features/feat_gh-95_0bb007b559.json
+++ b/.clawpatch/features/feat_gh-95_0bb007b559.json
@@ -49,7 +49,7 @@
     "filesystem",
     "concurrency"
   ],
-  "status": "needs-fix",
+  "status": "fixed",
   "lock": null,
   "findingIds": [
     "fnd_sig-gh-95-e76b263713_bd318f63d5"
@@ -66,5 +66,5 @@
     }
   ],
   "createdAt": "2026-05-20T12:08:14.295Z",
-  "updatedAt": "2026-05-20T12:08:14.295Z"
+  "updatedAt": "2026-05-20T12:15:49.052Z"
 }

--- a/.clawpatch/features/feat_gh-95_0bb007b559.json
+++ b/.clawpatch/features/feat_gh-95_0bb007b559.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-95_0bb007b559",
+  "title": "gh#95: Import Posts template download links do not provide CSV templates",
+  "summary": "Imported from GitHub issue gh#95 in BACKLOG.md section \"P0 — Production blockers\".",
+  "kind": "ui-flow",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/web/src/hooks/use-csv-templates.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/web",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/web/src/hooks/use-csv-templates.ts",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/web",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#95"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#95",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/95",
+    "backlog-order:0001",
+    "backlog-section:p0-production-blockers",
+    "label:bug"
+  ],
+  "trustBoundaries": [
+    "filesystem",
+    "concurrency"
+  ],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-95-e76b263713_bd318f63d5"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T120814-2f872c",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#95",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-20T12:08:14.295Z"
+    }
+  ],
+  "createdAt": "2026-05-20T12:08:14.295Z",
+  "updatedAt": "2026-05-20T12:08:14.295Z"
+}

--- a/.clawpatch/features/feat_gh-96_a79f3c8574.json
+++ b/.clawpatch/features/feat_gh-96_a79f3c8574.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-96_a79f3c8574",
+  "title": "gh#96: CSV import failures return 500 and hidden toast instead of visible validation errors",
+  "summary": "Imported from GitHub issue gh#96 in BACKLOG.md section \"P0 — Production blockers\".",
+  "kind": "route",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/web/src/pages/posts/BulkImportPage.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/web/src/hooks/use-bulk-ops.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/api/src/routes/bulk-import.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/web/src/pages/posts/BulkImportPage.tsx",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/web/src/hooks/use-bulk-ops.ts",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/api/src/routes/bulk-import.ts",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/api/src/services/bulk-import.service.ts",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/shared/src/schemas/bulk-import.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#96"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#96",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/96",
+    "backlog-order:0002",
+    "backlog-section:p0-production-blockers",
+    "label:bug"
+  ],
+  "trustBoundaries": [
+    "network",
+    "filesystem",
+    "database",
+    "concurrency",
+    "external-api"
+  ],
+  "status": "needs-fix",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-96-8858823d13_f140d51e3c"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260520T120814-2f872c",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#96",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-20T12:08:14.295Z"
+    }
+  ],
+  "createdAt": "2026-05-20T12:08:14.295Z",
+  "updatedAt": "2026-05-20T12:08:14.295Z"
+}

--- a/.clawpatch/features/feat_gh-96_a79f3c8574.json
+++ b/.clawpatch/features/feat_gh-96_a79f3c8574.json
@@ -70,7 +70,7 @@
     "concurrency",
     "external-api"
   ],
-  "status": "needs-fix",
+  "status": "fixed",
   "lock": null,
   "findingIds": [
     "fnd_sig-gh-96-8858823d13_f140d51e3c"
@@ -87,5 +87,5 @@
     }
   ],
   "createdAt": "2026-05-20T12:08:14.295Z",
-  "updatedAt": "2026-05-20T12:08:14.295Z"
+  "updatedAt": "2026-05-20T12:31:03.706Z"
 }

--- a/.clawpatch/findings/fnd_sig-gh-95-e76b263713_bd318f63d5.json
+++ b/.clawpatch/findings/fnd_sig-gh-95-e76b263713_bd318f63d5.json
@@ -29,11 +29,56 @@
   "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
   "suggestedRegressionTest": null,
   "minimumFixScope": "packages/web/src/hooks/use-csv-templates.ts, packages/web",
-  "status": "open",
-  "history": [],
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260520T120838-cd0acb",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence path still exists. packages/web/src/hooks/use-csv-templates.ts still returns /templates/scheduled-posts.csv and /templates/queue-posts.csv, and packages/web/src/pages/posts/BulkImportPage.tsx still uses those functions for the Download Scheduled Template and Download Queue Template anchors. Current repository checks found no matching scheduled-posts.csv or queue-posts.csv under packages/web, including the Vite-served public/templates path and existing dist/templates path. A web test run could not start because the read-only sandbox prevented Vitest/Vite from writing its temporary config file, so there is no passing regression evidence that this is fixed. The current code and static asset checks indicate the download links still point to missing CSV assets.",
+      "commands": [
+        "sed -n '1,80p' packages/web/src/hooks/use-csv-templates.ts",
+        "sed -n '1,180p' packages/web/src/pages/posts/BulkImportPage.tsx",
+        "rg -n \"scheduled-posts|queue-posts|Download Scheduled Template|Download Queue Template|useCsvTemplates|use-csv-templates|Need a template\" packages/web",
+        "find packages/web -type f \\( -name 'scheduled-posts.csv' -o -name 'queue-posts.csv' \\) -print",
+        "node -e \"const fs=require('fs'); for (const p of ['packages/web/public/templates/scheduled-posts.csv','packages/web/public/templates/queue-posts.csv','packages/web/dist/templates/scheduled-posts.csv','packages/web/dist/templates/queue-posts.csv']) console.log(p, fs.existsSync(p) ? 'exists' : 'missing')\"",
+        "nl -ba packages/web/src/hooks/use-csv-templates.ts",
+        "nl -ba packages/web/src/pages/posts/BulkImportPage.tsx | sed -n '112,126p'",
+        "pnpm --filter @sms/web test -- --run"
+      ],
+      "createdAt": "2026-05-20T12:10:14.448Z"
+    },
+    {
+      "runId": "20260520T121441-5e3ba5",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence path still exists and still returns /templates/scheduled-posts.csv and /templates/queue-posts.csv. BulkImportPage still uses those URLs for the Download Scheduled Template and Download Queue Template links. Unlike the prior validation, matching CSV assets now exist at packages/web/public/templates/scheduled-posts.csv and packages/web/public/templates/queue-posts.csv, with headers plus one sample row each; matching built copies also exist under packages/web/dist/templates. A focused regression test now exists at packages/web/src/hooks/__tests__/use-csv-templates.test.ts and asserts the URLs resolve to raw CSV content with the expected headers/sample rows. I could not execute Vitest in this read-only sandbox because Vite/Vitest tried to write temporary config files under packages/web/node_modules/.vite-temp, and the runner workaround failed because the config uses __dirname. Static code and asset checks indicate the missing-template issue is fixed in the current worktree.",
+      "commands": [
+        "sed -n '1,120p' packages/web/src/hooks/use-csv-templates.ts",
+        "rg -n \"scheduled-posts|queue-posts|Download Scheduled Template|Download Queue Template|useCsvTemplates|use-csv-templates|Need a template\" packages/web",
+        "find packages/web -type f \\( -name 'scheduled-posts.csv' -o -name 'queue-posts.csv' \\) -print",
+        "rg -n \"csv template|templates/|scheduled-posts.csv|queue-posts.csv|Download.*Template\" packages/web/src packages/web/tests packages/web/public package.json packages/web/package.json",
+        "sed -n '1,220p' packages/web/src/hooks/__tests__/use-csv-templates.test.ts",
+        "nl -ba packages/web/src/pages/posts/BulkImportPage.tsx | sed -n '108,128p'",
+        "nl -ba packages/web/public/templates/scheduled-posts.csv",
+        "nl -ba packages/web/public/templates/queue-posts.csv",
+        "cat packages/web/package.json",
+        "pnpm --filter @sms/web test -- --run packages/web/src/hooks/__tests__/use-csv-templates.test.ts",
+        "pnpm --dir packages/web exec vitest --run src/hooks/__tests__/use-csv-templates.test.ts --configLoader runner",
+        "sed -n '1,120p' packages/web/vitest.config.ts",
+        "node -e \"const fs=require('fs'); const paths=['packages/web/public/templates/scheduled-posts.csv','packages/web/public/templates/queue-posts.csv','packages/web/dist/templates/scheduled-posts.csv','packages/web/dist/templates/queue-posts.csv']; for (const p of paths) { const s=fs.existsSync(p)?fs.readFileSync(p,'utf8').trim().split(/\\r?\\n/):null; console.log(p, s ? JSON.stringify({exists:true, rows:s.length, header:s[0], sample:s[1]}) : JSON.stringify({exists:false})); }\"",
+        "git status --short"
+      ],
+      "createdAt": "2026-05-20T12:15:49.001Z"
+    }
+  ],
   "signature": "sig_gh-95_e76b263713",
-  "linkedPatchAttemptIds": [],
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-95-e76b263713-bd318f6_8d2c85cf96"
+  ],
   "createdByRunId": "20260520T120814-2f872c",
   "createdAt": "2026-05-20T12:08:14.295Z",
-  "updatedAt": "2026-05-20T12:08:14.295Z"
+  "updatedAt": "2026-05-20T12:15:49.001Z"
 }

--- a/.clawpatch/findings/fnd_sig-gh-95-e76b263713_bd318f63d5.json
+++ b/.clawpatch/findings/fnd_sig-gh-95-e76b263713_bd318f63d5.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-95-e76b263713_bd318f63d5",
+  "featureId": "feat_gh-95_0bb007b559",
+  "title": "gh#95: Import Posts template download links do not provide CSV templates",
+  "category": "bug",
+  "severity": "critical",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "packages/web/src/hooks/use-csv-templates.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/web",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/95.\nBacklog section: P0 — Production blockers.\n\n## Problem\nUsers cannot download the CSV template from the Import Posts page, which leaves them without a reliable way to compare their CSV document against the expected import format before uploading.\n\n## User impact\nWhen importing posts into a queue, the user sees `Download Scheduled Template` and `Download Queue Template`, but the template download does not work. From the user perspective, there is no way to confirm whether a file such as `queue_cmw_promotions.csv` has the right columns and formatting before attempting the import.\n\n## Reproduction\n1. Open the app and go to **Import Posts**.\n2. Select **Queue** as the import target.\n3. Select a connected profile, e.g. `@clicksmortarweb`.\n4. Select an existing queue, e.g. `CMW Promotions`.\n5. Scroll to **Need a template?**.\n6. Click **Download Queue Template** or **Download Scheduled Template**.\n\n## Expected behavior\nThe app downloads a CSV template matching the selected import target:\n- Scheduled-post import template should show the columns required for rows with explicit publish times.\n- Queue import template should show the columns required for rows appended to an existing queue.\n\nThe downloaded file should be usable as a source of truth for users to compare their own CSV before importing.\n\n## Actual behavior\nThe template download does not produce a usable CSV template. The Import Posts page exposes links, but the CSV files appear to be missing or unreachable.\n\n## Implementation notes\nThe web page currently links to:\n\n- `/templates/scheduled-posts.csv`\n- `/templates/queue-posts.csv`\n\nvia `packages/web/src/hooks/use-csv-templates.ts`, but there are no matching template CSV files visible under `packages/web`.\n\n## Acceptance criteria\n- `Download Scheduled Template` downloads a valid scheduled-post CSV template.\n- `Download Queue Template` downloads a valid queue CSV template.\n- The templates include headers and at least one example row or clear placeholder row for the expected import schema.\n- Missing template assets are covered by a regression test or static asset check.\n- The user can download the template without first uploading a CSV.\n\n## References\nDepends on: nothing",
+  "reproduction": "Users cannot download the CSV template from the Import Posts page, which leaves them without a reliable way to compare their CSV document against the expected import format before uploading.",
+  "recommendation": "Implement the fix described by GitHub issue gh#95 and satisfy its acceptance criteria.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/web/src/hooks/use-csv-templates.ts, packages/web",
+  "status": "open",
+  "history": [],
+  "signature": "sig_gh-95_e76b263713",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260520T120814-2f872c",
+  "createdAt": "2026-05-20T12:08:14.295Z",
+  "updatedAt": "2026-05-20T12:08:14.295Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-96-8858823d13_f140d51e3c.json
+++ b/.clawpatch/findings/fnd_sig-gh-96-8858823d13_f140d51e3c.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-96-8858823d13_f140d51e3c",
+  "featureId": "feat_gh-96_a79f3c8574",
+  "title": "gh#96: CSV import failures return 500 and hidden toast instead of visible validation errors",
+  "category": "bug",
+  "severity": "critical",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "packages/web/src/pages/posts/BulkImportPage.tsx",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/web/src/hooks/use-bulk-ops.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/api/src/routes/bulk-import.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/api/src/services/bulk-import.service.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/shared/src/schemas/bulk-import.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/96.\nBacklog section: P0 — Production blockers.\n\n## Problem\nWhen a user uploads a CSV that has formatting/schema issues on the Import Posts page, the import can fail with a generic `Internal server error`. The error is shown only in a bottom-left toast that can be clipped/off-screen, so the user cannot see or act on the failure.\n\nThis is especially painful when combined with #95, because users cannot download a known-good template and then get no usable feedback when their attempted CSV does not match the importer's expectations.\n\n## User impact\nFrom the user perspective, uploading `queue_cmw_promotions.csv` appears to fail without a visible explanation. They do not know whether the file is missing required columns, has invalid values, targets the wrong import mode, or hit a server bug.\n\n## Reproduction\n1. Open **Import Posts**.\n2. Select **Queue** as the target.\n3. Select a connected profile, e.g. `@clicksmortarweb`.\n4. Select an existing queue, e.g. `CMW Promotions`.\n5. Upload a CSV with issues, e.g. `queue_cmw_promotions.csv`.\n6. Click **Import**.\n\n## Expected behavior\n- Invalid CSV content should return a 4xx validation response, not a generic 500.\n- The response should explain what the user can fix, ideally with row/column-level details when possible.\n- The Import Posts page should render the failure inline near the file/import controls, not only as a toast.\n- The user should be able to see the error without scrolling to a clipped toast area.\n\n## Actual behavior\n- The import fails with `Internal server error`.\n- The message appears in a bottom-left toast that is partially off-screen/clipped in the viewport.\n- The Import Posts page does not show an inline actionable error, so it looks like the import is broken with no useful guidance.\n\n## Implementation notes\nLikely areas to inspect:\n\n- Frontend page: `packages/web/src/pages/posts/BulkImportPage.tsx`\n- Frontend mutation/error path: `packages/web/src/hooks/use-bulk-ops.ts` (`useBulkImport` currently uses `showBulkOperationError`, which announces and calls `toast.error`)\n- API route: `packages/api/src/routes/bulk-import.ts`\n- CSV parsing/validation: `packages/api/src/services/bulk-import.service.ts` and `packages/shared/src/schemas/bulk-import.ts`\n\nThe page already has an inline alert pattern for Twitter budget errors. CSV validation/import startup errors should get a similarly visible inline surface.\n\n## Acceptance criteria\n- Malformed or schema-invalid CSV uploads return a non-500 response with an actionable error body.\n- Import Posts displays CSV import errors inline near the file/import section.\n- Inline error copy includes enough detail for the user to correct the CSV, such as missing headers, invalid row count, invalid dates, or row/column details when available.\n- The toast-only path is not the sole visible error surface for `useBulkImport` failures.\n- Regression coverage verifies that a rejected CSV import response is rendered inline on the Import Posts page.\n- API coverage verifies invalid CSV input is handled as validation/user input failure rather than an uncaught 500.\n\n## References\nRelated: #95\nDepends on: nothing",
+  "reproduction": "When a user uploads a CSV that has formatting/schema issues on the Import Posts page, the import can fail with a generic `Internal server error`. The error is shown only in a bottom-left toast that can be clipped/off-screen, so the user cannot see or act on the failure.\n\nThis is especially painful when combined with #95, because users cannot download a known-good template and then get no usable feedback when their attempted CSV does not match the importer's expectations.",
+  "recommendation": "Implement the fix described by GitHub issue gh#96 and satisfy its acceptance criteria.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/web/src/pages/posts/BulkImportPage.tsx, packages/web/src/hooks/use-bulk-ops.ts, packages/api/src/routes/bulk-import.ts, packages/api/src/services/bulk-import.service.ts, packages/shared/src/schemas/bulk-import.ts",
+  "status": "open",
+  "history": [],
+  "signature": "sig_gh-96_8858823d13",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260520T120814-2f872c",
+  "createdAt": "2026-05-20T12:08:14.295Z",
+  "updatedAt": "2026-05-20T12:08:14.295Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-96-8858823d13_f140d51e3c.json
+++ b/.clawpatch/findings/fnd_sig-gh-96-8858823d13_f140d51e3c.json
@@ -50,11 +50,71 @@
   "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
   "suggestedRegressionTest": null,
   "minimumFixScope": "packages/web/src/pages/posts/BulkImportPage.tsx, packages/web/src/hooks/use-bulk-ops.ts, packages/api/src/routes/bulk-import.ts, packages/api/src/services/bulk-import.service.ts, packages/shared/src/schemas/bulk-import.ts",
-  "status": "open",
-  "history": [],
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260520T121702-0e3def",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence files still exist. Current code still does not satisfy the finding: BulkImportPage only stores/renders an inline Alert for twitter_budget_exceeded; other import failures fall through to toast.error at packages/web/src/pages/posts/BulkImportPage.tsx:42-53, while useBulkImport also has onError: showBulkOperationError, which announces and toast.error's the same failure at packages/web/src/hooks/use-bulk-ops.ts:30-33 and :89-91. On the API side, parseCsvBuffer collects schema validation failures into parsedCsv.errors at packages/api/src/services/bulk-import.service.ts:40-50, and the route still inserts/enqueues the bulk operation and returns 202 with errorCount at packages/api/src/routes/bulk-import.ts:152-205 instead of returning a 4xx actionable validation body for invalid CSV rows. The route test file is still only it.todo coverage for bulk import behavior, so the acceptance criteria regression coverage is absent. Existing focused tests could not be executed in this read-only environment because Vitest attempted to write packages/api/node_modules/.vite-temp and failed with EPERM.",
+      "commands": [
+        "rg -n \"bulk import|BulkImport|useBulkImport|showBulkOperationError|csv|CSV|validation|toast|inline|Alert\" packages/web/src/pages/posts/BulkImportPage.tsx packages/web/src/hooks/use-bulk-ops.ts packages/api/src/routes/bulk-import.ts packages/api/src/services/bulk-import.service.ts packages/shared/src/schemas/bulk-import.ts",
+        "rg --files | rg \"bulk-import|BulkImport|use-bulk-ops\"",
+        "sed -n '1,260p' packages/api/src/routes/bulk-import.ts",
+        "sed -n '1,220p' packages/api/src/services/bulk-import.service.ts",
+        "sed -n '1,260p' packages/web/src/pages/posts/BulkImportPage.tsx",
+        "sed -n '1,140p' packages/web/src/hooks/use-bulk-ops.ts",
+        "sed -n '1,260p' packages/api/src/__tests__/routes/bulk-import.test.ts",
+        "sed -n '1,240p' packages/api/src/__tests__/services/bulk-import.test.ts",
+        "rg -n \"BulkImportPage|Import Posts|twitter_budget_exceeded|CSV|csv|bulk import|validation failed|queue_name_mismatch|errorCount\" packages/web/src packages/api/src packages/shared/src",
+        "pnpm --filter @sms/api test -- --run packages/api/src/__tests__/services/bulk-import.test.ts",
+        "nl -ba packages/web/src/pages/posts/BulkImportPage.tsx | sed -n '18,155p'",
+        "nl -ba packages/web/src/hooks/use-bulk-ops.ts | sed -n '25,100p'",
+        "nl -ba packages/api/src/routes/bulk-import.ts | sed -n '38,225p'",
+        "nl -ba packages/api/src/services/bulk-import.service.ts | sed -n '20,55p'",
+        "nl -ba packages/api/src/__tests__/routes/bulk-import.test.ts | sed -n '1,40p' && nl -ba packages/api/src/__tests__/services/bulk-import.test.ts | sed -n '1,60p'"
+      ],
+      "createdAt": "2026-05-20T12:18:17.526Z"
+    },
+    {
+      "runId": "20260520T122904-ac9354",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence paths still exist. Current API code now rejects invalid parsed CSV before creating/enqueuing a bulk operation: packages/api/src/routes/bulk-import.ts builds a csv_validation_failed body with row details and rejectInvalidCsv returns HTTP 400 for row errors or empty CSV; CsvParseError is mapped to HTTP 400 with code csv_parse_failed. The frontend now formats csv_validation_failed/csv_parse_failed responses and renders an inline destructive Alert beside the file/import controls in packages/web/src/pages/posts/BulkImportPage.tsx, so the toast path in useBulkImport is no longer the only visible error surface. Regression coverage exists in packages/web/src/pages/posts/__tests__/BulkImportPage.test.tsx for inline CSV details and packages/api/src/__tests__/routes/bulk-import.test.ts plus packages/api/src/__tests__/services/bulk-import.test.ts for validation details/row errors. API typecheck passed and web typecheck passed when run without build-mode tsbuildinfo writes. Vitest execution could not complete in this read-only sandbox because Vite/Vitest attempted to create temp/cache directories and failed with EPERM, but the current code satisfies the finding acceptance criteria.",
+      "commands": [
+        "rg --files | rg \"(BulkImportPage|use-bulk-ops|bulk-import|bulk-import\\.test)\"",
+        "rg -n \"useBulkImport|showBulkOperationError|toast\\.error|setInlineError|inlineError|twitter_budget_exceeded|Alert|validation|CSV|csv|errorCount|parsedCsv\\.errors|BulkImport\" packages/web/src/pages/posts/BulkImportPage.tsx packages/web/src/hooks/use-bulk-ops.ts packages/api/src/routes/bulk-import.ts packages/api/src/services/bulk-import.service.ts packages/shared/src/schemas/bulk-import.ts packages/api/src/__tests__ packages/web/src --glob '!**/node_modules/**'",
+        "git status --short",
+        "nl -ba packages/web/src/pages/posts/BulkImportPage.tsx | sed -n '1,240p'",
+        "nl -ba packages/web/src/hooks/use-bulk-ops.ts | sed -n '1,120p'",
+        "nl -ba packages/api/src/routes/bulk-import.ts | sed -n '1,310p'",
+        "nl -ba packages/api/src/services/bulk-import.service.ts | sed -n '1,180p'",
+        "nl -ba packages/shared/src/schemas/bulk-import.ts | sed -n '1,180p'",
+        "nl -ba packages/web/src/pages/posts/__tests__/BulkImportPage.test.tsx | sed -n '1,180p'",
+        "nl -ba packages/api/src/__tests__/routes/bulk-import.test.ts | sed -n '1,260p'",
+        "nl -ba packages/api/src/__tests__/services/bulk-import.test.ts | sed -n '1,160p'",
+        "rg -n \"csv_validation_failed|CSV import needs changes|renders rejected CSV|invalid CSV|buildCsvValidationFailure|CSV parse failed|errorCount\" packages/api/src/__tests__ packages/web/src/pages/posts/__tests__ packages/web/src --glob '!**/node_modules/**'",
+        "node -p \"require('./packages/api/package.json').dependencies?.express || require('./package.json').dependencies?.express\"",
+        "nl -ba packages/web/src/lib/api-client.ts | sed -n '1,220p'",
+        "pnpm --filter @sms/api test -- --run packages/api/src/__tests__/routes/bulk-import.test.ts packages/api/src/__tests__/services/bulk-import.test.ts",
+        "pnpm --filter @sms/web test -- --run packages/web/src/pages/posts/__tests__/BulkImportPage.test.tsx",
+        "pnpm --filter @sms/api typecheck",
+        "pnpm --filter @sms/web typecheck",
+        "pnpm --filter @sms/web exec tsc --noEmit --incremental false -p tsconfig.app.json",
+        "pnpm --filter @sms/web exec tsc --noEmit --incremental false -p tsconfig.node.json",
+        "pnpm --filter @sms/api exec vitest run src/__tests__/routes/bulk-import.test.ts src/__tests__/services/bulk-import.test.ts --configLoader runner",
+        "pnpm --filter @sms/web exec vitest run src/pages/posts/__tests__/BulkImportPage.test.tsx --configLoader runner"
+      ],
+      "createdAt": "2026-05-20T12:31:03.658Z"
+    }
+  ],
   "signature": "sig_gh-96_8858823d13",
-  "linkedPatchAttemptIds": [],
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-96-8858823d13-f140d51_09cc799598"
+  ],
   "createdByRunId": "20260520T120814-2f872c",
   "createdAt": "2026-05-20T12:08:14.295Z",
-  "updatedAt": "2026-05-20T12:08:14.295Z"
+  "updatedAt": "2026-05-20T12:31:03.658Z"
 }

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -20,6 +20,8 @@ Top-of-queue. An automated workflow should pull from here first.
 
 ### P0 — Production blockers
 
+- [ ] **gh#95** — Import Posts template download links do not provide CSV templates
+- [ ] **gh#96** — CSV import failures return 500 and hidden toast instead of visible validation errors
 - [x] **gh#54** — Profile edit returns 500 (`Couldn't save profile: Internal server error`) *(merged in #77 / 93510a0)*
 - [x] **gh#53** — Profile delete returns 500 (`Couldn't delete profile: Internal server error`) *(merged in cbde4a0)*
 - [x] **gh#49** — Prod docker-compose.yml doesn't pass OAuth/notification env vars to api+worker containers

--- a/packages/api/src/__tests__/routes/bulk-import.test.ts
+++ b/packages/api/src/__tests__/routes/bulk-import.test.ts
@@ -1,5 +1,5 @@
-// Wave 0 stub -- implementation lands in Plan 03. Replace it.todo with real assertions during the GREEN phase.
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { buildCsvValidationFailure } from '../../routes/bulk-import.js';
 
 describe('bulk import route', () => {
   it.todo('parses streaming CSV rows with csv-parse v6 and bom:true');
@@ -9,4 +9,24 @@ describe('bulk import route', () => {
   it.todo('rejects non-CSV MIME uploads before parsing');
   it.todo('requires an authenticated session and applies bulkOperationsLimiter');
   it.todo('enforces CSRF token on multipart upload');
+
+  it('builds a 400 body with row details for schema-invalid CSV rows', () => {
+    expect(
+      buildCsvValidationFailure({
+        rows: [],
+        errors: [
+          {
+            rowNumber: 2,
+            reason: 'scheduled_at: Invalid datetime',
+            row: { text: 'hello', scheduled_at: 'not-a-date' },
+          },
+        ],
+      }),
+    ).toEqual({
+      error: 'CSV validation failed',
+      code: 'csv_validation_failed',
+      errorCount: 1,
+      details: [{ rowNumber: 2, reason: 'scheduled_at: Invalid datetime' }],
+    });
+  });
 });

--- a/packages/api/src/__tests__/services/bulk-import.test.ts
+++ b/packages/api/src/__tests__/services/bulk-import.test.ts
@@ -22,6 +22,24 @@ describe('bulk CSV import service', () => {
     ]);
   });
 
+  it('collects row-level schema errors instead of throwing', async () => {
+    const csv = Buffer.from('text,scheduled_at\nhello,not-a-date\n', 'utf8');
+
+    const result = await parseCsvBuffer(csv, z.object({
+      text: z.string().min(1),
+      scheduled_at: z.string().datetime({ offset: true }),
+    }).strict());
+
+    expect(result.rows).toEqual([]);
+    expect(result.errors).toEqual([
+      {
+        rowNumber: 2,
+        reason: 'scheduled_at: Invalid datetime',
+        row: { text: 'hello', scheduled_at: 'not-a-date' },
+      },
+    ]);
+  });
+
   it('rejects non-UUID bulk operation ids for error reports', async () => {
     await expect(writeErrorReport('/tmp', '../escape', [
       { rowNumber: 2, reason: '=boom', row: { text: '=boom' } },

--- a/packages/api/src/routes/bulk-import.ts
+++ b/packages/api/src/routes/bulk-import.ts
@@ -10,7 +10,8 @@ import { requireAuth } from '../middleware/auth-guard.js';
 import { bulkOperationsLimiter } from '../middleware/rate-limiter.js';
 import { csvUpload } from '../middleware/csv-upload.js';
 import { checkBulkBudgetWithDb } from '../services/rate-limit.service.js';
-import { parseCsvBuffer, writeErrorReport } from '../services/bulk-import.service.js';
+import { CsvParseError, parseCsvBuffer, writeErrorReport } from '../services/bulk-import.service.js';
+import type { CsvRowError } from '../services/bulk-import.service.js';
 import type { BulkOpsQueueService } from '../services/bulk-ops-queue.service.js';
 
 interface BulkImportRouterDeps {
@@ -28,6 +29,45 @@ function parseIdempotencyKey(rawHeader: string | undefined): string | null {
   if (rawHeader === undefined) return randomUUID();
   const idempotencyKey = rawHeader.trim();
   return UUID_PATTERN.test(idempotencyKey) ? idempotencyKey : null;
+}
+
+function csvValidationDetails(errors: CsvRowError[]) {
+  return errors.slice(0, 10).map((error) => ({
+    rowNumber: error.rowNumber,
+    reason: error.reason,
+  }));
+}
+
+export function buildCsvValidationFailure(parsedCsv: { rows: unknown[]; errors: CsvRowError[] }) {
+  if (parsedCsv.errors.length > 0) {
+    return {
+      error: 'CSV validation failed',
+      code: 'csv_validation_failed',
+      errorCount: parsedCsv.errors.length,
+      details: csvValidationDetails(parsedCsv.errors),
+    };
+  }
+
+  if (parsedCsv.rows.length === 0) {
+    return {
+      error: 'CSV validation failed',
+      code: 'csv_validation_failed',
+      errorCount: 0,
+      details: [{ reason: 'CSV must include at least one data row.' }],
+    };
+  }
+
+  return null;
+}
+
+function rejectInvalidCsv(res: Response, parsedCsv: { rows: unknown[]; errors: CsvRowError[] }): boolean {
+  const failure = buildCsvValidationFailure(parsedCsv);
+  if (failure) {
+    res.status(400).json(failure);
+    return true;
+  }
+
+  return false;
 }
 
 export function createBulkImportRouter({ db, bulkOpsQueueService }: BulkImportRouterDeps): Router {
@@ -87,6 +127,9 @@ export function createBulkImportRouter({ db, bulkOpsQueueService }: BulkImportRo
       const parsedCsv = target === 'scheduled'
         ? await parseCsvBuffer(req.file.buffer, csvScheduledRowSchema)
         : await parseCsvBuffer(req.file.buffer, csvQueueRowSchema);
+      if (rejectInvalidCsv(res, parsedCsv)) {
+        return;
+      }
 
       let queueName: string | null = null;
       if (target === 'queue') {
@@ -209,6 +252,14 @@ export function createBulkImportRouter({ db, bulkOpsQueueService }: BulkImportRo
   router.use((err: unknown, _req: Request, res: Response, next: NextFunction) => {
     if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
       res.status(413).json({ error: 'CSV file exceeds 10 MB limit' });
+      return;
+    }
+    if (err instanceof CsvParseError) {
+      res.status(400).json({
+        error: 'CSV parse failed',
+        code: err.code,
+        details: [{ reason: err.message }],
+      });
       return;
     }
     if (err instanceof Error && err.message.includes('row limit')) {

--- a/packages/api/src/services/bulk-import.service.ts
+++ b/packages/api/src/services/bulk-import.service.ts
@@ -17,6 +17,15 @@ export interface ParsedCsvRows<T> {
   errors: CsvRowError[];
 }
 
+export class CsvParseError extends Error {
+  code = 'csv_parse_failed';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'CsvParseError';
+  }
+}
+
 export async function parseCsvBuffer<TSchema extends ZodType<Record<string, unknown>>>(
   buffer: Buffer,
   schema: TSchema,
@@ -32,22 +41,30 @@ export async function parseCsvBuffer<TSchema extends ZodType<Record<string, unkn
   });
 
   let rowNumber = 1;
-  for await (const rawRow of parser as AsyncIterable<Record<string, unknown>>) {
-    rowNumber += 1;
-    if (rows.length + errors.length >= maxRows) {
-      throw new Error(`CSV row limit exceeded: maximum ${maxRows} rows`);
-    }
-    const parsed = schema.safeParse(rawRow);
-    if (parsed.success) {
-      rows.push({ ...parsed.data, rowNumber });
-      continue;
-    }
+  try {
+    for await (const rawRow of parser as AsyncIterable<Record<string, unknown>>) {
+      rowNumber += 1;
+      if (rows.length + errors.length >= maxRows) {
+        throw new Error(`CSV row limit exceeded: maximum ${maxRows} rows`);
+      }
+      const parsed = schema.safeParse(rawRow);
+      if (parsed.success) {
+        rows.push({ ...parsed.data, rowNumber });
+        continue;
+      }
 
-    errors.push({
-      rowNumber,
-      reason: parsed.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; '),
-      row: rawRow,
-    });
+      errors.push({
+        rowNumber,
+        reason: parsed.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; '),
+        row: rawRow,
+      });
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('CSV row limit exceeded')) {
+      throw error;
+    }
+    const reason = error instanceof Error ? error.message : 'Unable to read CSV file';
+    throw new CsvParseError(`CSV parse failed: ${reason}`);
   }
 
   return { rows, errors };

--- a/packages/web/public/templates/queue-posts.csv
+++ b/packages/web/public/templates/queue-posts.csv
@@ -1,0 +1,2 @@
+text,queue_name,position,tags,spinnable,auto_destruct_after,notes
+Evergreen queue post,Example Queue,1,evergreen;tips,false,7d,Example queued post

--- a/packages/web/public/templates/queue-posts.csv
+++ b/packages/web/public/templates/queue-posts.csv
@@ -1,2 +1,2 @@
-text,queue_name,position,tags,spinnable,auto_destruct_after,notes
-Evergreen queue post,Example Queue,1,evergreen;tips,false,7d,Example queued post
+text,queue_name,tags,spinnable,auto_destruct_after,notes
+Evergreen queue post,Example Queue,evergreen;tips,false,7d,Example queued post

--- a/packages/web/public/templates/scheduled-posts.csv
+++ b/packages/web/public/templates/scheduled-posts.csv
@@ -1,0 +1,2 @@
+text,scheduled_at,tags,spinnable,auto_destruct_after,recycle,notes
+Launch day post,2026-06-01T14:00:00Z,launch;product,false,7d,false,Example scheduled post

--- a/packages/web/src/hooks/__tests__/use-csv-templates.test.ts
+++ b/packages/web/src/hooks/__tests__/use-csv-templates.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getQueueTemplateUrl, getScheduledTemplateUrl } from '../use-csv-templates';
+import queueTemplate from '../../../public/templates/queue-posts.csv?raw';
+import scheduledTemplate from '../../../public/templates/scheduled-posts.csv?raw';
+
+const templatesByUrl: Record<string, string> = {
+  '/templates/queue-posts.csv': queueTemplate,
+  '/templates/scheduled-posts.csv': scheduledTemplate,
+};
+
+describe('CSV template downloads', () => {
+  it('serves a scheduled-post template with import headers and a sample row', () => {
+    const csv = templatesByUrl[getScheduledTemplateUrl()];
+    const rows = csv.trim().split('\n');
+
+    expect(rows[0]).toBe('text,scheduled_at,tags,spinnable,auto_destruct_after,recycle,notes');
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toContain('2026-06-01T14:00:00Z');
+  });
+
+  it('serves a queue template with import headers and a sample row', () => {
+    const csv = templatesByUrl[getQueueTemplateUrl()];
+    const rows = csv.trim().split('\n');
+
+    expect(rows[0]).toBe('text,queue_name,position,tags,spinnable,auto_destruct_after,notes');
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toContain('Example Queue');
+  });
+});

--- a/packages/web/src/hooks/__tests__/use-csv-templates.test.ts
+++ b/packages/web/src/hooks/__tests__/use-csv-templates.test.ts
@@ -8,10 +8,14 @@ const templatesByUrl: Record<string, string> = {
   '/templates/scheduled-posts.csv': scheduledTemplate,
 };
 
+function csvRows(csv: string): string[] {
+  return csv.trim().split(/\r?\n/);
+}
+
 describe('CSV template downloads', () => {
   it('serves a scheduled-post template with import headers and a sample row', () => {
     const csv = templatesByUrl[getScheduledTemplateUrl()];
-    const rows = csv.trim().split('\n');
+    const rows = csvRows(csv);
 
     expect(rows[0]).toBe('text,scheduled_at,tags,spinnable,auto_destruct_after,recycle,notes');
     expect(rows).toHaveLength(2);
@@ -20,9 +24,9 @@ describe('CSV template downloads', () => {
 
   it('serves a queue template with import headers and a sample row', () => {
     const csv = templatesByUrl[getQueueTemplateUrl()];
-    const rows = csv.trim().split('\n');
+    const rows = csvRows(csv);
 
-    expect(rows[0]).toBe('text,queue_name,position,tags,spinnable,auto_destruct_after,notes');
+    expect(rows[0]).toBe('text,queue_name,tags,spinnable,auto_destruct_after,notes');
     expect(rows).toHaveLength(2);
     expect(rows[1]).toContain('Example Queue');
   });

--- a/packages/web/src/hooks/use-bulk-ops.ts
+++ b/packages/web/src/hooks/use-bulk-ops.ts
@@ -88,5 +88,5 @@ export function useQueueDedupe(queueId: string) {
 
 export function useBulkImport() {
   const invalidate = useInvalidateBulk();
-  return useMutation({ mutationFn: (formData: FormData) => apiClient.uploadCsv('/api/bulk-import', formData), onSuccess: () => { invalidate(); announceBulkOperationQueued(); }, onError: showBulkOperationError });
+  return useMutation({ mutationFn: (formData: FormData) => apiClient.uploadCsv('/api/bulk-import', formData), onSuccess: () => { invalidate(); announceBulkOperationQueued(); } });
 }

--- a/packages/web/src/pages/posts/BulkImportPage.tsx
+++ b/packages/web/src/pages/posts/BulkImportPage.tsx
@@ -170,7 +170,7 @@ export default function BulkImportPage() {
               <p>{importError.description}</p>
               {importError.details.length > 0 && (
                 <ul className="mt-2 list-disc space-y-1 pl-5">
-                  {importError.details.map((detail) => <li key={detail}>{detail}</li>)}
+                  {importError.details.map((detail, index) => <li key={`${index}-${detail}`}>{detail}</li>)}
                 </ul>
               )}
             </AlertDescription>

--- a/packages/web/src/pages/posts/BulkImportPage.tsx
+++ b/packages/web/src/pages/posts/BulkImportPage.tsx
@@ -15,6 +15,49 @@ import { useBulkImport } from '../../hooks/use-bulk-ops';
 import { getQueueTemplateUrl, getScheduledTemplateUrl } from '../../hooks/use-csv-templates';
 import { cn } from '../../lib/utils';
 
+interface ImportErrorMessage {
+  title: string;
+  description: string;
+  details: string[];
+}
+
+function formatImportError(error: unknown): ImportErrorMessage {
+  const fallback = error instanceof Error ? error.message : "Couldn't start the import. Try again.";
+  const body = (error as { body?: Record<string, unknown> }).body;
+  const rawDetails = Array.isArray(body?.details) ? body.details : [];
+  const details = rawDetails
+    .map((detail) => {
+      if (!detail || typeof detail !== 'object') return null;
+      const rowNumber = 'rowNumber' in detail ? Number(detail.rowNumber) : null;
+      const reason = 'reason' in detail ? String(detail.reason) : '';
+      if (!reason) return null;
+      return rowNumber && Number.isFinite(rowNumber) ? `Row ${rowNumber}: ${reason}` : reason;
+    })
+    .filter((detail): detail is string => Boolean(detail));
+
+  if (body?.code === 'csv_validation_failed' || body?.code === 'csv_parse_failed') {
+    return {
+      title: 'CSV import needs changes',
+      description: String(body.error ?? fallback),
+      details,
+    };
+  }
+
+  if (body?.error === 'queue_name_mismatch') {
+    return {
+      title: 'Queue name does not match',
+      description: `Rows must use queue_name "${String(body.expected ?? '')}" for this queue.`,
+      details: [`${Number(body.mismatchedRows) || 0} row(s) target a different queue.`],
+    };
+  }
+
+  return {
+    title: "Couldn't start the import",
+    description: fallback,
+    details,
+  };
+}
+
 export default function BulkImportPage() {
   const navigate = useNavigate();
   const { data: profiles } = useProfiles();
@@ -25,11 +68,14 @@ export default function BulkImportPage() {
   const [queueId, setQueueId] = useState('');
   const [file, setFile] = useState<File | null>(null);
   const [budgetError, setBudgetError] = useState<{ budget: number; currentCount: number; attemptedAdditional: number } | null>(null);
+  const [importError, setImportError] = useState<ImportErrorMessage | null>(null);
   const filteredQueues = queues?.filter((queue) => !profileId || queue.profileId === profileId) ?? [];
   const isReady = !!target && !!profileId && !!file && (target === 'scheduled' || !!queueId);
 
   async function handleSubmit() {
     if (!file) return;
+    setBudgetError(null);
+    setImportError(null);
     const formData = new FormData();
     formData.append('target', target);
     formData.append('profileId', profileId);
@@ -49,7 +95,7 @@ export default function BulkImportPage() {
         });
         return;
       }
-      toast.error(error instanceof Error ? error.message : "Couldn't start the import. Try again.");
+      setImportError(formatImportError(error));
     }
   }
 
@@ -109,7 +155,30 @@ export default function BulkImportPage() {
             <p className="text-xs text-muted-foreground">Only queues for the selected profile are shown.</p>
           </div>
         )}
-        <FileDropZone file={file} onFileChange={setFile} />
+        <FileDropZone
+          file={file}
+          onFileChange={(nextFile) => {
+            setFile(nextFile);
+            setBudgetError(null);
+            setImportError(null);
+          }}
+        />
+        {importError && (
+          <Alert variant="destructive" role="alert">
+            <AlertTitle>{importError.title}</AlertTitle>
+            <AlertDescription>
+              <p>{importError.description}</p>
+              {importError.details.length > 0 && (
+                <ul className="mt-2 list-disc space-y-1 pl-5">
+                  {importError.details.map((detail) => <li key={detail}>{detail}</li>)}
+                </ul>
+              )}
+            </AlertDescription>
+            <Button type="button" variant="link" className="mt-2 h-auto p-0 text-destructive" onClick={() => setImportError(null)}>
+              Edit CSV and try again
+            </Button>
+          </Alert>
+        )}
       </section>
 
       <Card>

--- a/packages/web/src/pages/posts/__tests__/BulkImportPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/BulkImportPage.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BulkImportPage from '../BulkImportPage';
+
+const mocks = vi.hoisted(() => ({
+  mutateAsync: vi.fn(),
+  navigate: vi.fn(),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+vi.mock('../../../hooks/use-profiles', () => ({
+  useProfiles: () => ({
+    data: [{ id: '550e8400-e29b-41d4-a716-446655440000', handle: 'clicksmortarweb' }],
+  }),
+}));
+
+vi.mock('../../../hooks/use-queues', () => ({
+  useQueues: () => ({ data: [] }),
+}));
+
+vi.mock('../../../hooks/use-bulk-ops', () => ({
+  useBulkImport: () => ({
+    mutateAsync: mocks.mutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock('../../../hooks/use-csv-templates', () => ({
+  getQueueTemplateUrl: () => '/queue-template.csv',
+  getScheduledTemplateUrl: () => '/scheduled-template.csv',
+}));
+
+vi.mock('../../../components/bulk/FileDropZone', () => ({
+  FileDropZone: ({ onFileChange }: { onFileChange: (file: File) => void }) => (
+    <button type="button" onClick={() => onFileChange(new File(['bad'], 'bad-import.csv', { type: 'text/csv' }))}>
+      Pick CSV
+    </button>
+  ),
+}));
+
+vi.mock('../../../components/ui/select', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  const SelectContext = React.createContext<(value: string) => void>(() => undefined);
+
+  return {
+    Select: ({ children, onValueChange }: { children: React.ReactNode; onValueChange: (value: string) => void }) => (
+      <SelectContext.Provider value={onValueChange}>
+        <div>{children}</div>
+      </SelectContext.Provider>
+    ),
+    SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => {
+      const onValueChange = React.useContext(SelectContext);
+      return (
+        <button type="button" onClick={() => onValueChange(value)}>
+          {children}
+        </button>
+      );
+    },
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    SelectValue: ({ placeholder }: { placeholder: string }) => <span>{placeholder}</span>,
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <BulkImportPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('BulkImportPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders rejected CSV import details inline near the import controls', async () => {
+    mocks.mutateAsync.mockRejectedValue(
+      Object.assign(new Error('CSV validation failed'), {
+        body: {
+          error: 'CSV validation failed',
+          code: 'csv_validation_failed',
+          errorCount: 1,
+          details: [{ rowNumber: 2, reason: 'scheduled_at: Invalid datetime' }],
+        },
+      }),
+    );
+
+    renderPage();
+
+    fireEvent.click(screen.getByText('@clicksmortarweb'));
+    fireEvent.click(screen.getByText('Pick CSV'));
+    fireEvent.click(screen.getByRole('button', { name: 'Import' }));
+
+    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole('alert')).toHaveTextContent('CSV import needs changes');
+    expect(screen.getByText('Row 2: scheduled_at: Invalid datetime')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- import GitHub issues #95 and #96 into the Clawpatch queue
- add reachable scheduled and queue CSV template assets with regression coverage
- return actionable 400 responses for invalid CSV imports instead of generic 500s
- render import failures inline near the file controls with row-level details when available

## Why
Users had no reliable template to download, then malformed CSV uploads could fail as hidden/clipped generic errors. These fixes make the import path self-service: known-good examples are available and invalid uploads produce visible, actionable feedback.

## Validation
- Clawpatch revalidated gh#95 and gh#96 as fixed
- pnpm typecheck
- pnpm lint
- pnpm test