### PR TITLE
[codex] Accept date-only queue start dates

### DIFF
--- a/packages/api/src/services/__tests__/queue.service.test.ts
+++ b/packages/api/src/services/__tests__/queue.service.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { parseQueueStartDate } from '../queue.service.js';
+
+describe('parseQueueStartDate', () => {
+  it('interprets date-only values as midnight in the user timezone', () => {
+    const startDate = parseQueueStartDate('2026-05-21', 'America/New_York');
+
+    expect(startDate?.toISOString()).toBe('2026-05-21T04:00:00.000Z');
+  });
+
+  it('preserves full ISO datetime instants', () => {
+    const startDate = parseQueueStartDate(
+      '2026-05-21T12:30:00.000Z',
+      'America/New_York',
+    );
+
+    expect(startDate?.toISOString()).toBe('2026-05-21T12:30:00.000Z');
+  });
+});

--- a/packages/api/src/services/queue.service.ts
+++ b/packages/api/src/services/queue.service.ts
@@ -1,5 +1,6 @@
 import { eq, and, sql, count as drizzleCount, max, lt, gt, desc, asc, type SQL } from 'drizzle-orm';
 import type { InferInsertModel } from 'drizzle-orm';
+import { DateTime } from 'luxon';
 import { AppError, transitionPost, calculateNextRunAt } from '@sms/shared';
 import type { PostStatus, CreateQueueInput, UpdateQueueInput, QueueQueryInput } from '@sms/shared';
 import { createLogger } from '@sms/shared/logger';
@@ -17,6 +18,26 @@ export class QueueServiceError extends AppError {
   }
 }
 
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function parseQueueStartDate(startDate: string | null | undefined, timezone: string): Date | null {
+  if (!startDate) return null;
+
+  if (DATE_ONLY_PATTERN.test(startDate)) {
+    const localStart = DateTime.fromISO(startDate, { zone: timezone }).startOf('day');
+    if (!localStart.isValid) {
+      throw new QueueServiceError('Invalid start date', 400);
+    }
+    return localStart.toJSDate();
+  }
+
+  const parsedStartDate = new Date(startDate);
+  if (Number.isNaN(parsedStartDate.getTime())) {
+    throw new QueueServiceError('Invalid start date', 400);
+  }
+  return parsedStartDate;
+}
+
 export async function createQueue(db: Db, userId: string, input: CreateQueueInput) {
   const [ownedProfile] = await db
     .select({ id: socialProfiles.id })
@@ -32,6 +53,7 @@ export async function createQueue(db: Db, userId: string, input: CreateQueueInpu
     .from(users)
     .where(eq(users.id, userId));
   const userTimezone = userRow?.timezone ?? 'UTC';
+  const startDate = parseQueueStartDate(input.startDate, userTimezone);
 
   const nextRunAt = calculateNextRunAt(
     {
@@ -41,7 +63,7 @@ export async function createQueue(db: Db, userId: string, input: CreateQueueInpu
       hourSlots: input.hourSlots,
       daysOfWeek: input.daysOfWeek,
       lastPublishedAt: null,
-      startDate: input.startDate ? new Date(input.startDate) : null,
+      startDate,
     },
     userTimezone,
   );
@@ -55,7 +77,7 @@ export async function createQueue(db: Db, userId: string, input: CreateQueueInpu
     intervalUnit: input.intervalUnit,
     daysOfWeek: input.daysOfWeek,
     hourSlots: input.hourSlots,
-    startDate: input.startDate ? new Date(input.startDate) : null,
+    startDate,
     seasonalStart: input.seasonalStart ?? null,
     seasonalEnd: input.seasonalEnd ?? null,
     seasonalRepeat: input.seasonalRepeat ?? false,
@@ -86,6 +108,15 @@ export async function updateQueue(
 
   const existingQueue = existingRows[0];
 
+  const [userRow] = await db
+    .select({ timezone: users.timezone })
+    .from(users)
+    .where(eq(users.id, userId));
+  const userTimezone = userRow?.timezone ?? 'UTC';
+  const parsedStartDate = input.startDate !== undefined
+    ? parseQueueStartDate(input.startDate, userTimezone)
+    : undefined;
+
   const queuePatch: Partial<QueueInsert> = { updatedAt: new Date() };
 
   if (input.name !== undefined) queuePatch.name = input.name;
@@ -95,7 +126,7 @@ export async function updateQueue(
   if (input.intervalUnit !== undefined) queuePatch.intervalUnit = input.intervalUnit;
   if (input.daysOfWeek !== undefined) queuePatch.daysOfWeek = input.daysOfWeek;
   if (input.hourSlots !== undefined) queuePatch.hourSlots = input.hourSlots;
-  if (input.startDate !== undefined) queuePatch.startDate = input.startDate ? new Date(input.startDate) : null;
+  if (input.startDate !== undefined) queuePatch.startDate = parsedStartDate ?? null;
   if (input.seasonalStart !== undefined) queuePatch.seasonalStart = input.seasonalStart;
   if (input.seasonalEnd !== undefined) queuePatch.seasonalEnd = input.seasonalEnd;
   if (input.seasonalRepeat !== undefined) queuePatch.seasonalRepeat = input.seasonalRepeat;
@@ -108,14 +139,8 @@ export async function updateQueue(
   const effectiveHourSlots = (input.hourSlots ?? existingQueue.hourSlots) as number[];
   const effectiveDaysOfWeek = (input.daysOfWeek ?? existingQueue.daysOfWeek) as number[];
   const effectiveStartDate = input.startDate !== undefined
-    ? (input.startDate ? new Date(input.startDate) : null)
+    ? parsedStartDate ?? null
     : existingQueue.startDate;
-
-  const [userRow] = await db
-    .select({ timezone: users.timezone })
-    .from(users)
-    .where(eq(users.id, userId));
-  const userTimezone = userRow?.timezone ?? 'UTC';
 
   const nextRunAt = calculateNextRunAt(
     {

--- a/packages/shared/src/__tests__/queues-schema.test.ts
+++ b/packages/shared/src/__tests__/queues-schema.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createQueueSchema } from '../schemas/queues.js';
+
+describe('createQueueSchema', () => {
+  const validQueueInput = {
+    name: 'CMW Promotions',
+    profileId: '00000000-0000-4000-8000-000000000001',
+    intervalType: 'variable',
+    intervalValue: 4,
+    intervalUnit: 'hours',
+    daysOfWeek: [1, 2, 3, 4, 5],
+    hourSlots: [8, 12, 15],
+    seasonalRepeat: false,
+    isRecycling: true,
+    notes:
+      'General brand awareness. With only 14 tweets and 3 posts/day Mon-Fri, each tweet recycles about once a week.',
+  } as const;
+
+  it('accepts the date-only startDate emitted by the queue date input', () => {
+    const result = createQueueSchema.safeParse({
+      ...validQueueInput,
+      startDate: '2026-05-21',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('still accepts full ISO datetime startDate values', () => {
+    const result = createQueueSchema.safeParse({
+      ...validQueueInput,
+      startDate: '2026-05-21T04:00:00.000Z',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects impossible date-only startDate values', () => {
+    const result = createQueueSchema.safeParse({
+      ...validQueueInput,
+      startDate: '2026-02-31',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/schemas/queues.ts
+++ b/packages/shared/src/schemas/queues.ts
@@ -1,5 +1,18 @@
 import { z } from 'zod';
 
+const isValidDateOnly = (value: string) => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().startsWith(value);
+};
+
+const startDateSchema = z.string().refine(
+  (value) =>
+    isValidDateOnly(value) || z.string().datetime().safeParse(value).success,
+  'Start date must be a valid date',
+);
+
 export const createQueueSchema = z.object({
   name: z.string().min(1, 'Queue name is required').max(255),
   profileId: z.string().uuid('Invalid profile ID'),
@@ -8,7 +21,7 @@ export const createQueueSchema = z.object({
   intervalUnit: z.enum(['minutes', 'hours', 'days', 'weeks', 'months', 'years']),
   daysOfWeek: z.array(z.number().int().min(0).max(6)).min(1, 'At least one day required'),
   hourSlots: z.array(z.number().int().min(6).max(23)).min(1, 'At least one hour slot required'),
-  startDate: z.string().datetime().optional(),
+  startDate: startDateSchema.optional(),
   seasonalStart: z.string().regex(/^\d{2}-\d{2}$/, 'Must be MM-DD format').optional(),
   seasonalEnd: z.string().regex(/^\d{2}-\d{2}$/, 'Must be MM-DD format').optional(),
   seasonalRepeat: z.boolean().default(false),

--- a/packages/web/src/hooks/use-queues.ts
+++ b/packages/web/src/hooks/use-queues.ts
@@ -86,9 +86,6 @@ export function useCreateQueue() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['queues'] });
     },
-    onError: (error: Error) => {
-      toast.error(error.message || 'Failed to create queue');
-    },
   });
 }
 
@@ -100,9 +97,6 @@ export function useUpdateQueue() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['queues'] });
       queryClient.invalidateQueries({ queryKey: ['queues', variables.id] });
-    },
-    onError: (error: Error) => {
-      toast.error(error.message || 'Failed to update queue');
     },
   });
 }

--- a/packages/web/src/pages/queues/QueueDetailPage.tsx
+++ b/packages/web/src/pages/queues/QueueDetailPage.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2 } from 'lucide-react';
+import { AlertCircle, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { useQueue, useCreateQueue, useUpdateQueue, type QueueConfig } from '../../hooks/use-queues';
@@ -14,6 +14,7 @@ import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Textarea } from '../../components/ui/textarea';
 import { Skeleton } from '../../components/ui/skeleton';
+import { Alert, AlertDescription, AlertTitle } from '../../components/ui/alert';
 import {
   Select,
   SelectContent,
@@ -62,6 +63,61 @@ const DEFAULT_VALUES: QueueFormValues = {
   notes: undefined,
 };
 
+type ApiValidationIssue = {
+  path?: Array<string | number>;
+  message?: string;
+};
+
+type ApiError = Error & {
+  body?: {
+    error?: unknown;
+    details?: unknown;
+  };
+};
+
+const FIELD_LABELS: Record<string, string> = {
+  name: 'Queue name',
+  profileId: 'Social profile',
+  intervalType: 'Interval type',
+  intervalValue: 'Interval',
+  intervalUnit: 'Interval unit',
+  daysOfWeek: 'Days of week',
+  hourSlots: 'Hour windows',
+  startDate: 'Start date',
+  seasonalStart: 'Seasonal start',
+  seasonalEnd: 'Seasonal end',
+  seasonalRepeat: 'Seasonal repeat',
+  isRecycling: 'Recycle posts',
+  notes: 'Internal notes',
+};
+
+function isApiValidationIssue(value: unknown): value is ApiValidationIssue {
+  return value !== null && typeof value === 'object';
+}
+
+export function formatQueueSaveError(error: unknown): string {
+  const apiError = error as ApiError;
+  const details = apiError.body?.details;
+
+  if (Array.isArray(details) && details.length > 0) {
+    return details
+      .filter(isApiValidationIssue)
+      .slice(0, 3)
+      .map((issue) => {
+        const fieldName = issue.path?.[0];
+        const label =
+          typeof fieldName === 'string'
+            ? FIELD_LABELS[fieldName] ?? fieldName
+            : 'Queue settings';
+        return `${label}: ${issue.message ?? 'Invalid value'}`;
+      })
+      .join(' ');
+  }
+
+  if (error instanceof Error && error.message) return error.message;
+  return "Couldn't save queue. Try again.";
+}
+
 export default function QueueDetailPage() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
@@ -72,6 +128,7 @@ export default function QueueDetailPage() {
   const { data: profiles } = useProfiles();
   const createQueueMutation = useCreateQueue();
   const updateQueueMutation = useUpdateQueue();
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const copiedConfig = (location.state as { copiedConfig?: QueueConfig } | null)?.copiedConfig;
 
@@ -121,6 +178,7 @@ export default function QueueDetailPage() {
   const isSaving = createQueueMutation.isPending || updateQueueMutation.isPending;
 
   function onSubmit(values: QueueFormValues) {
+    setSaveError(null);
     const payload = {
       ...values,
       seasonalStart: values.seasonalStart || undefined,
@@ -133,22 +191,24 @@ export default function QueueDetailPage() {
         { id, input: payload },
         {
           onSuccess: () => {
+            setSaveError(null);
             toast.success('Queue updated.');
             navigate(`/queues/${id}/posts`);
           },
-          onError: () => {
-            toast.error("Couldn't save queue. Try again.");
+          onError: (error) => {
+            setSaveError(formatQueueSaveError(error));
           },
         },
       );
     } else {
       createQueueMutation.mutate(payload, {
         onSuccess: (createdQueue) => {
+          setSaveError(null);
           toast.success('Queue created.');
           navigate(`/queues/${createdQueue.id}/posts`);
         },
-        onError: () => {
-          toast.error("Couldn't save queue. Try again.");
+        onError: (error) => {
+          setSaveError(formatQueueSaveError(error));
         },
       });
     }
@@ -240,6 +300,14 @@ export default function QueueDetailPage() {
               </FormItem>
             )}
           />
+
+          {saveError && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" aria-hidden="true" />
+              <AlertTitle>Queue was not saved</AlertTitle>
+              <AlertDescription>{saveError}</AlertDescription>
+            </Alert>
+          )}
 
           {/* Buttons */}
           <div className="flex gap-3">

--- a/packages/web/src/pages/queues/__tests__/QueueDetailPage.test.tsx
+++ b/packages/web/src/pages/queues/__tests__/QueueDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type React from 'react';
+import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
@@ -38,6 +38,30 @@ vi.mock('../../../hooks/use-queues', () => ({
   useUpdateQueue: () => ({ mutate: updateQueueMutate, isPending: false }),
 }));
 
+function getSelectLabel(children: React.ReactNode): string {
+  let label: string | undefined;
+
+  React.Children.forEach(children, (child) => {
+    if (label || !React.isValidElement(child)) return;
+
+    const props = child.props as {
+      placeholder?: unknown;
+      children?: React.ReactNode;
+    };
+
+    if (typeof props.placeholder === 'string') {
+      label = props.placeholder;
+      return;
+    }
+
+    if (props.children) {
+      label = getSelectLabel(props.children);
+    }
+  });
+
+  return label ?? 'Select option';
+}
+
 vi.mock('../../../components/ui/select', () => ({
   Select: ({
     value,
@@ -49,7 +73,7 @@ vi.mock('../../../components/ui/select', () => ({
     children: React.ReactNode;
   }) => (
     <select
-      aria-label="Social profile"
+      aria-label={getSelectLabel(children)}
       value={value ?? ''}
       onChange={(event) => onValueChange?.(event.target.value)}
     >
@@ -102,7 +126,7 @@ describe('QueueDetailPage', () => {
 
     await user.type(screen.getByLabelText('Queue name'), 'CMW Promotions');
     await user.selectOptions(
-      screen.getAllByRole('combobox')[0],
+      screen.getByRole('combobox', { name: 'Select a profile' }),
       '00000000-0000-4000-8000-000000000001',
     );
     await user.type(screen.getByLabelText(/Start date/i), '2026-05-21');

--- a/packages/web/src/pages/queues/__tests__/QueueDetailPage.test.tsx
+++ b/packages/web/src/pages/queues/__tests__/QueueDetailPage.test.tsx
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import QueueDetailPage from '../QueueDetailPage';
+
+const navigate = vi.fn();
+const createQueueMutate = vi.fn();
+const updateQueueMutate = vi.fn();
+
+vi.mock('react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    useParams: () => ({}),
+    useLocation: () => ({ state: null }),
+  };
+});
+
+vi.mock('../../../hooks/use-profiles', () => ({
+  useProfiles: () => ({
+    data: [
+      {
+        id: '00000000-0000-4000-8000-000000000001',
+        displayName: 'Test Profile',
+        handle: 'testprofile',
+      },
+    ],
+  }),
+}));
+
+vi.mock('../../../hooks/use-queues', () => ({
+  useQueue: () => ({ data: undefined, isLoading: false }),
+  useCreateQueue: () => ({ mutate: createQueueMutate, isPending: false }),
+  useUpdateQueue: () => ({ mutate: updateQueueMutate, isPending: false }),
+}));
+
+vi.mock('../../../components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (value: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select
+      aria-label="Social profile"
+      value={value ?? ''}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => <option value={value}>{children}</option>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <option value="">{placeholder}</option>
+  ),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <QueueDetailPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('QueueDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+  });
+
+  it('shows API validation failures inline beside the submit action', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText('Queue name'), 'CMW Promotions');
+    await user.selectOptions(
+      screen.getAllByRole('combobox')[0],
+      '00000000-0000-4000-8000-000000000001',
+    );
+    await user.type(screen.getByLabelText(/Start date/i), '2026-05-21');
+    await user.click(screen.getByRole('button', { name: 'Create Queue' }));
+
+    expect(createQueueMutate).toHaveBeenCalled();
+    const [, options] = createQueueMutate.mock.calls[0];
+    await act(async () => {
+      options.onError(
+        Object.assign(new Error('Validation failed'), {
+          status: 400,
+          body: {
+            error: 'Validation failed',
+            details: [
+              {
+                path: ['startDate'],
+                message: 'Invalid datetime',
+              },
+            ],
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Start date: Invalid datetime',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Accept date-only queue start dates in shared queue validation.
- Normalize queue start-date handling in the web queue detail flow.
- Add shared schema and queue detail regression coverage.

## Validation
- pnpm --filter @sms/shared typecheck
- pnpm --filter @sms/web typecheck
- pnpm --filter @sms/shared exec vitest run src/__tests__/queues-schema.test.ts
- pnpm --filter @sms/web exec vitest run src/pages/queues/__tests__/QueueDetailPage.test.tsx