### PR TITLE
[codex] Add Clawpatch RoboRev batch workflow

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,5 +1,5 @@
-# RoboRev reviews local commits with Codex.
-agent = "codex"
+# RoboRev reviews local commits with Claude Code.
+agent = "claude-code"
 display_name = "social-media-scheduler"
 
 # Keep successful background reviews out of the active queue.

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,0 +1,27 @@
+# RoboRev reviews local commits with Codex.
+agent = "codex"
+display_name = "social-media-scheduler"
+
+# Keep successful background reviews out of the active queue.
+auto_close_passing_reviews = true
+
+# Generated/build artifacts are not useful review inputs.
+exclude_patterns = [
+  "dist/",
+  "coverage/",
+]
+
+review_guidelines = """
+This is a pnpm TypeScript monorepo for a social media scheduler.
+
+Packages:
+- packages/api: Express API, authentication/session middleware, media uploads, profile and queue services.
+- packages/worker: background queue workers for publishing, token refresh, notifications, bulk operations, media cleanup, and lifecycle handling.
+- packages/db: Drizzle schema and migrations.
+- packages/shared: cross-package env, encryption, and rate-limit helpers.
+- packages/web: frontend application.
+
+Prioritize review findings around authentication/session handling, CSRF and security headers, token encryption/refresh flows, social API error handling, rate-limit accounting, queue idempotency, background worker retries, and data consistency between API, worker, and DB packages.
+
+For tests, prefer focused Vitest coverage near changed behavior. Do not require migrations unless schema files change.
+"""

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -147,6 +147,7 @@ These are tracked in GitHub. Listed here for completeness so an automated workfl
 
 ### Enhancements / config
 
+- [ ] **gh#94** — Queue creation: add inline help + live "Next 5 publish times" preview *(operator confusion — interval modes vs hour windows aren't legible from the form alone)*
 - [ ] **gh#19** — Transcode worker missing retry attempts and backoff
 
 ---

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "clawpatch:queue-gh": "node scripts/clawpatch-imported-queue.mjs",
     "clawpatch:fix-gh": "scripts/clawpatch-fix-imported-github-issues.sh",
     "clawpatch:overnight": "scripts/clawpatch-overnight-loop.sh",
+    "clawpatch:roborev-one": "scripts/clawpatch-roborev-loop.sh --max 1",
+    "clawpatch:roborev-batch": "scripts/clawpatch-roborev-loop.sh --max 3",
+    "clawpatch:roborev-overnight": "scripts/clawpatch-roborev-loop.sh --max 10 --interval-seconds 1800",
     "db:generate": "pnpm --filter @sms/db exec drizzle-kit generate",
     "db:migrate": "pnpm --filter @sms/db exec drizzle-kit migrate"
   },

--- a/scripts/clawpatch-imported-queue.mjs
+++ b/scripts/clawpatch-imported-queue.mjs
@@ -41,6 +41,7 @@ async function main() {
     .filter(
       ({ finding }) => args.status === "any" || finding.status === args.status,
     )
+    .filter(({ finding }) => !args.exclude.has(finding.findingId))
     .sort(compareQueueItems);
 
   if (args.command === "next") {
@@ -129,6 +130,7 @@ function parseArgs(argv) {
   const parsed = {
     command: "list",
     help: false,
+    exclude: new Set(),
     plain: false,
     status: "open",
   };
@@ -139,6 +141,10 @@ function parseArgs(argv) {
     else if (arg === "list" || arg === "next") parsed.command = arg;
     else if (arg === "--help" || arg === "-h") parsed.help = true;
     else if (arg === "--plain") parsed.plain = true;
+    else if (arg === "--exclude")
+      parsed.exclude.add(requireValue(argv, ++index, arg));
+    else if (arg.startsWith("--exclude="))
+      parsed.exclude.add(arg.slice("--exclude=".length));
     else if (arg === "--status")
       parsed.status = requireValue(argv, ++index, arg);
     else if (arg.startsWith("--status="))
@@ -163,6 +169,7 @@ Lists or selects Clawpatch findings imported from GitHub issues.
 
 Flags:
   --status <status|any>  Default: open
+  --exclude <finding>    Omit a finding id from the queue; repeatable
   --plain               Print tabular output for list, finding id for next
 `);
 }

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -280,36 +280,33 @@ include_stage_path() {
 changed_source_paths() {
   local path
   local seen_path
+  local already_seen
   local -a seen_paths=()
 
-  emit_path() {
-    local candidate="$1"
-
-    if ! include_stage_path "$candidate"; then
-      return 0
+  while IFS= read -r -d '' path; do
+    if ! include_stage_path "$path"; then
+      continue
     fi
 
+    already_seen=0
     for seen_path in "${seen_paths[@]}"; do
-      if [[ "$seen_path" == "$candidate" ]]; then
-        return 0
+      if [[ "$seen_path" == "$path" ]]; then
+        already_seen=1
+        break
       fi
     done
 
-    seen_paths+=("$candidate")
-    printf '%s\0' "$candidate"
-  }
+    if [[ "$already_seen" -eq 1 ]]; then
+      continue
+    fi
 
-  while IFS= read -r -d '' path; do
-    emit_path "$path"
-  done < <(git diff --name-only -z)
-
-  while IFS= read -r -d '' path; do
-    emit_path "$path"
-  done < <(git diff --cached --name-only -z)
-
-  while IFS= read -r -d '' path; do
-    emit_path "$path"
-  done < <(git ls-files --others --exclude-standard -z)
+    seen_paths+=("$path")
+    printf '%s\0' "$path"
+  done < <(
+    git diff --name-only -z
+    git diff --cached --name-only -z
+    git ls-files --others --exclude-standard -z
+  )
 }
 
 stage_changed_files() {

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -281,7 +281,9 @@ changed_source_paths() {
   local path
   local seen_path
   local already_seen
+  local index
   local -a seen_paths=()
+  local seen_paths_count=0
 
   while IFS= read -r -d '' path; do
     if ! include_stage_path "$path"; then
@@ -289,7 +291,8 @@ changed_source_paths() {
     fi
 
     already_seen=0
-    for seen_path in "${seen_paths[@]}"; do
+    for ((index = 0; index < seen_paths_count; index += 1)); do
+      seen_path="${seen_paths[$index]}"
       if [[ "$seen_path" == "$path" ]]; then
         already_seen=1
         break
@@ -300,7 +303,8 @@ changed_source_paths() {
       continue
     fi
 
-    seen_paths+=("$path")
+    seen_paths[$seen_paths_count]="$path"
+    seen_paths_count=$((seen_paths_count + 1))
     printf '%s\0' "$path"
   done < <(
     git diff --name-only -z

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -7,6 +7,8 @@ TEST_RETRIES=1
 ROBOREV_REPAIR_ATTEMPTS=1
 ROBOREV_FIX_AGENT="codex"
 INTERVAL_SECONDS=0
+REVIEW_TIMEOUT_SECONDS=1800
+STOP_ON_FAILURE=0
 
 usage() {
   cat <<'EOF'
@@ -23,6 +25,8 @@ Flags:
   --no-roborev-repair             Alias for --roborev-repair-attempts 0
   --roborev-fix-agent <agent>     Agent used to address RoboRev findings. Default: codex
   --interval-seconds <n>          Sleep between findings. Default: 0
+  --review-timeout-seconds <n>    Max seconds to wait for each RoboRev review. Default: 1800
+  --stop-on-failure               Stop instead of stashing failed work and moving on
   -h, --help                      Show this help
 
 The loop requires a clean source worktree at the start of every finding. It
@@ -88,6 +92,18 @@ while [[ $# -gt 0 ]]; do
       INTERVAL_SECONDS="${1#--interval-seconds=}"
       shift
       ;;
+    --review-timeout-seconds)
+      REVIEW_TIMEOUT_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --review-timeout-seconds=*)
+      REVIEW_TIMEOUT_SECONDS="${1#--review-timeout-seconds=}"
+      shift
+      ;;
+    --stop-on-failure)
+      STOP_ON_FAILURE=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -117,6 +133,11 @@ fi
 
 if ! [[ "$INTERVAL_SECONDS" =~ ^[0-9]+$ ]]; then
   echo "--interval-seconds must be a non-negative integer" >&2
+  exit 2
+fi
+
+if ! [[ "$REVIEW_TIMEOUT_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "--review-timeout-seconds must be a non-negative integer" >&2
   exit 2
 fi
 
@@ -162,8 +183,13 @@ process.stdin.on('end', () => {
 
 finding_title() {
   local finding_id="$1"
-  clawpatch show --finding "$finding_id" --json \
-    | json_field "parsed.finding?.title ?? parsed.title ?? '$finding_id'"
+  local title
+  title="$(clawpatch show --finding "$finding_id" --json \
+    | json_field "parsed.finding?.title ?? parsed.title")"
+  if [[ -z "$title" ]]; then
+    title="$finding_id"
+  fi
+  printf '%s\n' "$title"
 }
 
 review_job_id() {
@@ -191,6 +217,47 @@ run_with_retries() {
     attempt=$((attempt + 1))
     echo "command failed; retrying ($attempt/$max_attempts): $*"
   done
+}
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+
+  if [[ "$timeout_seconds" -eq 0 ]]; then
+    "$@"
+    return $?
+  fi
+
+  local marker
+  marker="$(mktemp)"
+
+  "$@" &
+  local command_pid=$!
+
+  (
+    sleep "$timeout_seconds"
+    if kill -0 "$command_pid" 2>/dev/null; then
+      printf 'timeout\n' >"$marker"
+      kill "$command_pid" 2>/dev/null || true
+    fi
+  ) &
+  local timer_pid=$!
+
+  set +e
+  wait "$command_pid"
+  local command_status=$?
+  set -e
+
+  kill "$timer_pid" 2>/dev/null || true
+  wait "$timer_pid" 2>/dev/null || true
+
+  if [[ -s "$marker" ]]; then
+    rm -f "$marker"
+    return 124
+  fi
+
+  rm -f "$marker"
+  return "$command_status"
 }
 
 validate_repo() {
@@ -247,6 +314,36 @@ commit_current_changes() {
   git commit -m "$subject" -m "$body"
 }
 
+stash_failed_work() {
+  local finding_id="$1"
+
+  if [[ -z "$(source_status)" ]]; then
+    return 0
+  fi
+
+  git stash push -u -m "clawpatch-roborev failed ${finding_id}" -- \
+    . \
+    ':!/.agent' \
+    ':!/.agents' \
+    ':!/.claude' \
+    ':!/skills-lock.json' \
+    ':!packages/web/.vite'
+}
+
+handle_finding_failure() {
+  local finding_id="$1"
+  local reason="$2"
+
+  echo "finding failed: $finding_id: $reason" >&2
+
+  if [[ "$STOP_ON_FAILURE" -eq 1 ]]; then
+    exit 6
+  fi
+
+  stash_failed_work "$finding_id"
+  return 0
+}
+
 wait_for_review_or_repair() {
   local finding_id="$1"
   local issue="$2"
@@ -258,13 +355,17 @@ wait_for_review_or_repair() {
     echo "waiting for RoboRev review of $review_sha"
 
     set +e
-    roborev wait "$review_sha"
+    run_with_timeout "$REVIEW_TIMEOUT_SECONDS" roborev wait "$review_sha"
     local review_status=$?
     set -e
 
     if [[ "$review_status" -eq 0 ]]; then
       roborev show "$review_sha"
       return 0
+    fi
+
+    if [[ "$review_status" -eq 124 ]]; then
+      echo "RoboRev review timed out for $review_sha after ${REVIEW_TIMEOUT_SECONDS}s" >&2
     fi
 
     echo "RoboRev found issues for $review_sha" >&2
@@ -345,8 +446,9 @@ while [[ "$completed" -lt "$MAX" ]]; do
   fi
 
   if [[ "$pre_outcome" != "open" ]]; then
-    echo "stopping because revalidation returned '$pre_outcome' for $finding_id" >&2
-    exit 6
+    handle_finding_failure "$finding_id" "pre-fix revalidation returned '$pre_outcome'"
+    completed=$((completed + 1))
+    continue
   fi
 
   set +e
@@ -362,11 +464,16 @@ while [[ "$completed" -lt "$MAX" ]]; do
   echo "post-fix revalidate: $post_outcome"
 
   if [[ "$post_outcome" != "fixed" ]]; then
-    echo "stopping because finding did not revalidate as fixed: $finding_id => $post_outcome" >&2
-    exit 6
+    handle_finding_failure "$finding_id" "post-fix revalidation returned '$post_outcome'"
+    completed=$((completed + 1))
+    continue
   fi
 
-  validate_repo
+  if ! validate_repo; then
+    handle_finding_failure "$finding_id" "validation failed"
+    completed=$((completed + 1))
+    continue
+  fi
 
   if ! commit_current_changes \
     "Fix ${issue}: ${subject_title}" \

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -373,7 +373,19 @@ handle_finding_failure() {
     exit 6
   fi
 
+  failed_findings+=("$finding_id")
   return 0
+}
+
+next_finding() {
+  local args=(next --plain --status "$STATUS")
+  local finding_id
+
+  for finding_id in "${failed_findings[@]}"; do
+    args+=(--exclude "$finding_id")
+  done
+
+  node scripts/clawpatch-imported-queue.mjs "${args[@]}"
 }
 
 wait_for_review_or_repair() {
@@ -450,11 +462,12 @@ require_command roborev
 require_clean_source_tree
 
 completed=0
+failed_findings=()
 
 while [[ "$completed" -lt "$MAX" ]]; do
   require_clean_source_tree
 
-  if ! finding_id="$(node scripts/clawpatch-imported-queue.mjs next --plain --status "$STATUS")"; then
+  if ! finding_id="$(next_finding)"; then
     echo "no imported GitHub issue findings with status '$STATUS'"
     break
   fi

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -279,23 +279,36 @@ include_stage_path() {
 
 changed_source_paths() {
   local path
+  local seen_path
+  local -a seen_paths=()
+
+  emit_path() {
+    local candidate="$1"
+
+    if ! include_stage_path "$candidate"; then
+      return 0
+    fi
+
+    for seen_path in "${seen_paths[@]}"; do
+      if [[ "$seen_path" == "$candidate" ]]; then
+        return 0
+      fi
+    done
+
+    seen_paths+=("$candidate")
+    printf '%s\0' "$candidate"
+  }
 
   while IFS= read -r -d '' path; do
-    if include_stage_path "$path"; then
-      printf '%s\0' "$path"
-    fi
+    emit_path "$path"
   done < <(git diff --name-only -z)
 
   while IFS= read -r -d '' path; do
-    if include_stage_path "$path"; then
-      printf '%s\0' "$path"
-    fi
+    emit_path "$path"
   done < <(git diff --cached --name-only -z)
 
   while IFS= read -r -d '' path; do
-    if include_stage_path "$path"; then
-      printf '%s\0' "$path"
-    fi
+    emit_path "$path"
   done < <(git ls-files --others --exclude-standard -z)
 }
 

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -229,7 +229,7 @@ run_with_timeout() {
   fi
 
   local marker
-  marker="$(mktemp)"
+  marker="$(mktemp -t clawpatch-roborev.XXXXXX)"
 
   "$@" &
   local command_pid=$!
@@ -261,9 +261,9 @@ run_with_timeout() {
 }
 
 validate_repo() {
-  pnpm typecheck
-  pnpm lint
-  run_with_retries "$TEST_RETRIES" pnpm test
+  pnpm typecheck || return 1
+  pnpm lint || return 1
+  run_with_retries "$TEST_RETRIES" pnpm test || return 1
 }
 
 include_stage_path() {
@@ -325,7 +325,7 @@ stage_changed_files() {
     return 0
   fi
 
-  git add -- "${paths[@]}"
+  git add -A -- "${paths[@]}"
 }
 
 commit_current_changes() {
@@ -387,12 +387,23 @@ next_finding() {
   local index
   local finding_id
 
+  for ((index = 0; index < processed_findings_count; index += 1)); do
+    finding_id="${processed_findings[$index]}"
+    args+=(--exclude "$finding_id")
+  done
+
   for ((index = 0; index < failed_findings_count; index += 1)); do
     finding_id="${failed_findings[$index]}"
     args+=(--exclude "$finding_id")
   done
 
   node scripts/clawpatch-imported-queue.mjs "${args[@]}"
+}
+
+mark_finding_processed() {
+  local finding_id="$1"
+  processed_findings[$processed_findings_count]="$finding_id"
+  processed_findings_count=$((processed_findings_count + 1))
 }
 
 wait_for_review_or_repair() {
@@ -439,7 +450,10 @@ wait_for_review_or_repair() {
     echo "attempting RoboRev repair $repair_attempt/$ROBOREV_REPAIR_ATTEMPTS with $ROBOREV_FIX_AGENT for job $job_id"
     roborev fix --agent "$ROBOREV_FIX_AGENT" "$job_id"
 
-    validate_repo
+    if ! validate_repo; then
+      echo "validation failed after RoboRev repair for $review_sha" >&2
+      return 8
+    fi
 
     if [[ -n "$(source_status)" ]]; then
       commit_current_changes \
@@ -456,7 +470,15 @@ wait_for_review_or_repair() {
     fi
     review_sha="$new_sha"
 
-    clawpatch revalidate --finding "$finding_id" --json >/dev/null
+    local repair_result
+    local repair_outcome
+    repair_result="$(clawpatch revalidate --finding "$finding_id" --json)"
+    repair_outcome="$(printf '%s\n' "$repair_result" | json_field "parsed.outcome ?? 'unknown'")"
+    echo "post-RoboRev repair revalidate: $repair_outcome"
+    if [[ "$repair_outcome" != "fixed" ]]; then
+      echo "RoboRev repair left Clawpatch finding $finding_id in '$repair_outcome'" >&2
+      return 8
+    fi
   done
 }
 
@@ -469,6 +491,8 @@ require_command roborev
 require_clean_source_tree
 
 completed=0
+processed_findings=()
+processed_findings_count=0
 failed_findings=()
 failed_findings_count=0
 
@@ -495,6 +519,7 @@ while [[ "$completed" -lt "$MAX" ]]; do
   echo "pre-fix revalidate: $pre_outcome"
 
   if [[ "$pre_outcome" == "fixed" || "$pre_outcome" == "false-positive" || "$pre_outcome" == "wont-fix" ]]; then
+    mark_finding_processed "$finding_id"
     completed=$((completed + 1))
     continue
   fi
@@ -532,6 +557,7 @@ while [[ "$completed" -lt "$MAX" ]]; do
   if ! commit_current_changes \
     "Fix ${issue}: ${subject_title}" \
     "Clawpatch finding: ${finding_id}"; then
+    mark_finding_processed "$finding_id"
     completed=$((completed + 1))
     continue
   fi
@@ -542,6 +568,7 @@ while [[ "$completed" -lt "$MAX" ]]; do
     exit 8
   fi
 
+  mark_finding_processed "$finding_id"
   completed=$((completed + 1))
   echo "completed $finding_id"
 

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -487,7 +487,10 @@ while [[ "$completed" -lt "$MAX" ]]; do
     continue
   fi
 
-  wait_for_review_or_repair "$finding_id" "$issue"
+  if ! wait_for_review_or_repair "$finding_id" "$issue"; then
+    echo "RoboRev gate failed for $finding_id" >&2
+    exit 8
+  fi
 
   completed=$((completed + 1))
   echo "completed $finding_id"

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -373,15 +373,18 @@ handle_finding_failure() {
     exit 6
   fi
 
-  failed_findings+=("$finding_id")
+  failed_findings[$failed_findings_count]="$finding_id"
+  failed_findings_count=$((failed_findings_count + 1))
   return 0
 }
 
 next_finding() {
   local args=(next --plain --status "$STATUS")
+  local index
   local finding_id
 
-  for finding_id in "${failed_findings[@]}"; do
+  for ((index = 0; index < failed_findings_count; index += 1)); do
+    finding_id="${failed_findings[$index]}"
     args+=(--exclude "$finding_id")
   done
 
@@ -463,6 +466,7 @@ require_clean_source_tree
 
 completed=0
 failed_findings=()
+failed_findings_count=0
 
 while [[ "$completed" -lt "$MAX" ]]; do
   require_clean_source_tree

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -277,21 +277,35 @@ include_stage_path() {
   esac
 }
 
-stage_changed_files() {
-  local paths=()
+changed_source_paths() {
   local path
 
   while IFS= read -r -d '' path; do
     if include_stage_path "$path"; then
-      paths+=("$path")
+      printf '%s\0' "$path"
     fi
   done < <(git diff --name-only -z)
 
   while IFS= read -r -d '' path; do
     if include_stage_path "$path"; then
-      paths+=("$path")
+      printf '%s\0' "$path"
+    fi
+  done < <(git diff --cached --name-only -z)
+
+  while IFS= read -r -d '' path; do
+    if include_stage_path "$path"; then
+      printf '%s\0' "$path"
     fi
   done < <(git ls-files --others --exclude-standard -z)
+}
+
+stage_changed_files() {
+  local paths=()
+  local path
+
+  while IFS= read -r -d '' path; do
+    paths+=("$path")
+  done < <(changed_source_paths)
 
   if [[ "${#paths[@]}" -eq 0 ]]; then
     return 0
@@ -316,18 +330,22 @@ commit_current_changes() {
 
 stash_failed_work() {
   local finding_id="$1"
+  local paths=()
+  local path
 
   if [[ -z "$(source_status)" ]]; then
     return 0
   fi
 
-  git stash push -u -m "clawpatch-roborev failed ${finding_id}" -- \
-    . \
-    ':!/.agent' \
-    ':!/.agents' \
-    ':!/.claude' \
-    ':!/skills-lock.json' \
-    ':!packages/web/.vite'
+  while IFS= read -r -d '' path; do
+    paths+=("$path")
+  done < <(changed_source_paths)
+
+  if [[ "${#paths[@]}" -eq 0 ]]; then
+    return 0
+  fi
+
+  git stash push -u -m "clawpatch-roborev failed ${finding_id}" -- "${paths[@]}"
 }
 
 handle_finding_failure() {

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -340,7 +340,11 @@ handle_finding_failure() {
     exit 6
   fi
 
-  stash_failed_work "$finding_id"
+  if ! stash_failed_work "$finding_id"; then
+    echo "failed to stash failed work for $finding_id; stopping to avoid a contaminated worktree" >&2
+    exit 6
+  fi
+
   return 0
 }
 
@@ -366,6 +370,7 @@ wait_for_review_or_repair() {
 
     if [[ "$review_status" -eq 124 ]]; then
       echo "RoboRev review timed out for $review_sha after ${REVIEW_TIMEOUT_SECONDS}s" >&2
+      return 8
     fi
 
     echo "RoboRev found issues for $review_sha" >&2

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -488,6 +488,7 @@ while [[ "$completed" -lt "$MAX" ]]; do
   fi
 
   if ! wait_for_review_or_repair "$finding_id" "$issue"; then
+    # The fix commit is already on the branch; stashing cannot isolate this failure.
     echo "RoboRev gate failed for $finding_id" >&2
     exit 8
   fi

--- a/scripts/clawpatch-roborev-loop.sh
+++ b/scripts/clawpatch-roborev-loop.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX=1
+STATUS="open"
+TEST_RETRIES=1
+ROBOREV_REPAIR_ATTEMPTS=1
+ROBOREV_FIX_AGENT="codex"
+INTERVAL_SECONDS=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/clawpatch-roborev-loop.sh [flags]
+
+Fixes imported GitHub-backed Clawpatch findings one at a time, commits each
+fixed finding, and gates progress on a local RoboRev review.
+
+Flags:
+  --max <n>                       Maximum findings to attempt. Default: 1
+  --status <s>                    Queue status to process. Default: open
+  --test-retries <n>              Retries for pnpm test after a failure. Default: 1
+  --roborev-repair-attempts <n>   RoboRev fix attempts per finding. Default: 1
+  --no-roborev-repair             Alias for --roborev-repair-attempts 0
+  --roborev-fix-agent <agent>     Agent used to address RoboRev findings. Default: codex
+  --interval-seconds <n>          Sleep between findings. Default: 0
+  -h, --help                      Show this help
+
+The loop requires a clean source worktree at the start of every finding. It
+ignores local agent/runtime artifacts such as .agent, .agents, .claude, and
+packages/web/.vite when checking and staging changes.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --)
+      shift
+      ;;
+    --max)
+      MAX="${2:-}"
+      shift 2
+      ;;
+    --max=*)
+      MAX="${1#--max=}"
+      shift
+      ;;
+    --status)
+      STATUS="${2:-}"
+      shift 2
+      ;;
+    --status=*)
+      STATUS="${1#--status=}"
+      shift
+      ;;
+    --test-retries)
+      TEST_RETRIES="${2:-}"
+      shift 2
+      ;;
+    --test-retries=*)
+      TEST_RETRIES="${1#--test-retries=}"
+      shift
+      ;;
+    --roborev-repair-attempts)
+      ROBOREV_REPAIR_ATTEMPTS="${2:-}"
+      shift 2
+      ;;
+    --roborev-repair-attempts=*)
+      ROBOREV_REPAIR_ATTEMPTS="${1#--roborev-repair-attempts=}"
+      shift
+      ;;
+    --no-roborev-repair)
+      ROBOREV_REPAIR_ATTEMPTS=0
+      shift
+      ;;
+    --roborev-fix-agent)
+      ROBOREV_FIX_AGENT="${2:-}"
+      shift 2
+      ;;
+    --roborev-fix-agent=*)
+      ROBOREV_FIX_AGENT="${1#--roborev-fix-agent=}"
+      shift
+      ;;
+    --interval-seconds)
+      INTERVAL_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --interval-seconds=*)
+      INTERVAL_SECONDS="${1#--interval-seconds=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$MAX" =~ ^[0-9]+$ ]] || [[ "$MAX" -lt 1 ]]; then
+  echo "--max must be a positive integer" >&2
+  exit 2
+fi
+
+if ! [[ "$TEST_RETRIES" =~ ^[0-9]+$ ]]; then
+  echo "--test-retries must be a non-negative integer" >&2
+  exit 2
+fi
+
+if ! [[ "$ROBOREV_REPAIR_ATTEMPTS" =~ ^[0-9]+$ ]]; then
+  echo "--roborev-repair-attempts must be a non-negative integer" >&2
+  exit 2
+fi
+
+if ! [[ "$INTERVAL_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "--interval-seconds must be a non-negative integer" >&2
+  exit 2
+fi
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 127
+  fi
+}
+
+source_status() {
+  git status --porcelain -- \
+    ':!/.agent' \
+    ':!/.agents' \
+    ':!/.claude' \
+    ':!/skills-lock.json' \
+    ':!packages/web/.vite'
+}
+
+require_clean_source_tree() {
+  if [[ -n "$(source_status)" ]]; then
+    echo "source worktree is dirty; commit or stash first" >&2
+    source_status >&2
+    exit 3
+  fi
+}
+
+json_field() {
+  local expr="$1"
+  node -e "
+let s = '';
+process.stdin.on('data', d => s += d);
+process.stdin.on('end', () => {
+  const parsed = JSON.parse(s);
+  const value = (${expr});
+  if (value !== undefined && value !== null) console.log(value);
+});
+"
+}
+
+finding_title() {
+  local finding_id="$1"
+  clawpatch show --finding "$finding_id" --json \
+    | json_field "parsed.finding?.title ?? parsed.title ?? '$finding_id'"
+}
+
+review_job_id() {
+  local sha="$1"
+  roborev show --json "$sha" \
+    | json_field "parsed.job_id ?? parsed.id ?? parsed.job?.id"
+}
+
+run_with_retries() {
+  local retries="$1"
+  shift
+
+  local attempt=1
+  local max_attempts=$((retries + 1))
+
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+
+    if [[ "$attempt" -ge "$max_attempts" ]]; then
+      return 1
+    fi
+
+    attempt=$((attempt + 1))
+    echo "command failed; retrying ($attempt/$max_attempts): $*"
+  done
+}
+
+validate_repo() {
+  pnpm typecheck
+  pnpm lint
+  run_with_retries "$TEST_RETRIES" pnpm test
+}
+
+include_stage_path() {
+  case "$1" in
+    .agent|.agent/*|.agents|.agents/*|.claude|.claude/*|skills-lock.json|packages/web/.vite|packages/web/.vite/*)
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+stage_changed_files() {
+  local paths=()
+  local path
+
+  while IFS= read -r -d '' path; do
+    if include_stage_path "$path"; then
+      paths+=("$path")
+    fi
+  done < <(git diff --name-only -z)
+
+  while IFS= read -r -d '' path; do
+    if include_stage_path "$path"; then
+      paths+=("$path")
+    fi
+  done < <(git ls-files --others --exclude-standard -z)
+
+  if [[ "${#paths[@]}" -eq 0 ]]; then
+    return 0
+  fi
+
+  git add -- "${paths[@]}"
+}
+
+commit_current_changes() {
+  local subject="$1"
+  local body="$2"
+
+  stage_changed_files
+
+  if git diff --cached --quiet; then
+    echo "no source changes staged"
+    return 1
+  fi
+
+  git commit -m "$subject" -m "$body"
+}
+
+wait_for_review_or_repair() {
+  local finding_id="$1"
+  local issue="$2"
+  local review_sha
+  review_sha="$(git rev-parse HEAD)"
+
+  local repair_attempt=0
+  while true; do
+    echo "waiting for RoboRev review of $review_sha"
+
+    set +e
+    roborev wait "$review_sha"
+    local review_status=$?
+    set -e
+
+    if [[ "$review_status" -eq 0 ]]; then
+      roborev show "$review_sha"
+      return 0
+    fi
+
+    echo "RoboRev found issues for $review_sha" >&2
+    roborev show "$review_sha" >&2 || true
+
+    if [[ "$repair_attempt" -ge "$ROBOREV_REPAIR_ATTEMPTS" ]]; then
+      echo "stopping after RoboRev failure; repair attempts exhausted" >&2
+      return 8
+    fi
+
+    repair_attempt=$((repair_attempt + 1))
+    local job_id
+    job_id="$(review_job_id "$review_sha")"
+    if [[ -z "$job_id" ]]; then
+      echo "could not determine RoboRev job id for $review_sha" >&2
+      return 8
+    fi
+
+    echo "attempting RoboRev repair $repair_attempt/$ROBOREV_REPAIR_ATTEMPTS with $ROBOREV_FIX_AGENT for job $job_id"
+    roborev fix --agent "$ROBOREV_FIX_AGENT" "$job_id"
+
+    validate_repo
+
+    if [[ -n "$(source_status)" ]]; then
+      commit_current_changes \
+        "Address RoboRev feedback for ${issue}" \
+        "RoboRev review for: ${review_sha}" \
+        || true
+    fi
+
+    local new_sha
+    new_sha="$(git rev-parse HEAD)"
+    if [[ "$new_sha" == "$review_sha" ]]; then
+      echo "RoboRev repair did not create a new commit" >&2
+      return 8
+    fi
+    review_sha="$new_sha"
+
+    clawpatch revalidate --finding "$finding_id" --json >/dev/null
+  done
+}
+
+require_command clawpatch
+require_command git
+require_command node
+require_command pnpm
+require_command roborev
+
+require_clean_source_tree
+
+completed=0
+
+while [[ "$completed" -lt "$MAX" ]]; do
+  require_clean_source_tree
+
+  if ! finding_id="$(node scripts/clawpatch-imported-queue.mjs next --plain --status "$STATUS")"; then
+    echo "no imported GitHub issue findings with status '$STATUS'"
+    break
+  fi
+
+  title="$(finding_title "$finding_id")"
+  issue="$(printf '%s\n' "$title" | sed -nE 's/^(gh#[0-9]+):.*/\1/p')"
+  if [[ -z "$issue" ]]; then
+    issue="$finding_id"
+  fi
+  subject_title="$(printf '%s\n' "$title" | sed -E 's/^gh#[0-9]+:[[:space:]]*//')"
+
+  echo "[$((completed + 1))/$MAX] selected $finding_id"
+  echo "$title"
+
+  pre_result="$(clawpatch revalidate --finding "$finding_id" --json)"
+  pre_outcome="$(printf '%s\n' "$pre_result" | json_field "parsed.outcome ?? 'unknown'")"
+  echo "pre-fix revalidate: $pre_outcome"
+
+  if [[ "$pre_outcome" == "fixed" || "$pre_outcome" == "false-positive" || "$pre_outcome" == "wont-fix" ]]; then
+    completed=$((completed + 1))
+    continue
+  fi
+
+  if [[ "$pre_outcome" != "open" ]]; then
+    echo "stopping because revalidation returned '$pre_outcome' for $finding_id" >&2
+    exit 6
+  fi
+
+  set +e
+  clawpatch fix --finding "$finding_id" --json
+  fix_status=$?
+  set -e
+  if [[ "$fix_status" -ne 0 ]]; then
+    echo "clawpatch fix exited $fix_status; continuing only if revalidation and local checks pass"
+  fi
+
+  post_result="$(clawpatch revalidate --finding "$finding_id" --json)"
+  post_outcome="$(printf '%s\n' "$post_result" | json_field "parsed.outcome ?? 'unknown'")"
+  echo "post-fix revalidate: $post_outcome"
+
+  if [[ "$post_outcome" != "fixed" ]]; then
+    echo "stopping because finding did not revalidate as fixed: $finding_id => $post_outcome" >&2
+    exit 6
+  fi
+
+  validate_repo
+
+  if ! commit_current_changes \
+    "Fix ${issue}: ${subject_title}" \
+    "Clawpatch finding: ${finding_id}"; then
+    completed=$((completed + 1))
+    continue
+  fi
+
+  wait_for_review_or_repair "$finding_id" "$issue"
+
+  completed=$((completed + 1))
+  echo "completed $finding_id"
+
+  if [[ "$completed" -lt "$MAX" && "$INTERVAL_SECONDS" -gt 0 ]]; then
+    sleep "$INTERVAL_SECONDS"
+  fi
+done
+
+echo "finished: completed $completed finding(s)"


### PR DESCRIPTION
## Summary
- Configure local RoboRev reviews with Claude Code.
- Add the Clawpatch + RoboRev batch loop script and package command.
- Harden failed finding handling, failed stash preservation, Bash 3.2 compatibility, and review gate failure behavior.

## Validation
- bash -n scripts/clawpatch-roborev-loop.sh
- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"