### PR TITLE
[codex] Frontend composer and login fixes

### DIFF
--- a/.clawpatch/features/feat_gh-21_03053befbe.json
+++ b/.clawpatch/features/feat_gh-21_03053befbe.json
@@ -1,1 +1,78 @@
-{"schemaVersion":1,"featureId":"feat_gh-21_03053befbe","title":"gh#21: Bug: MediaStatusPoller never updates parent state after transcode completes","summary":"Imported from GitHub issue gh#21 in BACKLOG.md section \"Bugs\".","kind":"ui-flow","source":"github-issue-import","confidence":"high","entrypoints":[{"path":"packages/web/src/components/posts/MediaThumbnailGrid.tsx","symbol":null,"route":null,"command":null},{"path":"packages/web/src/pages/posts/NewPostPage.tsx","symbol":null,"route":null,"command":null},{"path":"packages/web/src/pages/posts/EditPostPage.tsx","symbol":null,"route":null,"command":null}],"ownedFiles":[{"path":"packages/web/src/components/posts/MediaThumbnailGrid.tsx","reason":"mentioned by issue at packages/web/src/components/posts/MediaThumbnailGrid.tsx:86"},{"path":"packages/web/src/pages/posts/NewPostPage.tsx","reason":"mentioned by issue body"},{"path":"packages/web/src/pages/posts/EditPostPage.tsx","reason":"mentioned by issue body"}],"contextFiles":[{"path":"BACKLOG.md","reason":"backlog queue item for gh#21"}],"tests":[],"tags":["github-issue","gh#21","github-url:https://github.com/joshgk00/social-media-scheduler/issues/21","backlog-order:0028","backlog-section:bugs"],"trustBoundaries":["filesystem"],"status":"needs-fix","lock":null,"findingIds":["fnd_sig-gh-21-fc4009ae73_5487ff0602"],"patchAttemptIds":[],"analysisHistory":[{"runId":"20260519T201935-c24f6a","kind":"github-issue-import","summary":"Imported GitHub issue gh#21","provider":"gh","model":null,"createdAt":"2026-05-19T20:19:35.980Z"}],"createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-21_03053befbe",
+  "title": "gh#21: Bug: MediaStatusPoller never updates parent state after transcode completes",
+  "summary": "Imported from GitHub issue gh#21 in BACKLOG.md section \"Bugs\".",
+  "kind": "ui-flow",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/web/src/components/posts/MediaThumbnailGrid.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/web/src/pages/posts/NewPostPage.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/web/src/pages/posts/EditPostPage.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/web/src/components/posts/MediaThumbnailGrid.tsx",
+      "reason": "mentioned by issue at packages/web/src/components/posts/MediaThumbnailGrid.tsx:86"
+    },
+    {
+      "path": "packages/web/src/pages/posts/NewPostPage.tsx",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/web/src/pages/posts/EditPostPage.tsx",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#21"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#21",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/21",
+    "backlog-order:0028",
+    "backlog-section:bugs"
+  ],
+  "trustBoundaries": [
+    "filesystem"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-21-fc4009ae73_5487ff0602"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260519T201935-c24f6a",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#21",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-19T20:19:35.980Z"
+    }
+  ],
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-20T22:26:26.938Z"
+}

--- a/.clawpatch/features/feat_gh-34_ae664d7f2e.json
+++ b/.clawpatch/features/feat_gh-34_ae664d7f2e.json
@@ -1,1 +1,71 @@
-{"schemaVersion":1,"featureId":"feat_gh-34_ae664d7f2e","title":"gh#34: Bug: Auto-destruct help copy hardcoded to \"Twitter/X\" on LinkedIn and Facebook composer forms","summary":"Imported from GitHub issue gh#34 in BACKLOG.md section \"Bugs\".","kind":"infra","source":"github-issue-import","confidence":"high","entrypoints":[{"path":"packages/web/src/components/posts/SharedPostFields.tsx","symbol":null,"route":null,"command":null},{"path":"packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx","symbol":null,"route":null,"command":null}],"ownedFiles":[{"path":"packages/web/src/components/posts/SharedPostFields.tsx","reason":"mentioned by issue body"},{"path":"packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx","reason":"mentioned by issue body"}],"contextFiles":[{"path":"BACKLOG.md","reason":"backlog queue item for gh#34"}],"tests":[],"tags":["github-issue","gh#34","github-url:https://github.com/joshgk00/social-media-scheduler/issues/34","backlog-order:0026","backlog-section:bugs","label:bug"],"trustBoundaries":["filesystem","concurrency","external-api"],"status":"needs-fix","lock":null,"findingIds":["fnd_sig-gh-34-f319aead5b_f2344b158d"],"patchAttemptIds":[],"analysisHistory":[{"runId":"20260519T201935-c24f6a","kind":"github-issue-import","summary":"Imported GitHub issue gh#34","provider":"gh","model":null,"createdAt":"2026-05-19T20:19:35.980Z"}],"createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-34_ae664d7f2e",
+  "title": "gh#34: Bug: Auto-destruct help copy hardcoded to \"Twitter/X\" on LinkedIn and Facebook composer forms",
+  "summary": "Imported from GitHub issue gh#34 in BACKLOG.md section \"Bugs\".",
+  "kind": "infra",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/web/src/components/posts/SharedPostFields.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/web/src/components/posts/SharedPostFields.tsx",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#34"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#34",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/34",
+    "backlog-order:0026",
+    "backlog-section:bugs",
+    "label:bug"
+  ],
+  "trustBoundaries": [
+    "filesystem",
+    "concurrency",
+    "external-api"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-34-f319aead5b_f2344b158d"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260519T201935-c24f6a",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#34",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-19T20:19:35.980Z"
+    }
+  ],
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-20T22:37:03.646Z"
+}

--- a/.clawpatch/features/feat_library_1234e9e402.json
+++ b/.clawpatch/features/feat_library_1234e9e402.json
@@ -1,1 +1,56 @@
-{"schemaVersion":1,"featureId":"feat_library_1234e9e402","title":"Node source packages/web/src/pages/login","summary":"Node/TypeScript source file packages/web/src/pages/login/LoginPage.tsx.","kind":"library","source":"node-source-group","confidence":"medium","entrypoints":[{"path":"packages/web/package.json","symbol":"packages/web/src/pages/login","route":null,"command":null}],"ownedFiles":[{"path":"packages/web/src/pages/login/LoginPage.tsx","reason":"source group packages/web/src/pages/login"}],"contextFiles":[{"path":"packages/web/package.json","reason":"package manifest"}],"tests":[],"tags":["node","typescript","source-group","project:@sms/web","project-root:packages/web"],"trustBoundaries":[],"status":"needs-fix","lock":null,"findingIds":["fnd_sig-feat-library-1234e9e402-f2c6_2151d4af4e"],"patchAttemptIds":[],"analysisHistory":[{"runId":"20260518T230011-245d4c","kind":"review","summary":"1 finding(s)","provider":"codex","model":null,"createdAt":"2026-05-18T23:00:31.225Z"}],"createdAt":"2026-05-18T23:00:06.938Z","updatedAt":"2026-05-18T23:00:31.225Z"}
+{
+  "schemaVersion": 1,
+  "featureId": "feat_library_1234e9e402",
+  "title": "Node source packages/web/src/pages/login",
+  "summary": "Node/TypeScript source file packages/web/src/pages/login/LoginPage.tsx.",
+  "kind": "library",
+  "source": "node-source-group",
+  "confidence": "medium",
+  "entrypoints": [
+    {
+      "path": "packages/web/package.json",
+      "symbol": "packages/web/src/pages/login",
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/web/src/pages/login/LoginPage.tsx",
+      "reason": "source group packages/web/src/pages/login"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "packages/web/package.json",
+      "reason": "package manifest"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "node",
+    "typescript",
+    "source-group",
+    "project:@sms/web",
+    "project-root:packages/web"
+  ],
+  "trustBoundaries": [],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-feat-library-1234e9e402-f2c6_2151d4af4e"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260518T230011-245d4c",
+      "kind": "review",
+      "summary": "1 finding(s)",
+      "provider": "codex",
+      "model": null,
+      "createdAt": "2026-05-18T23:00:31.225Z"
+    }
+  ],
+  "createdAt": "2026-05-18T23:00:06.938Z",
+  "updatedAt": "2026-05-20T21:44:04.390Z"
+}

--- a/.clawpatch/findings/fnd_sig-feat-library-1234e9e402-f2c6_2151d4af4e.json
+++ b/.clawpatch/findings/fnd_sig-feat-library-1234e9e402-f2c6_2151d4af4e.json
@@ -1,1 +1,105 @@
-{"schemaVersion":1,"findingId":"fnd_sig-feat-library-1234e9e402-f2c6_2151d4af4e","featureId":"feat_library_1234e9e402","title":"TOTP timeout can expire a fresh second 2FA challenge immediately after re-entering the TOTP step","category":"bug","severity":"medium","confidence":"high","triage":"confirmed-bug","evidence":[{"path":"packages/web/src/pages/login/LoginPage.tsx","startLine":57,"endLine":75,"symbol":"LoginPage","quote":"if (step !== 'totp') return;\n\n    setCountdown(TOTP_TIMEOUT_SECONDS);\n\n    const interval = setInterval(() => {\n      setCountdown((prev) => {\n        if (prev <= 1) {\n          clearInterval(interval);\n          setStep('credentials');"},{"path":"packages/web/src/pages/login/LoginPage.tsx","startLine":92,"endLine":94,"symbol":"onCredentialsSubmit","quote":"if (result.requiresTwoFactor) {\n        setStep('totp');\n      }"},{"path":"packages/web/src/pages/login/LoginPage.tsx","startLine":124,"endLine":128,"symbol":"handleBackToLogin","quote":"function handleBackToLogin() {\n    setStep('credentials');\n    setTotpError(null);\n    totpForm.reset();\n  }"}],"reasoning":"The countdown effect only restarts when the `step` dependency changes. When the user leaves the TOTP step, the countdown state is left at its previous value, including 0 after timeout. If the user is returned to credentials and submits credentials again before React has run the new TOTP effect's `setCountdown(300)` update, the rendered TOTP form is active with `countdown` still 0. The interval callback then treats the fresh challenge as expired and sends the user back to credentials. The same stale countdown can also be visible after using Back to login and re-entering TOTP because `handleBackToLogin` does not reset it.","reproduction":"Let the TOTP countdown reach 0 so the page returns to credentials, then immediately sign in again with credentials that require 2FA. The fresh TOTP step can render `Code expires in 0:00` and the interval path can expire it instead of giving a new 5-minute window.","recommendation":"Reset `countdown` synchronously when entering or leaving the TOTP flow, for example in `onCredentialsSubmit` before `setStep('totp')` and in `handleBackToLogin`, or model the expiry as an absolute timestamp created per challenge rather than relying on retained countdown state.","whyTestsDoNotAlreadyCoverThis":"No linked tests were provided for this feature, and the owned file has no evidence of timer or step-transition coverage.","suggestedRegressionTest":"Add a LoginPage test with fake timers: reach the TOTP step, advance the timer to expiry, submit credentials again for a 2FA-required login, and assert the TOTP page shows `Code expires in 5:00` and does not immediately navigate back to credentials.","minimumFixScope":"packages/web/src/pages/login/LoginPage.tsx","status":"open","history":[],"signature":"sig_feat-library-1234e9e402_f2c6061bf5","linkedPatchAttemptIds":[],"createdByRunId":"20260518T230011-245d4c","createdAt":"2026-05-18T23:00:31.224Z","updatedAt":"2026-05-18T23:00:31.224Z"}
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-feat-library-1234e9e402-f2c6_2151d4af4e",
+  "featureId": "feat_library_1234e9e402",
+  "title": "TOTP timeout can expire a fresh second 2FA challenge immediately after re-entering the TOTP step",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "packages/web/src/pages/login/LoginPage.tsx",
+      "startLine": 57,
+      "endLine": 75,
+      "symbol": "LoginPage",
+      "quote": "if (step !== 'totp') return;\n\n    setCountdown(TOTP_TIMEOUT_SECONDS);\n\n    const interval = setInterval(() => {\n      setCountdown((prev) => {\n        if (prev <= 1) {\n          clearInterval(interval);\n          setStep('credentials');"
+    },
+    {
+      "path": "packages/web/src/pages/login/LoginPage.tsx",
+      "startLine": 92,
+      "endLine": 94,
+      "symbol": "onCredentialsSubmit",
+      "quote": "if (result.requiresTwoFactor) {\n        setStep('totp');\n      }"
+    },
+    {
+      "path": "packages/web/src/pages/login/LoginPage.tsx",
+      "startLine": 124,
+      "endLine": 128,
+      "symbol": "handleBackToLogin",
+      "quote": "function handleBackToLogin() {\n    setStep('credentials');\n    setTotpError(null);\n    totpForm.reset();\n  }"
+    }
+  ],
+  "reasoning": "The countdown effect only restarts when the `step` dependency changes. When the user leaves the TOTP step, the countdown state is left at its previous value, including 0 after timeout. If the user is returned to credentials and submits credentials again before React has run the new TOTP effect's `setCountdown(300)` update, the rendered TOTP form is active with `countdown` still 0. The interval callback then treats the fresh challenge as expired and sends the user back to credentials. The same stale countdown can also be visible after using Back to login and re-entering TOTP because `handleBackToLogin` does not reset it.",
+  "reproduction": "Let the TOTP countdown reach 0 so the page returns to credentials, then immediately sign in again with credentials that require 2FA. The fresh TOTP step can render `Code expires in 0:00` and the interval path can expire it instead of giving a new 5-minute window.",
+  "recommendation": "Reset `countdown` synchronously when entering or leaving the TOTP flow, for example in `onCredentialsSubmit` before `setStep('totp')` and in `handleBackToLogin`, or model the expiry as an absolute timestamp created per challenge rather than relying on retained countdown state.",
+  "whyTestsDoNotAlreadyCoverThis": "No linked tests were provided for this feature, and the owned file has no evidence of timer or step-transition coverage.",
+  "suggestedRegressionTest": "Add a LoginPage test with fake timers: reach the TOTP step, advance the timer to expiry, submit credentials again for a 2FA-required login, and assert the TOTP page shows `Code expires in 5:00` and does not immediately navigate back to credentials.",
+  "minimumFixScope": "packages/web/src/pages/login/LoginPage.tsx",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260520T213731-eaa91d",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence still exists in packages/web/src/pages/login/LoginPage.tsx at the same effective locations: the TOTP effect resets countdown only after step becomes 'totp' (lines 60-80), onCredentialsSubmit still only calls setStep('totp') for 2FA (lines 94-100), and handleBackToLogin still leaves countdown untouched (lines 135-139). The rendered TOTP footer still reads Code expires in {formatCountdown(countdown)} (line 291), so re-entering the TOTP step can still render retained stale countdown state before the effect reset. I found no LoginPage/TOTP regression test. The normal web typecheck was blocked by read-only tsbuildinfo writes, but rerunning the app and node TypeScript projects with --incremental false passed.",
+      "commands": [
+        "sed -n '1,220p' packages/web/src/pages/login/LoginPage.tsx",
+        "rg -n \"TOTP_TIMEOUT_SECONDS|requiresTwoFactor|handleBackToLogin|Code expires|totp\" packages/web/src packages/web/tests packages/web -g '*.{ts,tsx}'",
+        "rg --files packages/web | rg '(LoginPage|login|auth).*\\.(test|spec)\\.(ts|tsx)$|test'",
+        "sed -n '220,330p' packages/web/src/pages/login/LoginPage.tsx",
+        "cat packages/web/package.json",
+        "sed -n '1,220p' packages/web/src/__tests__/setup.ts",
+        "rg -n \"vi\\.useFakeTimers|advanceTimers|react-router|MemoryRouter|QueryClientProvider|render\\(\" packages/web/src -g '*.{test,spec}.tsx'",
+        "ls",
+        "rg -n \"@sms/web|packageManager|pnpm|npm|yarn|vitest\" package.json pnpm-workspace.yaml package-lock.json pnpm-lock.yaml yarn.lock 2>/dev/null",
+        "nl -ba packages/web/src/pages/login/LoginPage.tsx | sed -n '55,145p'",
+        "pnpm --filter @sms/web typecheck",
+        "cat packages/web/tsconfig.json",
+        "cat packages/web/tsconfig.app.json",
+        "cat packages/web/tsconfig.node.json",
+        "cat package.json",
+        "pnpm --filter @sms/web exec tsc -p tsconfig.app.json --noEmit --incremental false",
+        "pnpm --filter @sms/web exec tsc -p tsconfig.node.json --noEmit --incremental false"
+      ],
+      "createdAt": "2026-05-20T21:39:05.234Z"
+    },
+    {
+      "runId": "20260520T214232-c4052f",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original file path still exists, but the relevant code has changed in the current repository. In packages/web/src/pages/login/LoginPage.tsx, onCredentialsSubmit now resets countdown to TOTP_TIMEOUT_SECONDS before setStep('totp'), handleBackToLogin now resets countdown before returning to credentials, and the session-expired TOTP error path also resets countdown. The interval expiry path now returns TOTP_TIMEOUT_SECONDS instead of leaving countdown at 0. A regression test now exists at packages/web/src/pages/login/__tests__/LoginPage.test.tsx that advances fake timers through a full TOTP expiry, submits credentials again, asserts 'Code expires in 5:00', advances one second, and asserts the TOTP screen remains with 'Code expires in 4:59'. The targeted Vitest run could not complete in this read-only sandbox because Vite/Vitest attempted to write temp files, but both web TypeScript project checks passed with --incremental false.",
+      "commands": [
+        "nl -ba packages/web/src/pages/login/LoginPage.tsx | sed -n '1,180p'",
+        "nl -ba packages/web/src/pages/login/LoginPage.tsx | sed -n '180,340p'",
+        "rg -n \"TOTP_TIMEOUT_SECONDS|requiresTwoFactor|handleBackToLogin|setCountdown|Code expires|formatCountdown|totp\" packages/web/src packages/web/tests packages/web -g '*.{ts,tsx}'",
+        "nl -ba packages/web/src/pages/login/__tests__/LoginPage.test.tsx | sed -n '1,180p'",
+        "cat packages/web/package.json",
+        "cat package.json",
+        "rg -n \"LoginPage.test|Code expires in 5:00|useFakeTimers|advanceTimers\" packages/web/src -g '*.{test,spec}.{ts,tsx}'",
+        "pnpm --filter @sms/web exec vitest run src/pages/login/__tests__/LoginPage.test.tsx",
+        "pnpm --filter @sms/web exec tsc -p tsconfig.app.json --noEmit --incremental false",
+        "pnpm --filter @sms/web exec tsc -p tsconfig.node.json --noEmit --incremental false",
+        "pnpm --filter @sms/web exec vitest --help | sed -n '1,160p'",
+        "pnpm --filter @sms/web exec vitest run src/pages/login/__tests__/LoginPage.test.tsx --configLoader runner",
+        "pnpm --filter @sms/web exec vitest run src/pages/login/__tests__/LoginPage.test.tsx --configLoader native",
+        "nl -ba packages/web/vitest.config.ts | sed -n '1,120p'",
+        "rg -n \"vite-temp|cacheDir|loadConfigFromBundledFile|VITE_.*TEMP|TEMP\" node_modules/.pnpm/vite@*/node_modules/vite/dist/node/chunks/node.js | sed -n '1,120p'",
+        "sed -n '34640,34710p' node_modules/.pnpm/vite@*/node_modules/vite/dist/node/chunks/node.js",
+        "pnpm --filter @sms/web exec vitest run --help --expand-help | rg -n \"alias|setup|environment|config\" | sed -n '1,160p'",
+        "node --input-type=module -e \"globalThis.__dirname='x'; console.log(__dirname)\"",
+        "NODE_OPTIONS=\"--import=data:text/javascript,globalThis.__dirname%3D%27%2FUsers%2Fslaughterassistant%2Fsocial-media-scheduler%2Fpackages%2Fweb%27\" pnpm --filter @sms/web exec vitest run src/pages/login/__tests__/LoginPage.test.tsx --configLoader runner"
+      ],
+      "createdAt": "2026-05-20T21:44:04.338Z"
+    }
+  ],
+  "signature": "sig_feat-library-1234e9e402_f2c6061bf5",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-feat-library-1234e9e402-_990934f096"
+  ],
+  "createdByRunId": "20260518T230011-245d4c",
+  "createdAt": "2026-05-18T23:00:31.224Z",
+  "updatedAt": "2026-05-20T21:44:04.338Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-21-fc4009ae73_5487ff0602.json
+++ b/.clawpatch/findings/fnd_sig-gh-21-fc4009ae73_5487ff0602.json
@@ -1,1 +1,93 @@
-{"schemaVersion":1,"findingId":"fnd_sig-gh-21-fc4009ae73_5487ff0602","featureId":"feat_gh-21_03053befbe","title":"gh#21: Bug: MediaStatusPoller never updates parent state after transcode completes","category":"bug","severity":"medium","confidence":"high","triage":"confirmed-bug","evidence":[{"path":"packages/web/src/components/posts/MediaThumbnailGrid.tsx","startLine":86,"endLine":127,"symbol":null,"quote":null},{"path":"packages/web/src/pages/posts/NewPostPage.tsx","startLine":null,"endLine":null,"symbol":null,"quote":null},{"path":"packages/web/src/pages/posts/EditPostPage.tsx","startLine":null,"endLine":null,"symbol":null,"quote":null}],"reasoning":"Imported from https://github.com/joshgk00/social-media-scheduler/issues/21.\nBacklog section: Bugs.\n\n## Problem\n\nMediaStatusPoller in MediaThumbnailGrid.tsx fires useMediaStatus queries that populate the TanStack Query cache, but handleStatusUpdate is an empty no-op. The parent's mediaItems state holds transcodeStatus as a snapshot from upload time — it never updates when transcoding completes or fails. The submit button stays permanently disabled with \"Video is still transcoding.\"\n\n## Identified by\n\nCode quality review Run 3 — web comprehensive review (H-1)\n\n## Fix\n\nEither propagate handleStatusUpdate to call setMediaItems in the parent, or have MediaThumbnailGrid read transcode status directly from the TanStack Query cache and merge with props-based mediaItems.\n\n## Files\n\n- `packages/web/src/components/posts/MediaThumbnailGrid.tsx:86-127`\n- `packages/web/src/pages/posts/NewPostPage.tsx`\n- `packages/web/src/pages/posts/EditPostPage.tsx`","reproduction":"MediaStatusPoller in MediaThumbnailGrid.tsx fires useMediaStatus queries that populate the TanStack Query cache, but handleStatusUpdate is an empty no-op. The parent's mediaItems state holds transcodeStatus as a snapshot from upload time — it never updates when transcoding completes or fails. The submit button stays permanently disabled with \"Video is still transcoding.\"","recommendation":"Either propagate handleStatusUpdate to call setMediaItems in the parent, or have MediaThumbnailGrid read transcode status directly from the TanStack Query cache and merge with props-based mediaItems.","whyTestsDoNotAlreadyCoverThis":"Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.","suggestedRegressionTest":null,"minimumFixScope":"packages/web/src/components/posts/MediaThumbnailGrid.tsx, packages/web/src/pages/posts/NewPostPage.tsx, packages/web/src/pages/posts/EditPostPage.tsx","status":"open","history":[],"signature":"sig_gh-21_fc4009ae73","linkedPatchAttemptIds":[],"createdByRunId":"20260519T201935-c24f6a","createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-21-fc4009ae73_5487ff0602",
+  "featureId": "feat_gh-21_03053befbe",
+  "title": "gh#21: Bug: MediaStatusPoller never updates parent state after transcode completes",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "packages/web/src/components/posts/MediaThumbnailGrid.tsx",
+      "startLine": 86,
+      "endLine": 127,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/web/src/pages/posts/NewPostPage.tsx",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/web/src/pages/posts/EditPostPage.tsx",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/21.\nBacklog section: Bugs.\n\n## Problem\n\nMediaStatusPoller in MediaThumbnailGrid.tsx fires useMediaStatus queries that populate the TanStack Query cache, but handleStatusUpdate is an empty no-op. The parent's mediaItems state holds transcodeStatus as a snapshot from upload time — it never updates when transcoding completes or fails. The submit button stays permanently disabled with \"Video is still transcoding.\"\n\n## Identified by\n\nCode quality review Run 3 — web comprehensive review (H-1)\n\n## Fix\n\nEither propagate handleStatusUpdate to call setMediaItems in the parent, or have MediaThumbnailGrid read transcode status directly from the TanStack Query cache and merge with props-based mediaItems.\n\n## Files\n\n- `packages/web/src/components/posts/MediaThumbnailGrid.tsx:86-127`\n- `packages/web/src/pages/posts/NewPostPage.tsx`\n- `packages/web/src/pages/posts/EditPostPage.tsx`",
+  "reproduction": "MediaStatusPoller in MediaThumbnailGrid.tsx fires useMediaStatus queries that populate the TanStack Query cache, but handleStatusUpdate is an empty no-op. The parent's mediaItems state holds transcodeStatus as a snapshot from upload time — it never updates when transcoding completes or fails. The submit button stays permanently disabled with \"Video is still transcoding.\"",
+  "recommendation": "Either propagate handleStatusUpdate to call setMediaItems in the parent, or have MediaThumbnailGrid read transcode status directly from the TanStack Query cache and merge with props-based mediaItems.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/web/src/components/posts/MediaThumbnailGrid.tsx, packages/web/src/pages/posts/NewPostPage.tsx, packages/web/src/pages/posts/EditPostPage.tsx",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260520T221712-13a2b3",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence path still exists and the issue remains present. In packages/web/src/components/posts/MediaThumbnailGrid.tsx, MediaStatusPoller still calls onStatusUpdate when useMediaStatus returns data, but handleStatusUpdate at lines 120-127 is still a no-op. The grid continues polling only for mediaItems whose prop snapshot is pending/processing, while NewPostPage and EditPostPage still keep mediaItems in local state and derive hasTranscodingMedia/isMediaBlocking from that state. The platform field components pass mediaItems into MediaThumbnailGrid but expose no status-update callback back to setMediaItems. Therefore a completed/failed transcode in the query cache still does not update the parent state that controls the submit disabled reason. I attempted the relevant web test command, but it could not start under the read-only sandbox because Vitest/Vite tried to write packages/web/node_modules/.vite-temp.",
+      "commands": [
+        "sed -n '1,220p' packages/web/src/components/posts/MediaThumbnailGrid.tsx",
+        "sed -n '1,260p' packages/web/src/pages/posts/NewPostPage.tsx",
+        "sed -n '1,320p' packages/web/src/pages/posts/EditPostPage.tsx",
+        "rg -n \"MediaStatusPoller|handleStatusUpdate|useMediaStatus|transcodeStatus|Video is still transcoding|setMediaItems|mediaItems\" packages/web/src",
+        "sed -n '250,560p' packages/web/src/pages/posts/NewPostPage.tsx",
+        "sed -n '390,640p' packages/web/src/pages/posts/EditPostPage.tsx",
+        "sed -n '1,180p' packages/web/src/hooks/use-media.ts",
+        "rg -n \"MediaThumbnailGrid|onStatusUpdate|handleStatusUpdate|transcodeStatus\" packages/web/src --glob '*test*' --glob '*spec*'",
+        "pnpm --filter @sms/web test -- --run use-media",
+        "nl -ba packages/web/src/components/posts/MediaThumbnailGrid.tsx | sed -n '80,160p'",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '90,140p;250,275p;460,545p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '82,170p;224,235p;540,620p'"
+      ],
+      "createdAt": "2026-05-20T22:18:03.919Z"
+    },
+    {
+      "runId": "20260520T222534-58437d",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence path still exists, but the current code no longer has the reported no-op. MediaThumbnailGrid.tsx now accepts onStatusUpdate, MediaStatusPoller invokes it when useMediaStatus returns data, and handleStatusUpdate forwards the status/error instead of doing nothing. NewPostPage.tsx and EditPostPage.tsx now define handleMediaStatusUpdate callbacks that call setMediaItems to update the matching media item's transcodeStatus/transcodeError, and Twitter/Facebook/LinkedIn field components pass that callback through to MediaThumbnailGrid. The submit-disabled logic still derives from mediaItems, so the parent state now changes when polling reports completed/failed status. A focused regression test exists in NewPostPage.test.tsx asserting scheduling is reenabled after a completed transcode callback. I attempted to run the relevant Vitest tests, but both test commands failed at startup because the read-only sandbox prevented Vite from writing packages/web/node_modules/.vite-temp config cache files.",
+      "commands": [
+        "pwd && git status --short",
+        "nl -ba packages/web/src/components/posts/MediaThumbnailGrid.tsx | sed -n '1,220p'",
+        "rg -n \"MediaStatusPoller|handleStatusUpdate|onStatusUpdate|useMediaStatus|transcodeStatus|Video is still transcoding|MediaThumbnailGrid|setMediaItems|hasTranscodingMedia|isMediaBlocking\" packages/web/src",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '80,260p;270,390p;520,620p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '80,270p;460,505p;570,660p'",
+        "nl -ba packages/web/src/components/posts/TwitterPostFields.tsx | sed -n '1,150p' && nl -ba packages/web/src/components/posts/FacebookPostFields.tsx | sed -n '1,130p' && nl -ba packages/web/src/components/posts/LinkedInPostFields.tsx | sed -n '1,110p'",
+        "nl -ba packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx | sed -n '160,260p'",
+        "nl -ba packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx | sed -n '1,170p'",
+        "nl -ba packages/web/src/hooks/use-media.ts | sed -n '1,140p'",
+        "rg -n \"onMediaStatusUpdate|onStatusUpdate=|handleMediaStatusUpdate|reenables scheduling|completed transcode|MediaThumbnailGrid\" packages/web/src/pages/posts/__tests__ packages/web/src/components/posts --glob '*test*' --glob '*spec*'",
+        "pnpm --filter @sms/web test -- --run NewPostPage",
+        "pnpm --filter @sms/web test -- --run use-media"
+      ],
+      "createdAt": "2026-05-20T22:26:26.890Z"
+    }
+  ],
+  "signature": "sig_gh-21_fc4009ae73",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-21-fc4009ae73-5487ff0_b7501caf17"
+  ],
+  "createdByRunId": "20260519T201935-c24f6a",
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-20T22:26:26.890Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-34-f319aead5b_f2344b158d.json
+++ b/.clawpatch/findings/fnd_sig-gh-34-f319aead5b_f2344b158d.json
@@ -1,1 +1,96 @@
-{"schemaVersion":1,"findingId":"fnd_sig-gh-34-f319aead5b_f2344b158d","featureId":"feat_gh-34_ae664d7f2e","title":"gh#34: Bug: Auto-destruct help copy hardcoded to \"Twitter/X\" on LinkedIn and Facebook composer forms","category":"bug","severity":"medium","confidence":"high","triage":"confirmed-bug","evidence":[{"path":"packages/web/src/components/posts/SharedPostFields.tsx","startLine":null,"endLine":null,"symbol":null,"quote":null},{"path":"packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx","startLine":null,"endLine":null,"symbol":null,"quote":null}],"reasoning":"Imported from https://github.com/joshgk00/social-media-scheduler/issues/34.\nBacklog section: Bugs.\n\n## Summary\n\nThe Auto-destruct toggle on the new-post / edit-post composer shows the help text:\n\n> Automatically delete this post from Twitter/X after the specified time. The deletion runs in the background.\n\nThis copy renders verbatim on LinkedIn and Facebook composer forms after the profile picker switches platforms. It's misleading — and if auto-destruct isn't supported on LI/FB at all, the toggle itself shouldn't appear on those platforms.\n\n## Reproduction\n\n1. Open `/posts/new`.\n2. Select a LinkedIn profile — the form switches to LinkedIn shape, but the Auto-destruct help copy still references \"Twitter/X\".\n3. Switch to a Facebook profile — same copy.\n\n## Open question\n\nIs auto-destruct actually supported on LinkedIn or Facebook? If not, the right fix is to hide the toggle entirely on those platforms (it already isn't part of the LinkedIn / Facebook posting flows in the worker). If it is supported, the help text needs platform-aware copy.\n\n## Suggested fix\n\nEither:\n\n1. Move the Auto-destruct toggle into `TwitterPostFields.tsx` only (current `LinkedInPostFields.tsx` and `FacebookPostFields.tsx` shouldn't include it).\n2. Or keep it shared and parameterize the help-text string by platform.\n\n## Affected files\n\n- `packages/web/src/components/posts/SharedPostFields.tsx` (or wherever the auto-destruct block lives)\n- `packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx`\n\n## Scope\n\nPhase 8 platform-branching gap — auto-destruct UI was placed in a shared region without platform gating. Surfaced during browser verification.","reproduction":"1. Open `/posts/new`.\n2. Select a LinkedIn profile — the form switches to LinkedIn shape, but the Auto-destruct help copy still references \"Twitter/X\".\n3. Switch to a Facebook profile — same copy.","recommendation":"Phase 8 platform-branching gap — auto-destruct UI was placed in a shared region without platform gating. Surfaced during browser verification.","whyTestsDoNotAlreadyCoverThis":"Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.","suggestedRegressionTest":null,"minimumFixScope":"packages/web/src/components/posts/SharedPostFields.tsx, packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx","status":"open","history":[],"signature":"sig_gh-34_f319aead5b","linkedPatchAttemptIds":[],"createdByRunId":"20260519T201935-c24f6a","createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-34-f319aead5b_f2344b158d",
+  "featureId": "feat_gh-34_ae664d7f2e",
+  "title": "gh#34: Bug: Auto-destruct help copy hardcoded to \"Twitter/X\" on LinkedIn and Facebook composer forms",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "packages/web/src/components/posts/SharedPostFields.tsx",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/34.\nBacklog section: Bugs.\n\n## Summary\n\nThe Auto-destruct toggle on the new-post / edit-post composer shows the help text:\n\n> Automatically delete this post from Twitter/X after the specified time. The deletion runs in the background.\n\nThis copy renders verbatim on LinkedIn and Facebook composer forms after the profile picker switches platforms. It's misleading — and if auto-destruct isn't supported on LI/FB at all, the toggle itself shouldn't appear on those platforms.\n\n## Reproduction\n\n1. Open `/posts/new`.\n2. Select a LinkedIn profile — the form switches to LinkedIn shape, but the Auto-destruct help copy still references \"Twitter/X\".\n3. Switch to a Facebook profile — same copy.\n\n## Open question\n\nIs auto-destruct actually supported on LinkedIn or Facebook? If not, the right fix is to hide the toggle entirely on those platforms (it already isn't part of the LinkedIn / Facebook posting flows in the worker). If it is supported, the help text needs platform-aware copy.\n\n## Suggested fix\n\nEither:\n\n1. Move the Auto-destruct toggle into `TwitterPostFields.tsx` only (current `LinkedInPostFields.tsx` and `FacebookPostFields.tsx` shouldn't include it).\n2. Or keep it shared and parameterize the help-text string by platform.\n\n## Affected files\n\n- `packages/web/src/components/posts/SharedPostFields.tsx` (or wherever the auto-destruct block lives)\n- `packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx`\n\n## Scope\n\nPhase 8 platform-branching gap — auto-destruct UI was placed in a shared region without platform gating. Surfaced during browser verification.",
+  "reproduction": "1. Open `/posts/new`.\n2. Select a LinkedIn profile — the form switches to LinkedIn shape, but the Auto-destruct help copy still references \"Twitter/X\".\n3. Switch to a Facebook profile — same copy.",
+  "recommendation": "Phase 8 platform-branching gap — auto-destruct UI was placed in a shared region without platform gating. Surfaced during browser verification.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/web/src/components/posts/SharedPostFields.tsx, packages/web/src/components/posts/{Twitter,LinkedIn,Facebook}PostFields.tsx",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260520T223158-d59e64",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence paths still exist, and the issue is still present in current code. SharedPostFields unconditionally renders AutoDestructPicker at packages/web/src/components/posts/SharedPostFields.tsx:177-181, while AutoDestructPicker still hardcodes the help copy to \"Twitter/X\" at packages/web/src/components/posts/AutoDestructPicker.tsx:101-103. NewPostPage renders LinkedIn and Facebook branches at packages/web/src/pages/posts/NewPostPage.tsx:500-568, then always renders SharedPostFields at :570-590, so the same Twitter/X auto-destruct copy appears after selecting LinkedIn or Facebook. EditPostPage likewise always renders SharedPostFields at packages/web/src/pages/posts/EditPostPage.tsx:646-666. The platform-specific files still exist and do not contain their own gated auto-destruct control. Focused Vitest attempts could not run in this read-only sandbox because Vite/Vitest tried to write under packages/web/node_modules/.vite-temp, and alternate config loaders failed on the repo's __dirname-based config, but static current-code evidence is sufficient to revalidate the bug as open.",
+      "commands": [
+        "rg -n \"Auto-destruct|auto-destruct|Twitter/X|Automatically delete|delete this post\" packages/web/src/components/posts",
+        "rg --files packages/web/src/components/posts",
+        "sed -n '1,240p' packages/web/src/components/posts/SharedPostFields.tsx",
+        "sed -n '1,180p' packages/web/src/components/posts/AutoDestructPicker.tsx",
+        "sed -n '1,220p' packages/web/src/components/posts/TwitterPostFields.tsx",
+        "sed -n '1,220p' packages/web/src/components/posts/LinkedInPostFields.tsx",
+        "sed -n '1,220p' packages/web/src/components/posts/FacebookPostFields.tsx",
+        "rg -n \"<SharedPostFields|SharedPostFields\\(\" packages/web/src",
+        "sed -n '540,710p' packages/web/src/pages/posts/NewPostPage.tsx",
+        "sed -n '620,760p' packages/web/src/pages/posts/EditPostPage.tsx",
+        "rg -n \"autoDestructAfter|auto-destruct|AutoDestruct\" packages -g '*.{ts,tsx}'",
+        "pnpm --filter @sms/web test -- SharedPostFields.test.tsx --run",
+        "pnpm --filter @sms/web exec vitest --configLoader runner --run src/components/posts/__tests__/SharedPostFields.test.tsx",
+        "pnpm --filter @sms/web exec vitest --configLoader native --run src/components/posts/__tests__/SharedPostFields.test.tsx",
+        "nl -ba packages/web/src/components/posts/SharedPostFields.tsx | sed -n '168,184p'",
+        "nl -ba packages/web/src/components/posts/AutoDestructPicker.tsx | sed -n '96,106p'",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '468,590p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '644,666p'"
+      ],
+      "createdAt": "2026-05-20T22:33:22.916Z"
+    },
+    {
+      "runId": "20260520T223557-6e525f",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence files still exist, and the current code now implements the suggested platform gate. SharedPostFields takes a platform prop and renders AutoDestructPicker only when platform === 'twitter' at packages/web/src/components/posts/SharedPostFields.tsx:22 and :180-185. NewPostPage passes the selected/effective platform into SharedPostFields at packages/web/src/pages/posts/NewPostPage.tsx:572-589 and clears autoDestructAfter when switching to a non-Twitter profile at :147-156. EditPostPage passes formState.platform into SharedPostFields at packages/web/src/pages/posts/EditPostPage.tsx:647-665. AutoDestructPicker still contains Twitter/X-specific help copy at packages/web/src/components/posts/AutoDestructPicker.tsx:101-103, but it is now gated away from LinkedIn and Facebook. Current regression tests assert Twitter shows the control while LinkedIn/Facebook hide both Auto-destruct and the Twitter/X help copy at packages/web/src/components/posts/__tests__/SharedPostFields.test.tsx:122-139. I attempted to run the focused Vitest test, but this read-only sandbox blocked Vite's config temp-file write under node_modules/.vite-temp; native config loading also failed because the config uses __dirname in ESM scope.",
+      "commands": [
+        "rg -n \"Auto-destruct|auto-destruct|Twitter/X|Automatically delete|delete this post|AutoDestruct\" packages/web/src/components/posts packages/web/src/pages/posts packages -g '*.{ts,tsx}'",
+        "rg --files packages/web/src/components/posts",
+        "git status --short",
+        "nl -ba packages/web/src/components/posts/SharedPostFields.tsx | sed -n '1,230p'",
+        "nl -ba packages/web/src/components/posts/AutoDestructPicker.tsx | sed -n '1,140p'",
+        "nl -ba packages/web/src/components/posts/__tests__/SharedPostFields.test.tsx | sed -n '1,180p'",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '460,610p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '620,690p'",
+        "nl -ba packages/web/src/components/posts/TwitterPostFields.tsx | sed -n '1,180p' && nl -ba packages/web/src/components/posts/LinkedInPostFields.tsx | sed -n '1,180p' && nl -ba packages/web/src/components/posts/FacebookPostFields.tsx | sed -n '1,180p'",
+        "pnpm --filter @sms/web test -- src/components/posts/__tests__/SharedPostFields.test.tsx --run",
+        "pnpm --filter @sms/web exec vitest --configLoader native --run src/components/posts/__tests__/SharedPostFields.test.tsx",
+        "rg -n \"const platform|let platform|platform =|formState.platform|effectiveProfile|handleProfileChange\" packages/web/src/pages/posts/NewPostPage.tsx",
+        "rg -n \"const platform|let platform|platform =|formState.platform|handleProfileChange\" packages/web/src/pages/posts/EditPostPage.tsx",
+        "git diff -- packages/web/src/components/posts/SharedPostFields.tsx packages/web/src/components/posts/__tests__/SharedPostFields.test.tsx packages/web/src/pages/posts/NewPostPage.tsx packages/web/src/pages/posts/EditPostPage.tsx",
+        "rg -n \"<SharedPostFields|SharedPostFields\\(\" packages/web/src -g '*.tsx'",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '116,160p'"
+      ],
+      "createdAt": "2026-05-20T22:37:03.598Z"
+    }
+  ],
+  "signature": "sig_gh-34_f319aead5b",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-34-f319aead5b-f2344b1_0a25f12562"
+  ],
+  "createdByRunId": "20260519T201935-c24f6a",
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-20T22:37:03.598Z"
+}

--- a/packages/web/src/components/posts/FacebookPostFields.tsx
+++ b/packages/web/src/components/posts/FacebookPostFields.tsx
@@ -16,6 +16,11 @@ interface FacebookPostFieldsProps {
   onRemoveMedia: (id: string) => void;
   onReorderMedia: (ids: string[]) => void;
   onRetryTranscode: (id: string) => void;
+  onMediaStatusUpdate?: (
+    id: string,
+    status: MediaItem['transcodeStatus'],
+    error: string | null,
+  ) => void;
   disabled?: boolean;
 }
 
@@ -36,6 +41,7 @@ export function FacebookPostFields({
   onRemoveMedia,
   onReorderMedia,
   onRetryTranscode,
+  onMediaStatusUpdate,
   disabled,
 }: FacebookPostFieldsProps) {
   return (
@@ -80,6 +86,7 @@ export function FacebookPostFields({
             onRemove={onRemoveMedia}
             onReorder={onReorderMedia}
             onRetryTranscode={onRetryTranscode}
+            onStatusUpdate={onMediaStatusUpdate}
             readOnly={false}
           />
         )}

--- a/packages/web/src/components/posts/LinkedInPostFields.tsx
+++ b/packages/web/src/components/posts/LinkedInPostFields.tsx
@@ -13,6 +13,11 @@ interface LinkedInPostFieldsProps {
   onRemoveMedia: (id: string) => void;
   onReorderMedia: (ids: string[]) => void;
   onRetryTranscode: (id: string) => void;
+  onMediaStatusUpdate?: (
+    id: string,
+    status: MediaItem['transcodeStatus'],
+    error: string | null,
+  ) => void;
   disabled?: boolean;
 }
 
@@ -32,6 +37,7 @@ export function LinkedInPostFields({
   onRemoveMedia,
   onReorderMedia,
   onRetryTranscode,
+  onMediaStatusUpdate,
   disabled,
 }: LinkedInPostFieldsProps) {
   return (
@@ -60,6 +66,7 @@ export function LinkedInPostFields({
             onRemove={onRemoveMedia}
             onReorder={onReorderMedia}
             onRetryTranscode={onRetryTranscode}
+            onStatusUpdate={onMediaStatusUpdate}
             readOnly={false}
           />
         )}

--- a/packages/web/src/components/posts/MediaThumbnailGrid.tsx
+++ b/packages/web/src/components/posts/MediaThumbnailGrid.tsx
@@ -26,6 +26,11 @@ interface MediaThumbnailGridProps {
   onRemove: (id: string) => void;
   onReorder: (ids: string[]) => void;
   onRetryTranscode: (id: string) => void;
+  onStatusUpdate?: (
+    id: string,
+    status: MediaItem['transcodeStatus'],
+    error: string | null,
+  ) => void;
   readOnly: boolean;
 }
 
@@ -88,7 +93,11 @@ function MediaStatusPoller({
   onStatusUpdate,
 }: {
   mediaId: string;
-  onStatusUpdate: (mediaId: string, status: string, error: string | null) => void;
+  onStatusUpdate: (
+    mediaId: string,
+    status: MediaItem['transcodeStatus'],
+    error: string | null,
+  ) => void;
 }) {
   const shouldPoll = true;
   const { data } = useMediaStatus(mediaId, shouldPoll);
@@ -108,6 +117,7 @@ export function MediaThumbnailGrid({
   onRemove,
   onReorder,
   onRetryTranscode,
+  onStatusUpdate,
   readOnly,
 }: MediaThumbnailGridProps) {
   const sensors = useSensors(
@@ -118,12 +128,14 @@ export function MediaThumbnailGrid({
   );
 
   const handleStatusUpdate = useCallback(
-    (_mediaId: string, _status: string, _error: string | null) => {
-      // Status updates are received via TanStack Query cache.
-      // The parent component handles state updates when media status changes
-      // through the polling mechanism.
+    (
+      mediaId: string,
+      status: MediaItem['transcodeStatus'],
+      error: string | null,
+    ) => {
+      onStatusUpdate?.(mediaId, status, error);
     },
-    [],
+    [onStatusUpdate],
   );
 
   function handleDragEnd(event: DragEndEvent) {

--- a/packages/web/src/components/posts/SharedPostFields.tsx
+++ b/packages/web/src/components/posts/SharedPostFields.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from 'react';
+import type { Platform } from '../../hooks/use-profiles';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Switch } from '../ui/switch';
@@ -18,6 +19,7 @@ interface SharedPostFieldsProps {
    * - 'queue' — schedule fields hidden (queue posts inherit cadence)
    */
   mode: 'new' | 'edit' | 'queue';
+  platform: Platform;
   userTimezone: string;
   effectiveProfileId: string;
   excludePostId?: string;
@@ -49,16 +51,15 @@ interface SharedPostFieldsProps {
  * component (B-03 closure).
  *
  * Mounted ABOVE the platform-specific branch in BOTH NewPostPage and
- * EditPostPage so every POST-CMN requirement always has a control on the
- * page regardless of platform. Schedule-related fields (POST-CMN-01,
- * POST-CMN-02, POST-CMN-07) hide in queue mode where the queue cadence
- * supplies the schedule.
+ * EditPostPage so common controls have one source of truth. Schedule-related
+ * fields (POST-CMN-01, POST-CMN-02, POST-CMN-07) hide in queue mode where the
+ * queue cadence supplies the schedule.
  *
  * POST-CMN coverage:
  *   - POST-CMN-01: schedule datetime input
  *   - POST-CMN-02: timezone-aware datetime conversion + helper text
  *   - POST-CMN-03: spinnable toggle
- *   - POST-CMN-04: auto-destruct picker
+ *   - POST-CMN-04: auto-destruct picker (Twitter/X only)
  *   - POST-CMN-05: tag selector + notes textarea
  *   - POST-CMN-06: Save as Draft is delivered by the parent's `<SplitButton>`
  *                  rendered below this component
@@ -66,6 +67,7 @@ interface SharedPostFieldsProps {
  */
 export function SharedPostFields({
   mode,
+  platform,
   userTimezone,
   effectiveProfileId,
   excludePostId,
@@ -175,10 +177,12 @@ export function SharedPostFields({
       </div>
 
       {/* POST-CMN-04: auto-destruct picker */}
-      <AutoDestructPicker
-        value={autoDestructAfter}
-        onChange={onAutoDestructAfterChange}
-      />
+      {platform === 'twitter' && (
+        <AutoDestructPicker
+          value={autoDestructAfter}
+          onChange={onAutoDestructAfterChange}
+        />
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/posts/TwitterPostFields.tsx
+++ b/packages/web/src/components/posts/TwitterPostFields.tsx
@@ -24,6 +24,11 @@ interface TwitterPostFieldsProps {
   onRemoveMedia: (id: string) => void;
   onReorderMedia: (ids: string[]) => void;
   onRetryTranscode: (id: string) => void;
+  onMediaStatusUpdate?: (
+    id: string,
+    status: MediaItem['transcodeStatus'],
+    error: string | null,
+  ) => void;
   disabled?: boolean;
   textareaRef?: RefObject<HTMLTextAreaElement | null>;
 }
@@ -50,6 +55,7 @@ export function TwitterPostFields({
   onRemoveMedia,
   onReorderMedia,
   onRetryTranscode,
+  onMediaStatusUpdate,
   disabled,
   textareaRef,
 }: TwitterPostFieldsProps) {
@@ -102,6 +108,7 @@ export function TwitterPostFields({
           onRemove={onRemoveMedia}
           onReorder={onReorderMedia}
           onRetryTranscode={onRetryTranscode}
+          onStatusUpdate={onMediaStatusUpdate}
           readOnly={false}
         />
       )}

--- a/packages/web/src/components/posts/__tests__/SharedPostFields.test.tsx
+++ b/packages/web/src/components/posts/__tests__/SharedPostFields.test.tsx
@@ -126,15 +126,13 @@ describe('SharedPostFields', () => {
     expect(screen.getByText(/Automatically delete this post from Twitter\/X/)).toBeInTheDocument();
   });
 
-  it('hides auto-destruct controls for LinkedIn and Facebook posts', () => {
-    renderSharedPostFields('linkedin');
+  it.each(['linkedin', 'facebook'] as const)(
+    'hides auto-destruct controls for %s posts',
+    (platform) => {
+      renderSharedPostFields(platform);
 
-    expect(screen.queryByText('Auto-destruct')).not.toBeInTheDocument();
-    expect(screen.queryByText(/Automatically delete this post from Twitter\/X/)).not.toBeInTheDocument();
-
-    renderSharedPostFields('facebook');
-
-    expect(screen.queryByText('Auto-destruct')).not.toBeInTheDocument();
-    expect(screen.queryByText(/Automatically delete this post from Twitter\/X/)).not.toBeInTheDocument();
-  });
+      expect(screen.queryByText('Auto-destruct')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Automatically delete this post from Twitter\/X/)).not.toBeInTheDocument();
+    },
+  );
 });

--- a/packages/web/src/components/posts/__tests__/SharedPostFields.test.tsx
+++ b/packages/web/src/components/posts/__tests__/SharedPostFields.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { SharedPostFields } from '../SharedPostFields';
+import type { Platform } from '../../../hooks/use-profiles';
 
 vi.mock('../../../hooks/use-tags', () => ({
   useTags: () => ({ data: [] }),
@@ -13,6 +14,39 @@ vi.mock('../../../hooks/use-tags', () => ({
 vi.mock('../../../hooks/use-posts', () => ({
   useCheckConflicts: () => ({ data: [] }),
 }));
+
+function renderSharedPostFields(platform: Platform = 'twitter') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  const textareaRef = createRef<HTMLTextAreaElement>();
+
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <SharedPostFields
+          mode="queue"
+          platform={platform}
+          userTimezone="UTC"
+          effectiveProfileId="profile-1"
+          scheduledAt={null}
+          onScheduledAtChange={vi.fn()}
+          tagIds={[]}
+          onTagIdsChange={vi.fn()}
+          onOpenTagManagement={vi.fn()}
+          notes=""
+          onNotesChange={vi.fn()}
+          hasSpinnableText={false}
+          onHasSpinnableTextChange={vi.fn()}
+          autoDestructAfter={null}
+          onAutoDestructAfterChange={vi.fn()}
+          textareaRef={textareaRef}
+          onInsertSnippet={vi.fn()}
+        />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
 
 beforeAll(() => {
   class ResizeObserverMock {
@@ -52,6 +86,7 @@ describe('SharedPostFields', () => {
             <textarea ref={textareaRef} defaultValue="Pre  Post" aria-label="Composer textarea" />
             <SharedPostFields
               mode="queue"
+              platform="twitter"
               userTimezone="UTC"
               effectiveProfileId="profile-1"
               scheduledAt={null}
@@ -82,5 +117,24 @@ describe('SharedPostFields', () => {
     await user.click(await screen.findByText('tag'));
 
     expect(onInsertSnippet).toHaveBeenCalledWith('Pre #tag Post');
+  });
+
+  it('renders auto-destruct controls for Twitter posts', () => {
+    renderSharedPostFields('twitter');
+
+    expect(screen.getByText('Auto-destruct')).toBeInTheDocument();
+    expect(screen.getByText(/Automatically delete this post from Twitter\/X/)).toBeInTheDocument();
+  });
+
+  it('hides auto-destruct controls for LinkedIn and Facebook posts', () => {
+    renderSharedPostFields('linkedin');
+
+    expect(screen.queryByText('Auto-destruct')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Automatically delete this post from Twitter\/X/)).not.toBeInTheDocument();
+
+    renderSharedPostFields('facebook');
+
+    expect(screen.queryByText('Auto-destruct')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Automatically delete this post from Twitter\/X/)).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/pages/login/LoginPage.tsx
+++ b/packages/web/src/pages/login/LoginPage.tsx
@@ -70,7 +70,7 @@ export default function LoginPage() {
           setStep('credentials');
           setTotpError(null);
           toast.error('Session expired. Please sign in again.');
-          return 0;
+          return TOTP_TIMEOUT_SECONDS;
         }
         return prev - 1;
       });
@@ -96,6 +96,7 @@ export default function LoginPage() {
     try {
       const result = await loginMutation.mutateAsync(data);
       if (result.requiresTwoFactor) {
+        setCountdown(TOTP_TIMEOUT_SECONDS);
         setStep('totp');
       } else {
         redirectToTarget();
@@ -120,6 +121,7 @@ export default function LoginPage() {
     } catch (err: unknown) {
       const error = err as { status?: number; body?: { error?: string } };
       if (error.status === 401 && error.body?.error?.toLowerCase().includes('session expired')) {
+        setCountdown(TOTP_TIMEOUT_SECONDS);
         setStep('credentials');
         setTotpError(null);
         totpForm.reset();
@@ -133,6 +135,7 @@ export default function LoginPage() {
   }
 
   function handleBackToLogin() {
+    setCountdown(TOTP_TIMEOUT_SECONDS);
     setStep('credentials');
     setTotpError(null);
     totpForm.reset();

--- a/packages/web/src/pages/login/__tests__/LoginPage.test.tsx
+++ b/packages/web/src/pages/login/__tests__/LoginPage.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import LoginPage from '../LoginPage';
+
+const mocks = vi.hoisted(() => ({
+  loginMutateAsync: vi.fn(),
+  verify2FAMutateAsync: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useLogin: () => ({
+    mutateAsync: mocks.loginMutateAsync,
+    isPending: false,
+  }),
+  useVerify2FA: () => ({
+    mutateAsync: mocks.verify2FAMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+  },
+}));
+
+function renderPage() {
+  render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
+
+async function submitCredentials() {
+  fireEvent.change(screen.getByLabelText('Email'), {
+    target: { value: 'user@example.com' },
+  });
+  fireEvent.change(screen.getByLabelText('Password'), {
+    target: { value: 'password' },
+  });
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+  });
+
+  expect(screen.getByText('Two-Factor Authentication')).toBeInTheDocument();
+}
+
+describe('LoginPage TOTP countdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.loginMutateAsync.mockResolvedValue({ requiresTwoFactor: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('starts a fresh countdown after a previous TOTP challenge expires', async () => {
+    renderPage();
+
+    await submitCredentials();
+    expect(screen.getByText('Code expires in 5:00')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(300_000);
+    });
+
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument();
+
+    await submitCredentials();
+    expect(screen.getByText('Code expires in 5:00')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText('Two-Factor Authentication')).toBeInTheDocument();
+    expect(screen.getByText('Code expires in 4:59')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -646,6 +646,7 @@ export default function EditPostPage() {
           {/* SHARED POST-CMN BLOCK (B-03) — every common control lives here */}
           <SharedPostFields
             mode="edit"
+            platform={formState.platform}
             userTimezone={userTimezone}
             effectiveProfileId={formState.profileId}
             excludePostId={postId}

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -226,6 +226,25 @@ export default function EditPostPage() {
     });
   }
 
+  const handleMediaStatusUpdate = useCallback(
+    (
+      mediaId: string,
+      status: MediaItem['transcodeStatus'],
+      error: string | null,
+    ) => {
+      setMediaItems((prev) =>
+        prev.map((m) => {
+          if (m.id !== mediaId) return m;
+          if (m.transcodeStatus === status && m.transcodeError === error) {
+            return m;
+          }
+          return { ...m, transcodeStatus: status, transcodeError: error };
+        }),
+      );
+    },
+    [],
+  );
+
   function getSubmitDisabledReason(): string | null {
     if (hasTranscodingMedia) return 'Video is still transcoding.';
     if (hasFailedMedia) return 'Fix or remove failed media before submitting.';
@@ -550,6 +569,7 @@ export default function EditPostPage() {
               onRemoveMedia={handleRemoveMedia}
               onReorderMedia={handleReorderMedia}
               onRetryTranscode={handleRetryTranscode}
+              onMediaStatusUpdate={handleMediaStatusUpdate}
               disabled={updatePostMutation.isPending || isUploading}
             />
           )}
@@ -580,6 +600,7 @@ export default function EditPostPage() {
                 onRemoveMedia={handleRemoveMedia}
                 onReorderMedia={handleReorderMedia}
                 onRetryTranscode={handleRetryTranscode}
+                onMediaStatusUpdate={handleMediaStatusUpdate}
                 disabled={updatePostMutation.isPending || isUploading}
               />
             </>
@@ -616,6 +637,7 @@ export default function EditPostPage() {
                 onRemoveMedia={handleRemoveMedia}
                 onReorderMedia={handleReorderMedia}
                 onRetryTranscode={handleRetryTranscode}
+                onMediaStatusUpdate={handleMediaStatusUpdate}
                 disabled={updatePostMutation.isPending || isUploading}
               />
             </>

--- a/packages/web/src/pages/posts/NewPostPage.tsx
+++ b/packages/web/src/pages/posts/NewPostPage.tsx
@@ -225,6 +225,25 @@ export default function NewPostPage() {
     });
   }
 
+  const handleMediaStatusUpdate = useCallback(
+    (
+      mediaId: string,
+      status: MediaItem['transcodeStatus'],
+      error: string | null,
+    ) => {
+      setMediaItems((prev) =>
+        prev.map((m) => {
+          if (m.id !== mediaId) return m;
+          if (m.transcodeStatus === status && m.transcodeError === error) {
+            return m;
+          }
+          return { ...m, transcodeStatus: status, transcodeError: error };
+        }),
+      );
+    },
+    [],
+  );
+
   function handleThreadToggle(checked: boolean) {
     if (checked) {
       const currentText = formState.text;
@@ -474,6 +493,7 @@ export default function NewPostPage() {
               onRemoveMedia={handleRemoveMedia}
               onReorderMedia={handleReorderMedia}
               onRetryTranscode={handleRetryTranscode}
+              onMediaStatusUpdate={handleMediaStatusUpdate}
               disabled={isSubmitting}
             />
           )}
@@ -504,6 +524,7 @@ export default function NewPostPage() {
                 onRemoveMedia={handleRemoveMedia}
                 onReorderMedia={handleReorderMedia}
                 onRetryTranscode={handleRetryTranscode}
+                onMediaStatusUpdate={handleMediaStatusUpdate}
                 disabled={isSubmitting}
               />
             </>
@@ -540,6 +561,7 @@ export default function NewPostPage() {
                 onRemoveMedia={handleRemoveMedia}
                 onReorderMedia={handleReorderMedia}
                 onRetryTranscode={handleRetryTranscode}
+                onMediaStatusUpdate={handleMediaStatusUpdate}
                 disabled={isSubmitting}
               />
             </>

--- a/packages/web/src/pages/posts/NewPostPage.tsx
+++ b/packages/web/src/pages/posts/NewPostPage.tsx
@@ -152,6 +152,7 @@ export default function NewPostPage() {
       visibility: result.state.visibility ?? 'PUBLIC',
       linkUrl: result.state.linkUrl ?? '',
       isThread: result.state.isThread ?? false,
+      autoDestructAfter: newPlatform === 'twitter' ? prev.autoDestructAfter : null,
     }));
     if (result.state.mediaIds.length !== mediaItems.length) {
       const keepIds = new Set(result.state.mediaIds);
@@ -570,6 +571,7 @@ export default function NewPostPage() {
           {/* SHARED POST-CMN BLOCK (B-03) — every common control lives here */}
           <SharedPostFields
             mode={isQueueMode ? 'queue' : 'new'}
+            platform={platform}
             userTimezone={userTimezone}
             effectiveProfileId={effectiveProfileId}
             scheduledAt={formState.scheduledAt}

--- a/packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -7,6 +7,7 @@ import NewPostPage from '../NewPostPage';
 
 const navigate = vi.fn();
 const createPostMutate = vi.fn();
+const uploadMedia = vi.fn();
 
 vi.mock('react-router', async () => {
   const actual =
@@ -54,7 +55,7 @@ vi.mock('../../../hooks/use-queue-posts', () => ({
 
 vi.mock('../../../hooks/use-media-upload', () => ({
   useMediaUpload: () => ({
-    upload: vi.fn(),
+    upload: uploadMedia,
     uploadingFiles: new Map(),
     isUploading: false,
   }),
@@ -90,15 +91,40 @@ vi.mock('../../../components/posts/TwitterPostFields', () => ({
   TwitterPostFields: ({
     text,
     onTextChange,
+    mediaItems,
+    onFilesSelected,
+    onMediaStatusUpdate,
   }: {
     text: string;
     onTextChange: (value: string) => void;
+    mediaItems: Array<{ id: string }>;
+    onFilesSelected: (files: File[]) => void;
+    onMediaStatusUpdate: (
+      id: string,
+      status: 'completed',
+      error: string | null,
+    ) => void;
   }) => (
-    <textarea
-      aria-label="Tweet text"
-      value={text}
-      onChange={(event) => onTextChange(event.target.value)}
-    />
+    <div>
+      <textarea
+        aria-label="Tweet text"
+        value={text}
+        onChange={(event) => onTextChange(event.target.value)}
+      />
+      <button
+        type="button"
+        onClick={() => onFilesSelected([new File(['video'], 'video.mp4')])}
+      >
+        Add pending video
+      </button>
+      <button
+        type="button"
+        onClick={() => onMediaStatusUpdate(mediaItems[0].id, 'completed', null)}
+        disabled={mediaItems.length === 0}
+      >
+        Complete transcode
+      </button>
+    </div>
   ),
 }));
 
@@ -173,6 +199,13 @@ function renderPage() {
 describe('NewPostPage scheduling validation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    uploadMedia.mockResolvedValue({
+      id: 'media-1',
+      fileName: 'video.mp4',
+      mimeType: 'video/mp4',
+      thumbnailUrl: null,
+      transcodeStatus: 'pending',
+    });
   });
 
   it('keeps the user on the form and focuses an inline schedule error when schedule time is missing', async () => {
@@ -191,5 +224,25 @@ describe('NewPostPage scheduling validation', () => {
       screen.getByText('Select a scheduled time before scheduling.'),
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Schedule')).toHaveFocus();
+  });
+
+  it('reenables scheduling when media polling reports a completed transcode', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Use Twitter profile' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Add pending video' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Schedule Post' })).toBeDisabled(),
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Complete transcode' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Schedule Post' })).not.toBeDisabled(),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- reset the login TOTP countdown before re-entering a fresh challenge
- propagate media polling status from thumbnails back to New/Edit post page state
- hide Twitter/X-only auto-destruct controls for LinkedIn and Facebook composers

## Validation

- pnpm --filter @sms/web exec vitest run src/pages/login/__tests__/LoginPage.test.tsx src/pages/posts/__tests__/NewPostPage.test.tsx src/components/posts/__tests__/SharedPostFields.test.tsx
- pnpm --filter @sms/web exec tsc -p tsconfig.app.json --noEmit --incremental false
- pnpm --filter @sms/web exec tsc -p tsconfig.node.json --noEmit --incremental false

## Notes

Draft PR split from the Clawpatch batch; target branch is develop.