### PR TITLE
[codex] Media service performance fixes

### DIFF
--- a/.clawpatch/features/feat_gh-7_00482921b7.json
+++ b/.clawpatch/features/feat_gh-7_00482921b7.json
@@ -1,1 +1,74 @@
-{"schemaVersion":1,"featureId":"feat_gh-7_00482921b7","title":"gh#7: Perf: Sharp triple-decode in processImageUpload","summary":"Imported from GitHub issue gh#7 in BACKLOG.md section \"Performance\".","kind":"test-suite","source":"github-issue-import","confidence":"high","entrypoints":[{"path":"packages/api/src/services/media.service.ts","symbol":null,"route":null,"command":null},{"path":"packages/api/src/__tests__/services/media.test.ts","symbol":null,"route":null,"command":null}],"ownedFiles":[{"path":"packages/api/src/services/media.service.ts","reason":"mentioned by issue at packages/api/src/services/media.service.ts:54"},{"path":"packages/api/src/__tests__/services/media.test.ts","reason":"mentioned by issue body"}],"contextFiles":[{"path":"BACKLOG.md","reason":"backlog queue item for gh#7"}],"tests":[{"path":"packages/api/src/__tests__/services/media.test.ts","command":null}],"tags":["github-issue","gh#7","github-url:https://github.com/joshgk00/social-media-scheduler/issues/7","backlog-order:0029","backlog-section:performance"],"trustBoundaries":["network","filesystem"],"status":"needs-fix","lock":null,"findingIds":["fnd_sig-gh-7-112ba0d315_26d79992da"],"patchAttemptIds":[],"analysisHistory":[{"runId":"20260519T201935-c24f6a","kind":"github-issue-import","summary":"Imported GitHub issue gh#7","provider":"gh","model":null,"createdAt":"2026-05-19T20:19:35.980Z"}],"createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-7_00482921b7",
+  "title": "gh#7: Perf: Sharp triple-decode in processImageUpload",
+  "summary": "Imported from GitHub issue gh#7 in BACKLOG.md section \"Performance\".",
+  "kind": "test-suite",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/api/src/services/media.service.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/api/src/__tests__/services/media.test.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/api/src/services/media.service.ts",
+      "reason": "mentioned by issue at packages/api/src/services/media.service.ts:54"
+    },
+    {
+      "path": "packages/api/src/__tests__/services/media.test.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#7"
+    }
+  ],
+  "tests": [
+    {
+      "path": "packages/api/src/__tests__/services/media.test.ts",
+      "command": null
+    }
+  ],
+  "tags": [
+    "github-issue",
+    "gh#7",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/7",
+    "backlog-order:0029",
+    "backlog-section:performance"
+  ],
+  "trustBoundaries": [
+    "network",
+    "filesystem"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-7-112ba0d315_26d79992da"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260519T201935-c24f6a",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#7",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-19T20:19:35.980Z"
+    }
+  ],
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T00:04:05.569Z"
+}

--- a/.clawpatch/features/feat_gh-8_f945ab2980.json
+++ b/.clawpatch/features/feat_gh-8_f945ab2980.json
@@ -1,1 +1,60 @@
-{"schemaVersion":1,"featureId":"feat_gh-8_f945ab2980","title":"gh#8: Perf: Serial UPDATE loop in associateMediaToPost","summary":"Imported from GitHub issue gh#8 in BACKLOG.md section \"Performance\".","kind":"service","source":"github-issue-import","confidence":"high","entrypoints":[{"path":"packages/api/src/services/media.service.ts","symbol":null,"route":null,"command":null}],"ownedFiles":[{"path":"packages/api/src/services/media.service.ts","reason":"mentioned by issue body"}],"contextFiles":[{"path":"BACKLOG.md","reason":"backlog queue item for gh#8"}],"tests":[],"tags":["github-issue","gh#8","github-url:https://github.com/joshgk00/social-media-scheduler/issues/8","backlog-order:0030","backlog-section:performance"],"trustBoundaries":["network","filesystem","external-api"],"status":"needs-fix","lock":null,"findingIds":["fnd_sig-gh-8-31d12ef214_71e69e6a80"],"patchAttemptIds":[],"analysisHistory":[{"runId":"20260519T201935-c24f6a","kind":"github-issue-import","summary":"Imported GitHub issue gh#8","provider":"gh","model":null,"createdAt":"2026-05-19T20:19:35.980Z"}],"createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-8_f945ab2980",
+  "title": "gh#8: Perf: Serial UPDATE loop in associateMediaToPost",
+  "summary": "Imported from GitHub issue gh#8 in BACKLOG.md section \"Performance\".",
+  "kind": "service",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/api/src/services/media.service.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/api/src/services/media.service.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#8"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#8",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/8",
+    "backlog-order:0030",
+    "backlog-section:performance"
+  ],
+  "trustBoundaries": [
+    "network",
+    "filesystem",
+    "external-api"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-8-31d12ef214_71e69e6a80"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260519T201935-c24f6a",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#8",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-19T20:19:35.980Z"
+    }
+  ],
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T00:08:40.682Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-7-112ba0d315_26d79992da.json
+++ b/.clawpatch/findings/fnd_sig-gh-7-112ba0d315_26d79992da.json
@@ -1,1 +1,79 @@
-{"schemaVersion":1,"findingId":"fnd_sig-gh-7-112ba0d315_26d79992da","featureId":"feat_gh-7_00482921b7","title":"gh#7: Perf: Sharp triple-decode in processImageUpload","category":"performance","severity":"medium","confidence":"high","triage":"risk","evidence":[{"path":"packages/api/src/services/media.service.ts","startLine":54,"endLine":93,"symbol":null,"quote":null},{"path":"packages/api/src/__tests__/services/media.test.ts","startLine":null,"endLine":null,"symbol":null,"quote":null}],"reasoning":"Imported from https://github.com/joshgk00/social-media-scheduler/issues/7.\nBacklog section: Performance.\n\n## Problem\n\n`processImageUpload` runs 4 separate Sharp pipelines on the same image. Each decode costs 80-120ms for a 25MP JPEG. Estimated 40-50% CPU reduction by reusing pipeline clones and `resolveWithObject`.\n\n## Identified by\n\nCode quality review Run 1 — performance-optimizer (perf-002, perf-003)\n\n## Fix\n\nUse `sharp.clone()` and `toBuffer({ resolveWithObject: true })` to get dimensions from the processing pass. Reduces 4 decodes to 2. Also consider `sharp.cache({ memory: 50 })` and `sharp.concurrency(2)`.\n\n## Files\n\n- `packages/api/src/services/media.service.ts:54-93`\n- `packages/api/src/__tests__/services/media.test.ts` (tests assert on call shape — need rewrite)","reproduction":"`processImageUpload` runs 4 separate Sharp pipelines on the same image. Each decode costs 80-120ms for a 25MP JPEG. Estimated 40-50% CPU reduction by reusing pipeline clones and `resolveWithObject`.","recommendation":"Use `sharp.clone()` and `toBuffer({ resolveWithObject: true })` to get dimensions from the processing pass. Reduces 4 decodes to 2. Also consider `sharp.cache({ memory: 50 })` and `sharp.concurrency(2)`.","whyTestsDoNotAlreadyCoverThis":"Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.","suggestedRegressionTest":null,"minimumFixScope":"packages/api/src/services/media.service.ts, packages/api/src/__tests__/services/media.test.ts","status":"open","history":[],"signature":"sig_gh-7_112ba0d315","linkedPatchAttemptIds":[],"createdByRunId":"20260519T201935-c24f6a","createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-7-112ba0d315_26d79992da",
+  "featureId": "feat_gh-7_00482921b7",
+  "title": "gh#7: Perf: Sharp triple-decode in processImageUpload",
+  "category": "performance",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "packages/api/src/services/media.service.ts",
+      "startLine": 54,
+      "endLine": 93,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/api/src/__tests__/services/media.test.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/7.\nBacklog section: Performance.\n\n## Problem\n\n`processImageUpload` runs 4 separate Sharp pipelines on the same image. Each decode costs 80-120ms for a 25MP JPEG. Estimated 40-50% CPU reduction by reusing pipeline clones and `resolveWithObject`.\n\n## Identified by\n\nCode quality review Run 1 — performance-optimizer (perf-002, perf-003)\n\n## Fix\n\nUse `sharp.clone()` and `toBuffer({ resolveWithObject: true })` to get dimensions from the processing pass. Reduces 4 decodes to 2. Also consider `sharp.cache({ memory: 50 })` and `sharp.concurrency(2)`.\n\n## Files\n\n- `packages/api/src/services/media.service.ts:54-93`\n- `packages/api/src/__tests__/services/media.test.ts` (tests assert on call shape — need rewrite)",
+  "reproduction": "`processImageUpload` runs 4 separate Sharp pipelines on the same image. Each decode costs 80-120ms for a 25MP JPEG. Estimated 40-50% CPU reduction by reusing pipeline clones and `resolveWithObject`.",
+  "recommendation": "Use `sharp.clone()` and `toBuffer({ resolveWithObject: true })` to get dimensions from the processing pass. Reduces 4 decodes to 2. Also consider `sharp.cache({ memory: 50 })` and `sharp.concurrency(2)`.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/api/src/services/media.service.ts, packages/api/src/__tests__/services/media.test.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260520T235938-053385",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence paths still exist. packages/api/src/services/media.service.ts still has processImageUpload at lines 55-142, and the reported hot section still creates separate Sharp pipelines: sharp(tempFilePath).metadata() at line 63, sharp(tempFilePath).rotate()/resize().toBuffer() at lines 76-84, sharp(processedBuffer).metadata() at line 88, and sharp(processedBuffer).resize().toBuffer() at lines 99-101. There is no sharp.clone() or toBuffer({ resolveWithObject: true }) usage in packages/api/src, and packages/api/src/__tests__/services/media.test.ts still mocks a single Sharp instance without regression coverage for clone/resolveWithObject call shape. The targeted test command could not run because the read-only sandbox blocked Vitest/Vite from writing its .vite-temp config bundle, so static current-code evidence is the basis for this revalidation.",
+      "commands": [
+        "git status --short",
+        "nl -ba packages/api/src/services/media.service.ts | sed -n '1,180p'",
+        "nl -ba packages/api/src/__tests__/services/media.test.ts | sed -n '1,260p'",
+        "rg -n \"processImageUpload|sharp\\(|resolveWithObject|clone\\(|metadata\\(|toBuffer\" packages/api/src",
+        "rg -n \"\\\"test\\\"|vitest|packages/api\" package.json packages/api/package.json pnpm-workspace.yaml",
+        "rg --files | rg '(^|/)media\\.service\\.ts$|media\\.test\\.ts$|package\\.json$'",
+        "pnpm --dir packages/api test -- --run src/__tests__/services/media.test.ts"
+      ],
+      "createdAt": "2026-05-21T00:00:11.607Z"
+    },
+    {
+      "runId": "20260521T000315-1cd18e",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence paths still exist, but the implementation has changed. packages/api/src/services/media.service.ts now creates one sharp(tempFilePath) instance at line 63, uses originalImage.clone().metadata() at line 64, uses originalImage.clone().rotate() for the processing pipeline at line 75, and reads processed dimensions from processedImage.toBuffer({ resolveWithObject: true }) at lines 83-87. The previous extra sharp(processedBuffer).metadata() pass is gone; sharp(processedBuffer) remains only for thumbnail generation at lines 96-98. The test file also now includes coverage asserting cloned pipelines, one metadata call, resolveWithObject, and processed dimensions from info at lines 165-189. I attempted targeted Vitest runs, but the read-only sandbox blocked Vite/Vitest temp-file creation with EPERM, so this revalidation is based on current code and test source evidence rather than passing test execution.",
+      "commands": [
+        "git status --short",
+        "nl -ba packages/api/src/services/media.service.ts | sed -n '1,220p'",
+        "nl -ba packages/api/src/__tests__/services/media.test.ts | sed -n '1,320p'",
+        "rg -n \"processImageUpload|sharp\\(|resolveWithObject|clone\\(|metadata\\(|toBuffer\" packages/api/src",
+        "rg -n \"\\\"test\\\"|vitest\" package.json packages/api/package.json pnpm-workspace.yaml",
+        "pnpm --dir packages/api test -- --run src/__tests__/services/media.test.ts",
+        "pnpm --dir packages/api exec vitest --configLoader runner --run src/__tests__/services/media.test.ts",
+        "git diff -- packages/api/src/services/media.service.ts",
+        "git diff -- packages/api/src/__tests__/services/media.test.ts",
+        "rg -n \"sharp\\(processedBuffer\\)\\.metadata|sharp\\(tempFilePath\\).*metadata|resolveWithObject|clone\\(|metadata\\(\\)\" packages/api/src/services/media.service.ts packages/api/src/__tests__/services/media.test.ts"
+      ],
+      "createdAt": "2026-05-21T00:04:05.518Z"
+    }
+  ],
+  "signature": "sig_gh-7_112ba0d315",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-7-112ba0d315-26d79992_6b8c0dd567"
+  ],
+  "createdByRunId": "20260519T201935-c24f6a",
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T00:04:05.518Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-8-31d12ef214_71e69e6a80.json
+++ b/.clawpatch/findings/fnd_sig-gh-8-31d12ef214_71e69e6a80.json
@@ -1,1 +1,73 @@
-{"schemaVersion":1,"findingId":"fnd_sig-gh-8-31d12ef214_71e69e6a80","featureId":"feat_gh-8_f945ab2980","title":"gh#8: Perf: Serial UPDATE loop in associateMediaToPost","category":"performance","severity":"medium","confidence":"high","triage":"risk","evidence":[{"path":"packages/api/src/services/media.service.ts","startLine":null,"endLine":null,"symbol":null,"quote":null}],"reasoning":"Imported from https://github.com/joshgk00/social-media-scheduler/issues/8.\nBacklog section: Performance.\n\n## Problem\n\n`associateMediaToPost` runs N sequential UPDATE statements (one per mediaId). 4 round trips for Twitter images, up to 10 for Facebook carousel.\n\n## Identified by\n\nCode quality review Run 1 — performance-optimizer (perf-001)\n\n## Fix\n\nCollapse to a single UPDATE with a CASE expression for sortOrder.\n\n## Files\n\n- `packages/api/src/services/media.service.ts`","reproduction":"`associateMediaToPost` runs N sequential UPDATE statements (one per mediaId). 4 round trips for Twitter images, up to 10 for Facebook carousel.","recommendation":"Collapse to a single UPDATE with a CASE expression for sortOrder.","whyTestsDoNotAlreadyCoverThis":"Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.","suggestedRegressionTest":null,"minimumFixScope":"packages/api/src/services/media.service.ts","status":"open","history":[],"signature":"sig_gh-8_31d12ef214","linkedPatchAttemptIds":[],"createdByRunId":"20260519T201935-c24f6a","createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-8-31d12ef214_71e69e6a80",
+  "featureId": "feat_gh-8_f945ab2980",
+  "title": "gh#8: Perf: Serial UPDATE loop in associateMediaToPost",
+  "category": "performance",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "packages/api/src/services/media.service.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/8.\nBacklog section: Performance.\n\n## Problem\n\n`associateMediaToPost` runs N sequential UPDATE statements (one per mediaId). 4 round trips for Twitter images, up to 10 for Facebook carousel.\n\n## Identified by\n\nCode quality review Run 1 — performance-optimizer (perf-001)\n\n## Fix\n\nCollapse to a single UPDATE with a CASE expression for sortOrder.\n\n## Files\n\n- `packages/api/src/services/media.service.ts`",
+  "reproduction": "`associateMediaToPost` runs N sequential UPDATE statements (one per mediaId). 4 round trips for Twitter images, up to 10 for Facebook carousel.",
+  "recommendation": "Collapse to a single UPDATE with a CASE expression for sortOrder.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/api/src/services/media.service.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260521T000432-8a4d36",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence path still exists. In packages/api/src/services/media.service.ts, associateMediaToPost is still at lines 292-326 and still performs a for loop over mediaIds with an awaited db.update(postMedia).set({ postId, sortOrder }).where(...) inside the loop at lines 316-326, so it remains N sequential UPDATE statements. The current unit test in packages/api/src/__tests__/services/media.test.ts lines 436-448 also asserts this behavior with expect(mockDb.update).toHaveBeenCalledTimes(3). A focused Vitest run could not complete because the read-only sandbox prevented Vite from writing its temporary config file, but the current code and tests are enough to determine the issue is still open.",
+      "commands": [
+        "rg -n \"associateMediaToPost|mediaId|sortOrder\" packages/api/src packages/api/test packages/api/tests || true",
+        "rg --files packages/api | rg \"media\\.service|media.*test|media.*spec\"",
+        "sed -n '285,335p' packages/api/src/services/media.service.ts",
+        "sed -n '430,470p' packages/api/src/__tests__/services/media.test.ts",
+        "rg -n 'CASE|case\\(|update\\(postMedia\\)|toHaveBeenCalledTimes\\(1\\)|bulk|associateMediaToPost' packages/api/src/services packages/api/src/__tests__",
+        "pnpm --filter @sms/api test -- --run packages/api/src/__tests__/services/media.test.ts",
+        "nl -ba packages/api/src/services/media.service.ts | sed -n '292,326p'",
+        "nl -ba packages/api/src/__tests__/services/media.test.ts | sed -n '436,452p'"
+      ],
+      "createdAt": "2026-05-21T00:05:27.074Z"
+    },
+    {
+      "runId": "20260521T000759-f7a860",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence path still exists. In packages/api/src/services/media.service.ts, associateMediaToPost is still present at lines 292-332, but the prior sequential for loop with an awaited db.update(postMedia) per mediaId has been replaced by one db.update(postMedia) call using inArray(postMedia.id, mediaIds) and a SQL CASE expression built from sortOrderCases for sortOrder. The focused regression test in packages/api/src/__tests__/services/media.test.ts lines 436-454 has also been updated to assert mockDb.update is called once and that sortOrder is SQL-backed. A targeted Vitest run could not execute because the read-only sandbox prevented Vite from writing packages/api/node_modules/.vite-temp, but the current code and test expectations show the reported serial UPDATE loop has been removed.",
+      "commands": [
+        "rg -n \"associateMediaToPost|update\\(postMedia\\)|sortOrder|CASE|case\\(\" packages/api/src/services/media.service.ts packages/api/src/__tests__/services/media.test.ts packages/api/src 2>/dev/null || true",
+        "rg --files packages/api | rg \"media\\.service|media.*test|media.*spec\"",
+        "git status --short",
+        "nl -ba packages/api/src/services/media.service.ts | sed -n '292,334p'",
+        "nl -ba packages/api/src/__tests__/services/media.test.ts | sed -n '436,492p'",
+        "sed -n '1,80p' packages/api/src/services/media.service.ts",
+        "pnpm --filter @sms/api test -- --run packages/api/src/__tests__/services/media.test.ts",
+        "rg -n \"for \\(|for await|forEach|Promise\\.all|update\\(postMedia\\)|sortOrderCases|sql\\.join\" packages/api/src/services/media.service.ts packages/api/src/__tests__/services/media.test.ts",
+        "git diff -- packages/api/src/services/media.service.ts packages/api/src/__tests__/services/media.test.ts",
+        "rg -n \"for \\(const .*mediaIds|for \\(let .*mediaIds|await db\\s*$|await db\\.[\\s\\S]*update\\(postMedia\\)\" packages/api/src/services/media.service.ts"
+      ],
+      "createdAt": "2026-05-21T00:08:40.634Z"
+    }
+  ],
+  "signature": "sig_gh-8_31d12ef214",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-8-31d12ef214-71e69e6a_20cda743d7"
+  ],
+  "createdByRunId": "20260519T201935-c24f6a",
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T00:08:40.634Z"
+}

--- a/packages/api/src/__tests__/services/media.test.ts
+++ b/packages/api/src/__tests__/services/media.test.ts
@@ -434,7 +434,7 @@ describe('media.service', () => {
   });
 
   describe('associateMediaToPost', () => {
-    it('sets postId + sortOrder for each media id', async () => {
+    it('sets postId + sortOrder for all media ids in one update', async () => {
       const mediaIds = ['media-1', 'media-2', 'media-3'];
       const selectChain: any = {
         from: vi.fn().mockReturnThis(),
@@ -444,8 +444,13 @@ describe('media.service', () => {
 
       await associateMediaToPost(mockDb, 'user-1', 'post-id-1', mediaIds);
 
-      // Should have called update for each media id directly (no inner transaction)
-      expect(mockDb.update).toHaveBeenCalledTimes(3);
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+      const updateChain = mockDb.update.mock.results[0].value;
+      const setCall = updateChain.set.mock.calls[0][0];
+      expect(setCall.postId).toBe('post-id-1');
+      expect(setCall.sortOrder).toEqual(expect.objectContaining({
+        getSQL: expect.any(Function),
+      }));
     });
 
     it('skips rows where postId is already set (prevents double-claiming)', async () => {

--- a/packages/api/src/__tests__/services/media.test.ts
+++ b/packages/api/src/__tests__/services/media.test.ts
@@ -4,10 +4,12 @@ import type { Queue } from 'bullmq';
 // Mock sharp before import
 const mockSharpInstance = {
   metadata: vi.fn(),
+  clone: vi.fn(),
   rotate: vi.fn(),
   resize: vi.fn(),
   toBuffer: vi.fn(),
 };
+mockSharpInstance.clone.mockReturnValue(mockSharpInstance);
 mockSharpInstance.rotate.mockReturnValue(mockSharpInstance);
 mockSharpInstance.resize.mockReturnValue(mockSharpInstance);
 
@@ -24,6 +26,7 @@ vi.mock('node:fs', () => ({
   createReadStream: vi.fn().mockReturnValue({ pipe: vi.fn() }),
 }));
 
+import sharp from 'sharp';
 import {
   processImageUpload,
   processVideoUpload,
@@ -106,7 +109,16 @@ describe('media.service', () => {
         height: 600,
         format: 'jpeg',
       });
-      mockSharpInstance.toBuffer.mockResolvedValue(Buffer.alloc(5000));
+      mockSharpInstance.toBuffer.mockImplementation((options?: { resolveWithObject?: boolean }) => {
+        const buffer = Buffer.alloc(5000);
+        if (options?.resolveWithObject) {
+          return Promise.resolve({
+            data: buffer,
+            info: { width: 800, height: 600 },
+          });
+        }
+        return Promise.resolve(buffer);
+      });
 
       // Mock insert returning a row with an id
       const insertChain: any = {
@@ -148,6 +160,32 @@ describe('media.service', () => {
       expect(mockSharpInstance.metadata).toHaveBeenCalled();
       expect(result.mimeType).toBe('image/jpeg');
       expect(result.fileSize).toBeGreaterThan(0);
+    });
+
+    it('uses cloned sharp pipelines and resolveWithObject for processed dimensions', async () => {
+      mockSharpInstance.toBuffer.mockImplementation((options?: { resolveWithObject?: boolean }) => {
+        const buffer = Buffer.alloc(5000);
+        if (options?.resolveWithObject) {
+          return Promise.resolve({
+            data: buffer,
+            info: { width: 640, height: 480 },
+          });
+        }
+        return Promise.resolve(buffer);
+      });
+
+      await processImageUpload(baseParams);
+
+      expect(vi.mocked(sharp)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(sharp).mock.calls[0][0]).toBe(baseParams.tempFilePath);
+      expect(Buffer.isBuffer(vi.mocked(sharp).mock.calls[1][0])).toBe(true);
+      expect(mockSharpInstance.clone).toHaveBeenCalledTimes(2);
+      expect(mockSharpInstance.metadata).toHaveBeenCalledTimes(1);
+      expect(mockSharpInstance.toBuffer).toHaveBeenCalledWith({ resolveWithObject: true });
+
+      const valuesCall = mockDb.insert.mock.results[0].value.values.mock.calls[0][0];
+      expect(valuesCall.width).toBe(640);
+      expect(valuesCall.height).toBe(480);
     });
 
     it('resizes images exceeding platform maxImageWidth/maxImageHeight before saving', async () => {

--- a/packages/api/src/services/media.service.ts
+++ b/packages/api/src/services/media.service.ts
@@ -60,7 +60,8 @@ export async function processImageUpload(params: ProcessImageParams) {
   }
 
   try {
-    const metadata = await sharp(tempFilePath).metadata();
+    const originalImage = sharp(tempFilePath);
+    const metadata = await originalImage.clone().metadata();
     const imageWidth = metadata.width ?? 0;
     const imageHeight = metadata.height ?? 0;
     const format = metadata.format ?? 'jpeg';
@@ -71,23 +72,19 @@ export async function processImageUpload(params: ProcessImageParams) {
       limits?.maxImageHeight &&
       (imageWidth > limits.maxImageWidth || imageHeight > limits.maxImageHeight);
 
-    let processedBuffer: Buffer;
+    const processedImage = originalImage.clone().rotate();
     if (needsResize) {
-      processedBuffer = await sharp(tempFilePath)
-        .rotate()
-        .resize(limits.maxImageWidth, limits.maxImageHeight, {
-          fit: 'inside',
-          withoutEnlargement: true,
-        })
-        .toBuffer();
-    } else {
-      processedBuffer = await sharp(tempFilePath).rotate().toBuffer();
+      processedImage.resize(limits.maxImageWidth, limits.maxImageHeight, {
+        fit: 'inside',
+        withoutEnlargement: true,
+      });
     }
 
-    // Re-read dimensions from the processed buffer
-    const processedMeta = await sharp(processedBuffer).metadata();
-    const resizedWidth = processedMeta.width ?? imageWidth;
-    const resizedHeight = processedMeta.height ?? imageHeight;
+    const { data: processedBuffer, info: processedInfo } = await processedImage.toBuffer({
+      resolveWithObject: true,
+    });
+    const resizedWidth = processedInfo.width ?? imageWidth;
+    const resizedHeight = processedInfo.height ?? imageHeight;
 
     const fileUuid = randomUUID();
     const ext = formatToExt(format);

--- a/packages/api/src/services/media.service.ts
+++ b/packages/api/src/services/media.service.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { unlink } from 'node:fs/promises';
 import { createReadStream } from 'node:fs';
 import sharp from 'sharp';
-import { eq, and, isNull, inArray } from 'drizzle-orm';
+import { eq, and, isNull, inArray, sql } from 'drizzle-orm';
 import type { Queue } from 'bullmq';
 import { PLATFORM_MEDIA_LIMITS, JOB_NAMES, AppError } from '@sms/shared';
 import { createLogger } from '@sms/shared/logger';
@@ -313,16 +313,20 @@ export async function associateMediaToPost(
     throw new MediaServiceError('One or more media files not found', 400);
   }
 
-  for (let sortOrder = 0; sortOrder < mediaIds.length; sortOrder++) {
-    const mediaId = mediaIds[sortOrder];
-    await db
-      .update(postMedia)
-      .set({ postId, sortOrder })
-      .where(and(
-        eq(postMedia.id, mediaId),
-        eq(postMedia.userId, userId),
-        isNull(postMedia.postId),
-        isNull(postMedia.deletedAt),
-      ));
-  }
+  const sortOrderCases = mediaIds.map((mediaId, sortOrder) => (
+    sql`when ${postMedia.id} = ${mediaId} then ${sortOrder}`
+  ));
+
+  await db
+    .update(postMedia)
+    .set({
+      postId,
+      sortOrder: sql<number>`case ${sql.join(sortOrderCases, sql` `)} else ${postMedia.sortOrder} end`,
+    })
+    .where(and(
+      inArray(postMedia.id, mediaIds),
+      eq(postMedia.userId, userId),
+      isNull(postMedia.postId),
+      isNull(postMedia.deletedAt),
+    ));
 }


### PR DESCRIPTION
## Summary

- avoid redundant Sharp decode passes in processImageUpload by using cloned pipelines and resolveWithObject metadata
- replace serial media association updates with one guarded bulk UPDATE using a SQL CASE expression for sort order

## Validation

- pnpm --filter @sms/api exec vitest run src/__tests__/services/media.test.ts

## Known existing blocker

- pnpm --filter @sms/api typecheck still fails on the pre-existing `packages/api/src/services/post-crud.service.ts(107,13)` scheduled_at_invalid exhaustiveness error, unrelated to this media change.

## Notes

Draft PR split from the Clawpatch batch; target branch is develop.