### PR TITLE
Add BulkOperationFactory and route bulk operations through it

### DIFF
--- a/.clawpatch/features/feat_gh-73_1c5c4c8dc2.json
+++ b/.clawpatch/features/feat_gh-73_1c5c4c8dc2.json
@@ -1,1 +1,71 @@
-{"schemaVersion":1,"featureId":"feat_gh-73_1c5c4c8dc2","title":"gh#73: R5.1 — Add BulkOperationFactory; absorb idempotency + insert + enqueue chain","summary":"Imported from GitHub issue gh#73 in BACKLOG.md section \"Candidate 5 — BulkOperationFactory\".","kind":"job","source":"github-issue-import","confidence":"high","entrypoints":[{"path":"packages/api/src/services/bulk-operation.factory.ts","symbol":null,"route":null,"command":null},{"path":"packages/shared/src/index.ts","symbol":null,"route":null,"command":null}],"ownedFiles":[{"path":"packages/api/src/services/bulk-operation.factory.ts","reason":"mentioned by issue body"},{"path":"packages/shared/src/index.ts","reason":"mentioned by issue body"}],"contextFiles":[{"path":"BACKLOG.md","reason":"backlog queue item for gh#73"}],"tests":[],"tags":["github-issue","gh#73","github-url:https://github.com/joshgk00/social-media-scheduler/issues/73","backlog-order:0018","backlog-section:candidate-5-bulkoperationfactory","label:enhancement"],"trustBoundaries":["network","database","concurrency"],"status":"needs-fix","lock":null,"findingIds":["fnd_sig-gh-73-899c10ed1d_7b2c2c83d5"],"patchAttemptIds":[],"analysisHistory":[{"runId":"20260519T201935-c24f6a","kind":"github-issue-import","summary":"Imported GitHub issue gh#73","provider":"gh","model":null,"createdAt":"2026-05-19T20:19:35.980Z"}],"createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-73_1c5c4c8dc2",
+  "title": "gh#73: R5.1 — Add BulkOperationFactory; absorb idempotency + insert + enqueue chain",
+  "summary": "Imported from GitHub issue gh#73 in BACKLOG.md section \"Candidate 5 — BulkOperationFactory\".",
+  "kind": "job",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/api/src/services/bulk-operation.factory.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/shared/src/index.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/api/src/services/bulk-operation.factory.ts",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/shared/src/index.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#73"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#73",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/73",
+    "backlog-order:0018",
+    "backlog-section:candidate-5-bulkoperationfactory",
+    "label:enhancement"
+  ],
+  "trustBoundaries": [
+    "network",
+    "database",
+    "concurrency"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-73-899c10ed1d_7b2c2c83d5"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260519T201935-c24f6a",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#73",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-19T20:19:35.980Z"
+    }
+  ],
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T03:34:13.803Z"
+}

--- a/.clawpatch/features/feat_gh-74_5ab9e85267.json
+++ b/.clawpatch/features/feat_gh-74_5ab9e85267.json
@@ -1,1 +1,62 @@
-{"schemaVersion":1,"featureId":"feat_gh-74_5ab9e85267","title":"gh#74: R5.2 — Switch routes/bulk-import.ts to BulkOperationFactory","summary":"Imported from GitHub issue gh#74 in BACKLOG.md section \"Candidate 5 — BulkOperationFactory\".","kind":"route","source":"github-issue-import","confidence":"high","entrypoints":[{"path":"packages/api/src/routes/bulk-import.ts","symbol":null,"route":null,"command":null}],"ownedFiles":[{"path":"packages/api/src/routes/bulk-import.ts","reason":"mentioned by issue body"}],"contextFiles":[{"path":"BACKLOG.md","reason":"backlog queue item for gh#74"}],"tests":[],"tags":["github-issue","gh#74","github-url:https://github.com/joshgk00/social-media-scheduler/issues/74","backlog-order:0019","backlog-section:candidate-5-bulkoperationfactory","label:enhancement"],"trustBoundaries":["auth","network","filesystem","concurrency"],"status":"needs-fix","lock":null,"findingIds":["fnd_sig-gh-74-b599156f48_584cde2681"],"patchAttemptIds":[],"analysisHistory":[{"runId":"20260519T201935-c24f6a","kind":"github-issue-import","summary":"Imported GitHub issue gh#74","provider":"gh","model":null,"createdAt":"2026-05-19T20:19:35.980Z"}],"createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-74_5ab9e85267",
+  "title": "gh#74: R5.2 — Switch routes/bulk-import.ts to BulkOperationFactory",
+  "summary": "Imported from GitHub issue gh#74 in BACKLOG.md section \"Candidate 5 — BulkOperationFactory\".",
+  "kind": "route",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/api/src/routes/bulk-import.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/api/src/routes/bulk-import.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#74"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#74",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/74",
+    "backlog-order:0019",
+    "backlog-section:candidate-5-bulkoperationfactory",
+    "label:enhancement"
+  ],
+  "trustBoundaries": [
+    "auth",
+    "network",
+    "filesystem",
+    "concurrency"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-74-b599156f48_584cde2681"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260519T201935-c24f6a",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#74",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-19T20:19:35.980Z"
+    }
+  ],
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T03:42:09.004Z"
+}

--- a/.clawpatch/features/feat_gh-75_2fe045d92a.json
+++ b/.clawpatch/features/feat_gh-75_2fe045d92a.json
@@ -1,1 +1,62 @@
-{"schemaVersion":1,"featureId":"feat_gh-75_2fe045d92a","title":"gh#75: R5.3 — Switch routes/queues.ts bulk-ops path to BulkOperationFactory; sweep","summary":"Imported from GitHub issue gh#75 in BACKLOG.md section \"Candidate 5 — BulkOperationFactory\".","kind":"route","source":"github-issue-import","confidence":"high","entrypoints":[{"path":"packages/api/src/routes/queues.ts","symbol":null,"route":null,"command":null}],"ownedFiles":[{"path":"packages/api/src/routes/queues.ts","reason":"mentioned by issue body"}],"contextFiles":[{"path":"BACKLOG.md","reason":"backlog queue item for gh#75"}],"tests":[],"tags":["github-issue","gh#75","github-url:https://github.com/joshgk00/social-media-scheduler/issues/75","backlog-order:0020","backlog-section:candidate-5-bulkoperationfactory","label:enhancement"],"trustBoundaries":["auth","network","filesystem","concurrency"],"status":"needs-fix","lock":null,"findingIds":["fnd_sig-gh-75-d37f32bc2b_d3133aef9d"],"patchAttemptIds":[],"analysisHistory":[{"runId":"20260519T201935-c24f6a","kind":"github-issue-import","summary":"Imported GitHub issue gh#75","provider":"gh","model":null,"createdAt":"2026-05-19T20:19:35.980Z"}],"createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-75_2fe045d92a",
+  "title": "gh#75: R5.3 — Switch routes/queues.ts bulk-ops path to BulkOperationFactory; sweep",
+  "summary": "Imported from GitHub issue gh#75 in BACKLOG.md section \"Candidate 5 — BulkOperationFactory\".",
+  "kind": "route",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/api/src/routes/queues.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/api/src/routes/queues.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#75"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#75",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/75",
+    "backlog-order:0020",
+    "backlog-section:candidate-5-bulkoperationfactory",
+    "label:enhancement"
+  ],
+  "trustBoundaries": [
+    "auth",
+    "network",
+    "filesystem",
+    "concurrency"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-75-d37f32bc2b_d3133aef9d"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260519T201935-c24f6a",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#75",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-19T20:19:35.980Z"
+    }
+  ],
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T03:53:09.234Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-73-899c10ed1d_7b2c2c83d5.json
+++ b/.clawpatch/findings/fnd_sig-gh-73-899c10ed1d_7b2c2c83d5.json
@@ -1,1 +1,97 @@
-{"schemaVersion":1,"findingId":"fnd_sig-gh-73-899c10ed1d_7b2c2c83d5","featureId":"feat_gh-73_1c5c4c8dc2","title":"gh#73: R5.1 — Add BulkOperationFactory; absorb idempotency + insert + enqueue chain","category":"maintainability","severity":"low","confidence":"high","triage":"risk","evidence":[{"path":"packages/api/src/services/bulk-operation.factory.ts","startLine":null,"endLine":null,"symbol":null,"quote":null},{"path":"packages/shared/src/index.ts","startLine":null,"endLine":null,"symbol":null,"quote":null}],"reasoning":"Imported from https://github.com/joshgk00/social-media-scheduler/issues/73.\nBacklog section: Candidate 5 — BulkOperationFactory.\n\n## Context\n\nFirst PR in Candidate 5. The current `bulk-ops-queue.service.ts` is a 36-line BullMQ wrapper. The real orchestration (idempotency-key parsing + bulk_operations existence check + insert + enqueue) lives in each route that needs bulk ops — currently `routes/bulk-import.ts` and the bulk-ops branch of `routes/queues.ts`. Future endpoints (e.g., bulk delete posts) would copy the same dance.\n\nSee [BACKLOG.md](../blob/main/BACKLOG.md) → Architectural Deepening → Candidate 5.\n\n## Scope\n\n- Add `packages/api/src/services/bulk-operation.factory.ts` (or a similar location) exporting:\n  ```ts\n  interface BulkOperationFactory {\n    startBulkOperation(args: {\n      userId: string;\n      idempotencyKey: string | undefined;\n      type: 'import_scheduled' | 'import_queue' | 'queue_bulk_op_X' | ...;\n      params: Record<string, unknown>;  // job payload\n      jobName: JobName;\n    }): Promise<{\n      bulkOperationId: string;\n      jobId: string | null;\n      replay: boolean;\n    }>;\n  }\n  ```\n- Move the full chain into the factory:\n  - Parse + validate `Idempotency-Key` header (UUID validation)\n  - Lookup existing `bulk_operations` row by (userId, idempotencyKey)\n  - If exists: return `{ bulkOperationId, jobId: null, replay: true }`\n  - Otherwise: insert new `bulk_operations` row, enqueue job, return `{ bulkOperationId, jobId, replay: false }`\n- Inject `BulkOpsQueueService` + `Db` via the factory constructor\n- Unit tests covering: new operation path, replay path, invalid idempotency key, transaction rollback if insert + enqueue is non-atomic (verify the ordering matches existing semantics)\n- Keep the existing `bulk-ops-queue.service.ts` for now — R5.2 / R5.3 switch consumers, then R5.3 sweep removes the standalone service if subsumed\n\n## Out of scope\n\n- Switching consumers (R5.2, R5.3)\n- Removing the existing `bulk-ops-queue.service.ts` (R5.3 sweep)\n- Moving the factory into `@sms/shared` — keep in api package since both consumers are routes; cross-package isn't needed\n\n## Acceptance\n\n- `pnpm --filter @sms/api build` and test pass\n- Factory unit tests achieve full branch coverage\n- No existing callers changed\n\n## References\n\n- Depends on: nothing (first in Candidate 5 series)","reproduction":"First PR in Candidate 5. The current `bulk-ops-queue.service.ts` is a 36-line BullMQ wrapper. The real orchestration (idempotency-key parsing + bulk_operations existence check + insert + enqueue) lives in each route that needs bulk ops — currently `routes/bulk-import.ts` and the bulk-ops branch of `routes/queues.ts`. Future endpoints (e.g., bulk delete posts) would copy the same dance.\n\nSee [BACKLOG.md](../blob/main/BACKLOG.md) → Architectural Deepening → Candidate 5.","recommendation":"- Add `packages/api/src/services/bulk-operation.factory.ts` (or a similar location) exporting:\n  ```ts\n  interface BulkOperationFactory {\n    startBulkOperation(args: {\n      userId: string;\n      idempotencyKey: string | undefined;\n      type: 'import_scheduled' | 'import_queue' | 'queue_bulk_op_X' | ...;\n      params: Record<string, unknown>;  // job payload\n      jobName: JobName;\n    }): Promise<{\n      bulkOperationId: string;\n      jobId: string | null;\n      replay: boolean;\n    }>;\n  }\n  ```\n- Move the full chain into the factory:\n  - Parse + validate `Idempotency-Key` header (UUID validation)\n  - Lookup existing `bulk_operations` row by (userId, idempotencyKey)\n  - If exists: return `{ bulkOperationId, jobId: null, replay: true }`\n  - Otherwise: insert new `bulk_operations` row, enqueue job, return `{ bulkOperationId, jobId, replay: false }`\n- Inject `BulkOpsQueueService` + `Db` via the factory constructor\n- Unit tests covering: new operation path, replay path, invalid idempotency key, transaction rollback if insert + enqueue is non-atomic (verify the ordering matches existing semantics)\n- Keep the existing `bulk-ops-queue.service.ts` for now — R5.2 / R5.3 switch consumers, then R5.3 sweep removes the standalone service if subsumed","whyTestsDoNotAlreadyCoverThis":"Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.","suggestedRegressionTest":"- `pnpm --filter @sms/api build` and test pass\n- Factory unit tests achieve full branch coverage\n- No existing callers changed","minimumFixScope":"packages/api/src/services/bulk-operation.factory.ts, packages/shared/src/index.ts","status":"open","history":[],"signature":"sig_gh-73_899c10ed1d","linkedPatchAttemptIds":[],"createdByRunId":"20260519T201935-c24f6a","createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-73-899c10ed1d_7b2c2c83d5",
+  "featureId": "feat_gh-73_1c5c4c8dc2",
+  "title": "gh#73: R5.1 — Add BulkOperationFactory; absorb idempotency + insert + enqueue chain",
+  "category": "maintainability",
+  "severity": "low",
+  "confidence": "high",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "packages/api/src/services/bulk-operation.factory.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/shared/src/index.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/73.\nBacklog section: Candidate 5 — BulkOperationFactory.\n\n## Context\n\nFirst PR in Candidate 5. The current `bulk-ops-queue.service.ts` is a 36-line BullMQ wrapper. The real orchestration (idempotency-key parsing + bulk_operations existence check + insert + enqueue) lives in each route that needs bulk ops — currently `routes/bulk-import.ts` and the bulk-ops branch of `routes/queues.ts`. Future endpoints (e.g., bulk delete posts) would copy the same dance.\n\nSee [BACKLOG.md](../blob/main/BACKLOG.md) → Architectural Deepening → Candidate 5.\n\n## Scope\n\n- Add `packages/api/src/services/bulk-operation.factory.ts` (or a similar location) exporting:\n  ```ts\n  interface BulkOperationFactory {\n    startBulkOperation(args: {\n      userId: string;\n      idempotencyKey: string | undefined;\n      type: 'import_scheduled' | 'import_queue' | 'queue_bulk_op_X' | ...;\n      params: Record<string, unknown>;  // job payload\n      jobName: JobName;\n    }): Promise<{\n      bulkOperationId: string;\n      jobId: string | null;\n      replay: boolean;\n    }>;\n  }\n  ```\n- Move the full chain into the factory:\n  - Parse + validate `Idempotency-Key` header (UUID validation)\n  - Lookup existing `bulk_operations` row by (userId, idempotencyKey)\n  - If exists: return `{ bulkOperationId, jobId: null, replay: true }`\n  - Otherwise: insert new `bulk_operations` row, enqueue job, return `{ bulkOperationId, jobId, replay: false }`\n- Inject `BulkOpsQueueService` + `Db` via the factory constructor\n- Unit tests covering: new operation path, replay path, invalid idempotency key, transaction rollback if insert + enqueue is non-atomic (verify the ordering matches existing semantics)\n- Keep the existing `bulk-ops-queue.service.ts` for now — R5.2 / R5.3 switch consumers, then R5.3 sweep removes the standalone service if subsumed\n\n## Out of scope\n\n- Switching consumers (R5.2, R5.3)\n- Removing the existing `bulk-ops-queue.service.ts` (R5.3 sweep)\n- Moving the factory into `@sms/shared` — keep in api package since both consumers are routes; cross-package isn't needed\n\n## Acceptance\n\n- `pnpm --filter @sms/api build` and test pass\n- Factory unit tests achieve full branch coverage\n- No existing callers changed\n\n## References\n\n- Depends on: nothing (first in Candidate 5 series)",
+  "reproduction": "First PR in Candidate 5. The current `bulk-ops-queue.service.ts` is a 36-line BullMQ wrapper. The real orchestration (idempotency-key parsing + bulk_operations existence check + insert + enqueue) lives in each route that needs bulk ops — currently `routes/bulk-import.ts` and the bulk-ops branch of `routes/queues.ts`. Future endpoints (e.g., bulk delete posts) would copy the same dance.\n\nSee [BACKLOG.md](../blob/main/BACKLOG.md) → Architectural Deepening → Candidate 5.",
+  "recommendation": "- Add `packages/api/src/services/bulk-operation.factory.ts` (or a similar location) exporting:\n  ```ts\n  interface BulkOperationFactory {\n    startBulkOperation(args: {\n      userId: string;\n      idempotencyKey: string | undefined;\n      type: 'import_scheduled' | 'import_queue' | 'queue_bulk_op_X' | ...;\n      params: Record<string, unknown>;  // job payload\n      jobName: JobName;\n    }): Promise<{\n      bulkOperationId: string;\n      jobId: string | null;\n      replay: boolean;\n    }>;\n  }\n  ```\n- Move the full chain into the factory:\n  - Parse + validate `Idempotency-Key` header (UUID validation)\n  - Lookup existing `bulk_operations` row by (userId, idempotencyKey)\n  - If exists: return `{ bulkOperationId, jobId: null, replay: true }`\n  - Otherwise: insert new `bulk_operations` row, enqueue job, return `{ bulkOperationId, jobId, replay: false }`\n- Inject `BulkOpsQueueService` + `Db` via the factory constructor\n- Unit tests covering: new operation path, replay path, invalid idempotency key, transaction rollback if insert + enqueue is non-atomic (verify the ordering matches existing semantics)\n- Keep the existing `bulk-ops-queue.service.ts` for now — R5.2 / R5.3 switch consumers, then R5.3 sweep removes the standalone service if subsumed",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": "- `pnpm --filter @sms/api build` and test pass\n- Factory unit tests achieve full branch coverage\n- No existing callers changed",
+  "minimumFixScope": "packages/api/src/services/bulk-operation.factory.ts, packages/shared/src/index.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260521T032700-de859f",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The requested factory still has not been added: packages/api/src/services/bulk-operation.factory.ts is absent, and searches found no BulkOperationFactory or startBulkOperation implementation/export. The original shared barrel path packages/shared/src/index.ts still exists, but it does not export any factory. The orchestration remains inline in current route code: bulk-import still parses Idempotency-Key, checks bulk_operations, inserts, and enqueues at packages/api/src/routes/bulk-import.ts:28,101,195,226; queues does the same through enqueueQueueBulkOperation at packages/api/src/routes/queues.ts:41,82,93,104,115; posts has another copy at packages/api/src/routes/posts.ts:134,184,196,207,218. Regression coverage is also not present: the only matching idempotency test is a todo. I attempted tests/typecheck: Vitest could not start in the read-only sandbox because Vite tried to write .vite-temp, and typecheck fails on an unrelated existing TS error in post-crud.service.ts. Current code evidence is sufficient that the maintainability issue remains open.",
+      "commands": [
+        "pwd && rg --files | rg 'packages/(api/src/services/bulk-operation.factory.ts|shared/src/index.ts|api/src/routes/(bulk-import|queues)\\.ts|api/src/services/bulk-ops-queue.service.ts|api/.*bulk.*factory|api/.*bulk.*operation)'",
+        "git status --short",
+        "sed -n '1,240p' packages/api/src/services/bulk-ops-queue.service.ts",
+        "sed -n '1,260p' packages/api/src/routes/bulk-import.ts",
+        "sed -n '1,320p' packages/api/src/routes/queues.ts",
+        "sed -n '1,200p' packages/shared/src/index.ts",
+        "sed -n '320,760p' packages/api/src/routes/queues.ts",
+        "rg -n \"BulkOperationFactory|bulk-operation.factory|startBulkOperation|parseIdempotencyKey|enqueueQueueBulkOperation|bulkOperations.*idempotencyKey|enqueueBulkOp\" packages/api/src packages/api/test packages/api/tests packages/shared/src 2>/dev/null",
+        "rg --files packages/api | rg '(test|spec)\\.(ts|tsx)$|__tests__'",
+        "find packages/api/src/services -maxdepth 1 -type f -print | sort",
+        "nl -ba packages/api/src/routes/bulk-import.ts | sed -n '20,245p'",
+        "nl -ba packages/api/src/routes/queues.ts | sed -n '35,130p;235,380p'",
+        "nl -ba packages/api/src/routes/posts.ts | sed -n '120,230p;470,565p'",
+        "test -f packages/api/src/services/bulk-operation.factory.ts; printf 'bulk-operation.factory.ts exists: %s\\n' \"$?\"; find packages/api/src -path '*bulk-operation*factory*' -o -path '*BulkOperationFactory*'",
+        "sed -n '1,220p' packages/api/package.json",
+        "rg -n \"bulk-operation\\.factory|BulkOperationFactory|startBulkOperation|idempotency|enqueueBulkOp|bulkOperationId|replay\" packages/api/src/__tests__ packages/api/src/services/__tests__ packages/api/src/routes/__tests__",
+        "pnpm --filter @sms/api test -- --run packages/api/src/__tests__/routes/bulk-idempotency.test.ts",
+        "sed -n '1,220p' packages/api/tsconfig.json",
+        "rg -n \"incremental|tsBuildInfo|noEmit\" tsconfig.json packages/api/tsconfig.json packages/*/tsconfig.json",
+        "pnpm --filter @sms/api typecheck"
+      ],
+      "createdAt": "2026-05-21T03:28:15.305Z"
+    },
+    {
+      "runId": "20260521T033221-626f28",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence paths now exist in the current working tree: packages/api/src/services/bulk-operation.factory.ts is present and exports BulkOperationFactory plus createBulkOperationFactory. The factory validates or generates the idempotency key, checks bulk_operations by userId/idempotencyKey, returns replay metadata for existing rows, inserts a new row, enqueues via BulkOpsQueueService, and returns the job id. Focused tests exist at packages/api/src/services/__tests__/bulk-operation.factory.test.ts covering the new operation path, generated/missing idempotency key path, replay path, invalid idempotency key, and insert-before-enqueue failure ordering. packages/shared/src/index.ts still exists; it was not changed, but the issue explicitly said to keep the factory in the api package and not move it into @sms/shared. Existing route orchestration remains inline in bulk-import/queues/posts, but consumer switching was explicitly out of scope for this R5.1 finding. Verification: a focused tsc check of bulk-operation.factory.ts passed. Full api typecheck is still blocked by an unrelated existing error in post-crud.service.ts, and Vitest could not run in the read-only sandbox because Vite tried to create temp/cache files.",
+      "commands": [
+        "pwd",
+        "git status --short",
+        "rg --files | rg 'packages/(api/src/services/bulk-operation.factory.ts|shared/src/index.ts|api/src/routes/(bulk-import|queues|posts)\\.ts|api/src/services/bulk-ops-queue.service.ts|api/src/.*bulk.*operation|api/src/.*bulk.*factory)'",
+        "rg -n \"BulkOperationFactory|bulk-operation\\.factory|startBulkOperation|parseIdempotencyKey|enqueueQueueBulkOperation|enqueueBulkOp|bulkOperations.*idempotencyKey|idempotencyKey\" packages/api/src packages/shared/src packages/api/test packages/api/tests 2>/dev/null",
+        "nl -ba packages/api/src/services/bulk-operation.factory.ts | sed -n '1,180p'",
+        "nl -ba packages/api/src/services/__tests__/bulk-operation.factory.test.ts | sed -n '1,240p'",
+        "nl -ba packages/shared/src/index.ts | sed -n '1,220p'",
+        "nl -ba packages/api/src/routes/bulk-import.ts | sed -n '20,245p'",
+        "nl -ba packages/api/src/routes/queues.ts | sed -n '35,390p'",
+        "nl -ba packages/api/src/routes/posts.ts | sed -n '120,230p;470,585p'",
+        "cat packages/api/package.json",
+        "cat packages/api/vitest.config.ts",
+        "pnpm --filter @sms/api exec tsc --noEmit --pretty false -p tsconfig.json",
+        "pnpm --filter @sms/api exec tsc --noEmit --pretty false --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --esModuleInterop --skipLibCheck src/services/bulk-operation.factory.ts",
+        "pnpm --filter @sms/api exec vitest run src/services/__tests__/bulk-operation.factory.test.ts --configLoader runner --no-cache"
+      ],
+      "createdAt": "2026-05-21T03:34:13.751Z"
+    }
+  ],
+  "signature": "sig_gh-73_899c10ed1d",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-73-899c10ed1d-7b2c2c8_aa34773ae7"
+  ],
+  "createdByRunId": "20260519T201935-c24f6a",
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T03:34:13.751Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-74-b599156f48_584cde2681.json
+++ b/.clawpatch/findings/fnd_sig-gh-74-b599156f48_584cde2681.json
@@ -1,1 +1,90 @@
-{"schemaVersion":1,"findingId":"fnd_sig-gh-74-b599156f48_584cde2681","featureId":"feat_gh-74_5ab9e85267","title":"gh#74: R5.2 — Switch routes/bulk-import.ts to BulkOperationFactory","category":"maintainability","severity":"low","confidence":"high","triage":"risk","evidence":[{"path":"packages/api/src/routes/bulk-import.ts","startLine":null,"endLine":null,"symbol":null,"quote":null}],"reasoning":"Imported from https://github.com/joshgk00/social-media-scheduler/issues/74.\nBacklog section: Candidate 5 — BulkOperationFactory.\n\n## Context\n\nSecond PR in Candidate 5. Migrates the bulk-import route to the factory. Validates the factory shape against the first consumer; R5.3 validates against the second.\n\n## Scope\n\n- Modify `packages/api/src/routes/bulk-import.ts`:\n  - Remove the inline idempotency-key parsing (`parseIdempotencyKey` + `UUID_PATTERN` regex — these move into the factory)\n  - Remove the inline `bulk_operations` existence-check SELECT\n  - Remove the inline insert + enqueue\n  - Replace with a single `factory.startBulkOperation(...)` call\n  - Profile / queue ownership checks STAY in the route (auth concern, not factory's job)\n  - CSV parsing STAYS in the route (input-shape concern, not factory's job)\n  - Route still emits the same response shape: `{ bulkOperationId, jobId, replay }`\n\n- Inject `BulkOperationFactory` via the existing `BulkImportRouterDeps`\n\n- Verify with existing integration tests — no behavior change\n\n## Out of scope\n\n- queues bulk-ops route (R5.3)\n- Removing the standalone `bulk-ops-queue.service.ts` (R5.3 sweep)\n\n## Acceptance\n\n- `pnpm --filter @sms/api build` and test pass\n- `rg \"UUID_PATTERN|parseIdempotencyKey\" packages/api/src/routes/bulk-import.ts` returns no matches\n- `rg \"from.*'bulkOperations'\" packages/api/src/routes/bulk-import.ts` returns no matches (the route doesn't import the table directly anymore)\n- Existing bulk-import integration tests pass\n\n## References\n\n- Depends on: #73","reproduction":"Second PR in Candidate 5. Migrates the bulk-import route to the factory. Validates the factory shape against the first consumer; R5.3 validates against the second.","recommendation":"- Modify `packages/api/src/routes/bulk-import.ts`:\n  - Remove the inline idempotency-key parsing (`parseIdempotencyKey` + `UUID_PATTERN` regex — these move into the factory)\n  - Remove the inline `bulk_operations` existence-check SELECT\n  - Remove the inline insert + enqueue\n  - Replace with a single `factory.startBulkOperation(...)` call\n  - Profile / queue ownership checks STAY in the route (auth concern, not factory's job)\n  - CSV parsing STAYS in the route (input-shape concern, not factory's job)\n  - Route still emits the same response shape: `{ bulkOperationId, jobId, replay }`\n\n- Inject `BulkOperationFactory` via the existing `BulkImportRouterDeps`\n\n- Verify with existing integration tests — no behavior change","whyTestsDoNotAlreadyCoverThis":"Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.","suggestedRegressionTest":"- `pnpm --filter @sms/api build` and test pass\n- `rg \"UUID_PATTERN|parseIdempotencyKey\" packages/api/src/routes/bulk-import.ts` returns no matches\n- `rg \"from.*'bulkOperations'\" packages/api/src/routes/bulk-import.ts` returns no matches (the route doesn't import the table directly anymore)\n- Existing bulk-import integration tests pass","minimumFixScope":"packages/api/src/routes/bulk-import.ts","status":"open","history":[],"signature":"sig_gh-74_b599156f48","linkedPatchAttemptIds":[],"createdByRunId":"20260519T201935-c24f6a","createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-74-b599156f48_584cde2681",
+  "featureId": "feat_gh-74_5ab9e85267",
+  "title": "gh#74: R5.2 — Switch routes/bulk-import.ts to BulkOperationFactory",
+  "category": "maintainability",
+  "severity": "low",
+  "confidence": "high",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "packages/api/src/routes/bulk-import.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/74.\nBacklog section: Candidate 5 — BulkOperationFactory.\n\n## Context\n\nSecond PR in Candidate 5. Migrates the bulk-import route to the factory. Validates the factory shape against the first consumer; R5.3 validates against the second.\n\n## Scope\n\n- Modify `packages/api/src/routes/bulk-import.ts`:\n  - Remove the inline idempotency-key parsing (`parseIdempotencyKey` + `UUID_PATTERN` regex — these move into the factory)\n  - Remove the inline `bulk_operations` existence-check SELECT\n  - Remove the inline insert + enqueue\n  - Replace with a single `factory.startBulkOperation(...)` call\n  - Profile / queue ownership checks STAY in the route (auth concern, not factory's job)\n  - CSV parsing STAYS in the route (input-shape concern, not factory's job)\n  - Route still emits the same response shape: `{ bulkOperationId, jobId, replay }`\n\n- Inject `BulkOperationFactory` via the existing `BulkImportRouterDeps`\n\n- Verify with existing integration tests — no behavior change\n\n## Out of scope\n\n- queues bulk-ops route (R5.3)\n- Removing the standalone `bulk-ops-queue.service.ts` (R5.3 sweep)\n\n## Acceptance\n\n- `pnpm --filter @sms/api build` and test pass\n- `rg \"UUID_PATTERN|parseIdempotencyKey\" packages/api/src/routes/bulk-import.ts` returns no matches\n- `rg \"from.*'bulkOperations'\" packages/api/src/routes/bulk-import.ts` returns no matches (the route doesn't import the table directly anymore)\n- Existing bulk-import integration tests pass\n\n## References\n\n- Depends on: #73",
+  "reproduction": "Second PR in Candidate 5. Migrates the bulk-import route to the factory. Validates the factory shape against the first consumer; R5.3 validates against the second.",
+  "recommendation": "- Modify `packages/api/src/routes/bulk-import.ts`:\n  - Remove the inline idempotency-key parsing (`parseIdempotencyKey` + `UUID_PATTERN` regex — these move into the factory)\n  - Remove the inline `bulk_operations` existence-check SELECT\n  - Remove the inline insert + enqueue\n  - Replace with a single `factory.startBulkOperation(...)` call\n  - Profile / queue ownership checks STAY in the route (auth concern, not factory's job)\n  - CSV parsing STAYS in the route (input-shape concern, not factory's job)\n  - Route still emits the same response shape: `{ bulkOperationId, jobId, replay }`\n\n- Inject `BulkOperationFactory` via the existing `BulkImportRouterDeps`\n\n- Verify with existing integration tests — no behavior change",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": "- `pnpm --filter @sms/api build` and test pass\n- `rg \"UUID_PATTERN|parseIdempotencyKey\" packages/api/src/routes/bulk-import.ts` returns no matches\n- `rg \"from.*'bulkOperations'\" packages/api/src/routes/bulk-import.ts` returns no matches (the route doesn't import the table directly anymore)\n- Existing bulk-import integration tests pass",
+  "minimumFixScope": "packages/api/src/routes/bulk-import.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260521T033548-c89ff6",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence path still exists at packages/api/src/routes/bulk-import.ts and the finding remains open. Current code still imports bulkOperations directly from @sms/db at line 7, defines UUID_PATTERN at line 22 and parseIdempotencyKey at lines 28-32, checks existing bulk operations with .from(bulkOperations) at lines 102-107, inserts bulkOperations at lines 196-217, updates bulkOperations at lines 221-223, and enqueues via bulkOpsQueueService.enqueueBulkOp at line 226 instead of using BulkOperationFactory.startBulkOperation. BulkOperationFactory exists in packages/api/src/services/bulk-operation.factory.ts, but createBulkImportRouter still accepts bulkOpsQueueService directly and app.ts still injects { db, bulkOpsQueueService }. Targeted Vitest runs could not execute in the current read-only sandbox because Vitest attempted to create temp/SSR directories and failed with EPERM; typecheck also fails on an unrelated existing error in src/services/post-crud.service.ts(107,13).",
+      "commands": [
+        "pwd && rg -n \"UUID_PATTERN|parseIdempotencyKey|bulkOperations|BulkOperationFactory|startBulkOperation|bulk_operations\" packages/api/src/routes/bulk-import.ts",
+        "sed -n '1,260p' packages/api/src/routes/bulk-import.ts",
+        "rg -n \"bulk-import|BulkImportRouterDeps|startBulkOperation|BulkOperationFactory\" packages/api/src packages/api/test packages/api/tests",
+        "sed -n '1,240p' packages/api/src/services/bulk-operation.factory.ts",
+        "sed -n '100,140p' packages/api/src/app.ts",
+        "rg -n \"createBulkImportRouter|bulkOpsQueueService|bulkOperationFactory|createBulkOperationFactory|parseIdempotencyKey|UUID_PATTERN|from\\(bulkOperations\\)|insert\\(bulkOperations\\)|enqueueBulkOp|startBulkOperation\" packages/api/src",
+        "sed -n '1,220p' package.json",
+        "sed -n '1,220p' packages/api/package.json",
+        "sed -n '1,220p' packages/api/src/__tests__/routes/bulk-import.test.ts",
+        "rg -n \"UUID_PATTERN|parseIdempotencyKey\" packages/api/src/routes/bulk-import.ts",
+        "rg -n \"from.*'bulkOperations'|bulkOperations\" packages/api/src/routes/bulk-import.ts",
+        "pnpm --filter @sms/api test -- --run packages/api/src/__tests__/routes/bulk-import.test.ts",
+        "pnpm --filter @sms/api exec vitest --help",
+        "sed -n '1,220p' packages/api/vitest.config.ts",
+        "find packages/api/node_modules -maxdepth 2 -type d -name '.vite-temp' -print -exec ls -ld {} \\;",
+        "pnpm --filter @sms/api exec vitest run packages/api/src/__tests__/routes/bulk-import.test.ts --configLoader runner",
+        "pnpm --filter @sms/api exec vitest run packages/api/src/services/__tests__/bulk-operation.factory.test.ts --configLoader runner",
+        "pnpm --filter @sms/api typecheck",
+        "pnpm --filter @sms/api exec vitest run src/__tests__/routes/bulk-import.test.ts --configLoader runner",
+        "pnpm --filter @sms/api exec vitest run src/services/__tests__/bulk-operation.factory.test.ts --configLoader runner"
+      ],
+      "createdAt": "2026-05-21T03:37:34.151Z"
+    },
+    {
+      "runId": "20260521T034051-6033eb",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence path still exists, but the finding's requested change has been applied. packages/api/src/routes/bulk-import.ts now imports and injects BulkOperationFactory, its deps require bulkOperationFactory, and the route calls bulkOperationFactory.startBulkOperation at line 166 while preserving profile/queue ownership checks and CSV parsing in the route. The route no longer defines UUID_PATTERN or parseIdempotencyKey, no longer imports the bulkOperations table, and no longer performs inline bulk_operations select/insert/enqueue logic; the only remaining bulkOperations matches in that file are bulkOperationsLimiter middleware references. packages/api/src/app.ts now constructs createBulkOperationFactory(db, bulkOpsQueueService) when wiring /api/bulk-import. The moved idempotency parsing, existing-operation check, insert, enqueue, and response shape live in packages/api/src/services/bulk-operation.factory.ts. Verification commands for Vitest and build could not complete in this read-only sandbox: Vitest failed creating an SSR temp directory with EPERM, pnpm build failed writing dist files with EPERM, and tsc --noEmit also reports an unrelated existing src/services/post-crud.service.ts(107,13) type error. Despite the environment/test blockers, current code satisfies the migration acceptance criteria for this finding, so the finding is fixed.",
+      "commands": [
+        "pwd",
+        "rg -n \"UUID_PATTERN|parseIdempotencyKey|bulkOperations|BulkOperationFactory|startBulkOperation|bulk_operations|bulkOpsQueueService|enqueueBulkOp\" packages/api/src/routes/bulk-import.ts packages/api/src/app.ts packages/api/src/services -S",
+        "sed -n '1,280p' packages/api/src/routes/bulk-import.ts",
+        "sed -n '112,132p' packages/api/src/app.ts",
+        "rg -n \"UUID_PATTERN|parseIdempotencyKey\" packages/api/src/routes/bulk-import.ts",
+        "rg -n \"from.*'bulkOperations'|bulkOperations\" packages/api/src/routes/bulk-import.ts",
+        "rg -n \"createBulkImportRouter|bulkOperationFactory|bulkOpsQueueService\" packages/api/src/app.ts packages/api/src/routes/bulk-import.ts packages/api/src/__tests__/routes/bulk-import.test.ts -S",
+        "pnpm --filter @sms/api test -- --run src/__tests__/routes/bulk-import.test.ts --configLoader runner",
+        "pnpm --filter @sms/api build",
+        "pnpm --filter @sms/api exec vitest run src/__tests__/routes/bulk-import.test.ts --configLoader runner",
+        "pnpm --filter @sms/api exec tsc --noEmit --pretty false",
+        "sed -n '1,120p' packages/api/src/services/bulk-operation.factory.ts",
+        "sed -n '1,220p' packages/api/src/__tests__/routes/bulk-import.test.ts",
+        "rg -n \"bulkOperationFactory|startBulkOperation|InvalidIdempotencyKeyError|replay|bulkOperationId|jobId\" packages/api/src/__tests__/routes/bulk-import.test.ts packages/api/src/services/__tests__/bulk-operation.factory.test.ts",
+        "pnpm --filter @sms/api exec vitest run src/services/__tests__/bulk-operation.factory.test.ts --configLoader runner"
+      ],
+      "createdAt": "2026-05-21T03:42:08.962Z"
+    }
+  ],
+  "signature": "sig_gh-74_b599156f48",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-74-b599156f48-584cde2_7e5589c458"
+  ],
+  "createdByRunId": "20260519T201935-c24f6a",
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T03:42:08.962Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-75-d37f32bc2b_d3133aef9d.json
+++ b/.clawpatch/findings/fnd_sig-gh-75-d37f32bc2b_d3133aef9d.json
@@ -1,1 +1,103 @@
-{"schemaVersion":1,"findingId":"fnd_sig-gh-75-d37f32bc2b_d3133aef9d","featureId":"feat_gh-75_2fe045d92a","title":"gh#75: R5.3 — Switch routes/queues.ts bulk-ops path to BulkOperationFactory; sweep","category":"maintainability","severity":"low","confidence":"high","triage":"risk","evidence":[{"path":"packages/api/src/routes/queues.ts","startLine":null,"endLine":null,"symbol":null,"quote":null}],"reasoning":"Imported from https://github.com/joshgk00/social-media-scheduler/issues/75.\nBacklog section: Candidate 5 — BulkOperationFactory.\n\n## Context\n\nThird PR in Candidate 5. Switches the second consumer (`enqueueQueueBulkOperation` in `routes/queues.ts`), confirming the factory generalizes. Two adapters = real seam.\n\n## Scope\n\n- Modify `packages/api/src/routes/queues.ts`:\n  - Remove the inline `enqueueQueueBulkOperation` orchestration (idempotency, insert, enqueue)\n  - Replace with `factory.startBulkOperation(...)` calls — likely 2–3 callsites within `queues.ts` for different bulk-op subtypes\n  - Same auth-stays-in-route discipline as R5.2\n- Sweep:\n  - Inspect `bulk-ops-queue.service.ts` — if the factory subsumes the queue construction, remove the service file and inline the queue construction inside the factory's setup. If the service still has unique queue-config responsibility (e.g., `defaultJobOptions`), keep it but ensure the factory consumes it cleanly\n  - Verify no other route imports `bulk-ops-queue.service` directly for the enqueue step\n\n## Out of scope\n\n- Adding NEW bulk endpoints (bulk delete posts, etc.) — those become trivial follow-ups once the factory is in place\n\n## Acceptance\n\n- `pnpm --filter @sms/api build` and test pass\n- `rg \"Idempotency-Key\" packages/api/src/routes/` returns matches only inside route handlers that *consume* the factory (none of them do raw parsing anymore)\n- `rg \"bulkOperations\\)\\\\.values\" packages/api/src/routes/` returns no matches (factory owns the insert)\n\n## References\n\n- Depends on: #74","reproduction":"Third PR in Candidate 5. Switches the second consumer (`enqueueQueueBulkOperation` in `routes/queues.ts`), confirming the factory generalizes. Two adapters = real seam.","recommendation":"- Modify `packages/api/src/routes/queues.ts`:\n  - Remove the inline `enqueueQueueBulkOperation` orchestration (idempotency, insert, enqueue)\n  - Replace with `factory.startBulkOperation(...)` calls — likely 2–3 callsites within `queues.ts` for different bulk-op subtypes\n  - Same auth-stays-in-route discipline as R5.2\n- Sweep:\n  - Inspect `bulk-ops-queue.service.ts` — if the factory subsumes the queue construction, remove the service file and inline the queue construction inside the factory's setup. If the service still has unique queue-config responsibility (e.g., `defaultJobOptions`), keep it but ensure the factory consumes it cleanly\n  - Verify no other route imports `bulk-ops-queue.service` directly for the enqueue step","whyTestsDoNotAlreadyCoverThis":"Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.","suggestedRegressionTest":"- `pnpm --filter @sms/api build` and test pass\n- `rg \"Idempotency-Key\" packages/api/src/routes/` returns matches only inside route handlers that *consume* the factory (none of them do raw parsing anymore)\n- `rg \"bulkOperations\\)\\\\.values\" packages/api/src/routes/` returns no matches (factory owns the insert)","minimumFixScope":"packages/api/src/routes/queues.ts","status":"open","history":[],"signature":"sig_gh-75_d37f32bc2b","linkedPatchAttemptIds":[],"createdByRunId":"20260519T201935-c24f6a","createdAt":"2026-05-19T20:19:35.980Z","updatedAt":"2026-05-19T20:19:35.980Z"}
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-75-d37f32bc2b_d3133aef9d",
+  "featureId": "feat_gh-75_2fe045d92a",
+  "title": "gh#75: R5.3 — Switch routes/queues.ts bulk-ops path to BulkOperationFactory; sweep",
+  "category": "maintainability",
+  "severity": "low",
+  "confidence": "high",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "packages/api/src/routes/queues.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/75.\nBacklog section: Candidate 5 — BulkOperationFactory.\n\n## Context\n\nThird PR in Candidate 5. Switches the second consumer (`enqueueQueueBulkOperation` in `routes/queues.ts`), confirming the factory generalizes. Two adapters = real seam.\n\n## Scope\n\n- Modify `packages/api/src/routes/queues.ts`:\n  - Remove the inline `enqueueQueueBulkOperation` orchestration (idempotency, insert, enqueue)\n  - Replace with `factory.startBulkOperation(...)` calls — likely 2–3 callsites within `queues.ts` for different bulk-op subtypes\n  - Same auth-stays-in-route discipline as R5.2\n- Sweep:\n  - Inspect `bulk-ops-queue.service.ts` — if the factory subsumes the queue construction, remove the service file and inline the queue construction inside the factory's setup. If the service still has unique queue-config responsibility (e.g., `defaultJobOptions`), keep it but ensure the factory consumes it cleanly\n  - Verify no other route imports `bulk-ops-queue.service` directly for the enqueue step\n\n## Out of scope\n\n- Adding NEW bulk endpoints (bulk delete posts, etc.) — those become trivial follow-ups once the factory is in place\n\n## Acceptance\n\n- `pnpm --filter @sms/api build` and test pass\n- `rg \"Idempotency-Key\" packages/api/src/routes/` returns matches only inside route handlers that *consume* the factory (none of them do raw parsing anymore)\n- `rg \"bulkOperations\\)\\\\.values\" packages/api/src/routes/` returns no matches (factory owns the insert)\n\n## References\n\n- Depends on: #74",
+  "reproduction": "Third PR in Candidate 5. Switches the second consumer (`enqueueQueueBulkOperation` in `routes/queues.ts`), confirming the factory generalizes. Two adapters = real seam.",
+  "recommendation": "- Modify `packages/api/src/routes/queues.ts`:\n  - Remove the inline `enqueueQueueBulkOperation` orchestration (idempotency, insert, enqueue)\n  - Replace with `factory.startBulkOperation(...)` calls — likely 2–3 callsites within `queues.ts` for different bulk-op subtypes\n  - Same auth-stays-in-route discipline as R5.2\n- Sweep:\n  - Inspect `bulk-ops-queue.service.ts` — if the factory subsumes the queue construction, remove the service file and inline the queue construction inside the factory's setup. If the service still has unique queue-config responsibility (e.g., `defaultJobOptions`), keep it but ensure the factory consumes it cleanly\n  - Verify no other route imports `bulk-ops-queue.service` directly for the enqueue step",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": "- `pnpm --filter @sms/api build` and test pass\n- `rg \"Idempotency-Key\" packages/api/src/routes/` returns matches only inside route handlers that *consume* the factory (none of them do raw parsing anymore)\n- `rg \"bulkOperations\\)\\\\.values\" packages/api/src/routes/` returns no matches (factory owns the insert)",
+  "minimumFixScope": "packages/api/src/routes/queues.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260521T034238-fe70f1",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence path still exists at packages/api/src/routes/queues.ts. The current file still imports BulkOpsQueueService directly, defines parseIdempotencyKey at lines 41-45, defines the inline enqueueQueueBulkOperation orchestration at lines 82-129, inserts into bulkOperations at lines 104-114, calls bulkOpsQueueService.enqueueBulkOp at lines 115-128, and all five queue bulk endpoints still parse Idempotency-Key and call enqueueQueueBulkOperation. The factory exists and is used by bulk-import, but queues.ts has not been switched to BulkOperationFactory. The acceptance search for Idempotency-Key still returns queue route raw parsing, and the route still contains .insert(bulkOperations). A targeted Vitest run could not execute because the read-only sandbox blocked Vite from writing packages/api/node_modules/.vite-temp, but source evidence is sufficient to classify the finding as still open.",
+      "commands": [
+        "rg -n \"enqueueQueueBulkOperation|BulkOperationFactory|startBulkOperation|bulkOperations\\)\\.values|Idempotency-Key|bulk-ops-queue\\.service\" packages/api/src/routes packages/api/src -S",
+        "sed -n '1,430p' packages/api/src/routes/queues.ts",
+        "sed -n '1,220p' packages/api/src/services/bulk-operation.factory.ts",
+        "sed -n '1,180p' packages/api/src/services/bulk-ops-queue.service.ts",
+        "rg -n \"bulkOperations\\)\\.values|\\.insert\\(bulkOperations\\)\" packages/api/src/routes/",
+        "rg -n \"Idempotency-Key\" packages/api/src/routes/",
+        "nl -ba packages/api/src/routes/queues.ts | sed -n '30,130p;235,380p'",
+        "rg -n \"from '../services/bulk-operation.factory|bulkOperationFactory|startBulkOperation|bulkOpsQueueService|enqueueBulkOp\" packages/api/src/routes/queues.ts packages/api/src/routes/*.ts",
+        "pnpm --filter @sms/api test -- --run src/services/__tests__/bulk-operation.factory.test.ts"
+      ],
+      "createdAt": "2026-05-21T03:43:42.641Z"
+    },
+    {
+      "runId": "20260521T034846-59f1b8",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence path still exists, but the queues.ts portion has moved to BulkOperationFactory: packages/api/src/routes/queues.ts now imports BulkOperationFactory, accepts bulkOperationFactory as a dependency, and startQueueBulkOperation calls bulkOperationFactory.startBulkOperation; queues.ts no longer imports bulk-ops-queue.service or inserts bulkOperations directly. App wiring also creates the factory and passes it to createQueuesRouter, and the queues route test includes a factory-path coverage case. However the finding's sweep/acceptance criteria are not satisfied: packages/api/src/routes/posts.ts still imports BulkOpsQueueService, still has inline enqueuePostBulkOperation orchestration, still calls .insert(bulkOperations) at line 208, still calls bulkOpsQueueService.enqueueBulkOp at line 218, and still parses Idempotency-Key in route handlers. Therefore the queues-specific evidence is fixed, but the broader finding remains open elsewhere in routes/posts.ts. Verification was limited by the read-only sandbox: Vitest failed before running because Vite could not write .vite-temp, pnpm build failed on dist writes, and tsc --noEmit also reports an existing unrelated TypeScript error in post-crud.service.ts.",
+      "commands": [
+        "pwd && git status --short",
+        "rg -n \"enqueueQueueBulkOperation|BulkOperationFactory|startBulkOperation|bulkOperations\\)\\.values|\\.insert\\(bulkOperations\\)|Idempotency-Key|bulk-ops-queue\\.service|enqueueBulkOp\" packages/api/src/routes packages/api/src/services -S",
+        "nl -ba packages/api/src/routes/queues.ts | sed -n '1,430p'",
+        "rg -n \"bulkOperations\\)\\.values|\\.insert\\(bulkOperations\\)\" packages/api/src/routes/",
+        "rg -n \"Idempotency-Key\" packages/api/src/routes/",
+        "nl -ba packages/api/src/services/bulk-operation.factory.ts | sed -n '1,150p'",
+        "nl -ba packages/api/src/app.ts | sed -n '1,180p'",
+        "rg -n \"bulkOperationFactory|startBulkOperation|Idempotency-Key|Bulk operations queue is not configured|bulkOperationId|replay\" packages/api/src/__tests__/routes/queues.test.ts packages/api/src/routes/queues.ts packages/api/src/routes/posts.ts -S",
+        "nl -ba packages/api/src/routes/posts.ts | sed -n '160,235p;455,570p'",
+        "nl -ba packages/api/src/__tests__/routes/queues.test.ts | sed -n '500,620p'",
+        "pnpm --filter @sms/api test -- --run src/__tests__/routes/queues.test.ts src/services/__tests__/bulk-operation.factory.test.ts",
+        "pnpm --filter @sms/api build",
+        "pnpm --filter @sms/api exec tsc --noEmit",
+        "rg -n \"from '../services/bulk-ops-queue.service|from './services/bulk-ops-queue.service|BulkOpsQueueService|enqueueBulkOp|createBulkOpsQueueService\" packages/api/src -S",
+        "nl -ba packages/api/src/services/bulk-ops-queue.service.ts | sed -n '1,120p'"
+      ],
+      "createdAt": "2026-05-21T03:50:02.500Z"
+    },
+    {
+      "runId": "20260521T035201-623c3c",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence path still exists at packages/api/src/routes/queues.ts, but the queued bulk-operation orchestration has been moved behind BulkOperationFactory. queues.ts now imports BulkOperationFactory, receives bulkOperationFactory as a dependency, and startQueueBulkOperation calls bulkOperationFactory.startBulkOperation; there is no enqueueQueueBulkOperation function, no direct BulkOpsQueueService import, and no route-local bulkOperations insert. The earlier open elsewhere evidence in routes/posts.ts has also been addressed: posts.ts now uses startPostBulkOperation/sendPostBulkOperation with bulkOperationFactory.startBulkOperation, and the acceptance search for route-level .insert(bulkOperations) returns no matches. Idempotency-Key references remain in routes only as header values passed to factory consumers; raw parsing/validation is centralized in packages/api/src/services/bulk-operation.factory.ts. bulk-ops-queue.service still exists, but it owns queue construction/defaultJobOptions and is consumed by the factory/app wiring, not directly by routes for enqueue orchestration. Verification commands for Vitest and build could not complete in this read-only sandbox because Vite/tsc could not write .vite-temp/dist files; build also surfaced an unrelated existing TS2322 in post-crud.service.ts, so test execution is not positive evidence, but current source and acceptance rg checks show this finding is fixed.",
+      "commands": [
+        "pwd && git status --short",
+        "rg -n \"enqueueQueueBulkOperation|startQueueBulkOperation|enqueuePostBulkOperation|BulkOperationFactory|startBulkOperation|bulkOperations\\)\\.values|\\.insert\\(bulkOperations\\)|Idempotency-Key|bulk-ops-queue\\.service|BulkOpsQueueService|enqueueBulkOp\" packages/api/src/routes packages/api/src/services packages/api/src/app.ts -S",
+        "rg -n \"bulkOperations\\)\\.values|\\.insert\\(bulkOperations\\)\" packages/api/src/routes/",
+        "rg -n \"Idempotency-Key\" packages/api/src/routes/",
+        "nl -ba packages/api/src/routes/queues.ts | sed -n '1,130p;220,345p'",
+        "nl -ba packages/api/src/routes/posts.ts | sed -n '1,110p;160,215p;455,540p'",
+        "nl -ba packages/api/src/services/bulk-operation.factory.ts | sed -n '1,130p'",
+        "nl -ba packages/api/src/app.ts | sed -n '1,150p'",
+        "rg -n \"from '../services/bulk-ops-queue.service|from './services/bulk-ops-queue.service|BulkOpsQueueService|enqueueBulkOp|createBulkOpsQueueService\" packages/api/src/routes packages/api/src -S",
+        "rg -n \"parseIdempotencyKey|Invalid Idempotency-Key|idempotencyKey =|idempotencyKey\\.trim|UUID_PATTERN\\.test\\(idempotencyKey\\)|req\\.get\\('Idempotency-Key'\\)\" packages/api/src/routes packages/api/src/services -S",
+        "rg -n \"bulkOperationFactory|startBulkOperation|InvalidIdempotencyKeyError|Bulk operations queue is not configured|replay|bulkOperationId\" packages/api/src/__tests__/routes/queues.test.ts packages/api/src/__tests__/routes/posts.test.ts packages/api/src/services/__tests__/bulk-operation.factory.test.ts -S",
+        "nl -ba packages/api/src/services/bulk-ops-queue.service.ts | sed -n '1,120p'",
+        "pnpm --filter @sms/api test -- --run src/__tests__/routes/queues.test.ts src/services/__tests__/bulk-operation.factory.test.ts",
+        "pnpm --filter @sms/api build"
+      ],
+      "createdAt": "2026-05-21T03:53:09.192Z"
+    }
+  ],
+  "signature": "sig_gh-75_d37f32bc2b",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-75-d37f32bc2b-d3133ae_7ab97aaa4d"
+  ],
+  "createdByRunId": "20260519T201935-c24f6a",
+  "createdAt": "2026-05-19T20:19:35.980Z",
+  "updatedAt": "2026-05-21T03:53:09.192Z"
+}

--- a/packages/api/src/__tests__/routes/bulk-import.test.ts
+++ b/packages/api/src/__tests__/routes/bulk-import.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { buildCsvValidationFailure } from '../../routes/bulk-import.js';
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+import { buildCsvValidationFailure, createBulkImportRouter } from '../../routes/bulk-import.js';
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+const PROFILE_ID = '550e8400-e29b-41d4-a716-446655440012';
+const IDEMPOTENCY_KEY = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
 
 describe('bulk import route', () => {
   it.todo('parses streaming CSV rows with csv-parse v6 and bom:true');
@@ -28,5 +34,46 @@ describe('bulk import route', () => {
       errorCount: 1,
       details: [{ rowNumber: 2, reason: 'scheduled_at: Invalid datetime' }],
     });
+  });
+
+  it('returns idempotency replay before requiring a CSV file or loading profile state', async () => {
+    const replayedOperation = {
+      bulkOperationId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      jobId: null,
+      replay: true,
+    };
+    const db = {
+      select: vi.fn(() => {
+        throw new Error('profile lookup should not run for idempotency replay');
+      }),
+    };
+    const bulkOperationFactory = {
+      findExistingBulkOperation: vi.fn().mockResolvedValue(replayedOperation),
+      startBulkOperation: vi.fn(),
+    };
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as typeof req & { session: { userId: string } }).session = { userId: USER_ID };
+      next();
+    });
+    app.use('/bulk-import', createBulkImportRouter({
+      db: db as never,
+      bulkOperationFactory: bulkOperationFactory as never,
+    }));
+
+    const response = await request(app)
+      .post('/bulk-import')
+      .set('Idempotency-Key', IDEMPOTENCY_KEY)
+      .field('target', 'scheduled')
+      .field('profileId', PROFILE_ID);
+
+    expect(response.status).toBe(202);
+    expect(response.body).toEqual(replayedOperation);
+    expect(bulkOperationFactory.findExistingBulkOperation).toHaveBeenCalledWith({
+      userId: USER_ID,
+      idempotencyKey: IDEMPOTENCY_KEY,
+    });
+    expect(db.select).not.toHaveBeenCalled();
+    expect(bulkOperationFactory.startBulkOperation).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/__tests__/routes/posts-bulk-ops.test.ts
+++ b/packages/api/src/__tests__/routes/posts-bulk-ops.test.ts
@@ -1,0 +1,40 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+import { createPostsRouter } from '../../routes/posts.js';
+import { InvalidIdempotencyKeyError } from '../../services/bulk-operation.factory.js';
+
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+const PROFILE_ID = '550e8400-e29b-41d4-a716-446655440012';
+
+describe('posts bulk operation routes', () => {
+  it('returns 400 when a posts bulk operation has an invalid idempotency key', async () => {
+    const bulkOperationFactory = {
+      findExistingBulkOperation: vi.fn(),
+      startBulkOperation: vi.fn().mockRejectedValue(new InvalidIdempotencyKeyError()),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as typeof req & { session: { userId: string } }).session = { userId: USER_ID };
+      next();
+    });
+    app.use(createPostsRouter({
+      db: {} as never,
+      bulkOperationFactory: bulkOperationFactory as never,
+    }));
+
+    const response = await request(app)
+      .post('/api/posts/bulk-pause')
+      .set('Idempotency-Key', 'not-a-uuid')
+      .send({
+        profileId: PROFILE_ID,
+        scope: 'scheduled-posts',
+        filter: { status: 'scheduled' },
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Invalid Idempotency-Key header' });
+    expect(bulkOperationFactory.startBulkOperation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/__tests__/routes/queues.test.ts
+++ b/packages/api/src/__tests__/routes/queues.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
+import { JOB_NAMES } from '@sms/shared';
 import { createApp } from '../../app.js';
 import { createMockRedis } from '../helpers/mock-redis.js';
 import type { RequestHandler } from 'express';
+import type { BulkOpsQueueService } from '../../services/bulk-ops-queue.service.js';
 
 const mockCreateQueue = vi.fn();
 const mockUpdateQueue = vi.fn();
@@ -162,17 +164,17 @@ function createMockDb() {
   } as any;
 }
 
-function createTestApp() {
+function createTestApp(args: { db?: any; bulkOpsQueueService?: BulkOpsQueueService } = {}) {
   return createApp({
     redis: createMockRedis(),
     sql: createMockSql(),
-    db: createMockDb(),
+    db: args.db ?? createMockDb(),
     sessionSecret: 'test-secret-that-is-long-enough-for-session',
+    bulkOpsQueueService: args.bulkOpsQueueService,
   });
 }
 
-async function authenticatedAgent() {
-  const app = createTestApp();
+async function authenticatedAgent(app = createTestApp()) {
   const agent = request.agent(app);
 
   mockUserExists.mockResolvedValueOnce(true);
@@ -248,6 +250,15 @@ const SAMPLE_QUEUE_LIST_ITEM = {
   notes: null,
   postCount: 3,
 };
+
+function resolvedChain<T>(terminal: T) {
+  const chain: Record<string, any> = {};
+  for (const method of ['from', 'where', 'values', 'returning']) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+  chain.then = (resolve: (value: T) => void) => resolve(terminal);
+  return chain;
+}
 
 describe('queues routes', () => {
   beforeEach(() => {
@@ -516,6 +527,60 @@ describe('queues routes', () => {
         'user-1',
         QUEUE_ID,
         { search: 'announcement' },
+      );
+    });
+  });
+
+  describe('queue bulk operations', () => {
+    it('uses the bulk operation factory path for randomize operations', async () => {
+      const bulkOperationId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+      const idempotencyKey = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+      const select = vi.fn()
+        .mockReturnValueOnce(resolvedChain([{ id: QUEUE_ID, name: SAMPLE_QUEUE.name, userId: 'user-1' }]))
+        .mockReturnValueOnce(resolvedChain([]));
+      const insertChain = resolvedChain([{ id: bulkOperationId }]);
+      const db = {
+        select,
+        insert: vi.fn().mockReturnValue(insertChain),
+        update: vi.fn().mockReturnValue(resolvedChain([])),
+        delete: vi.fn().mockReturnValue(resolvedChain([])),
+        transaction: vi.fn(),
+      };
+      const bulkOpsQueueService: BulkOpsQueueService = {
+        bulkOpsQueue: {} as never,
+        enqueueBulkOp: vi.fn().mockResolvedValue({ id: 'job-1' } as never),
+      };
+      const app = createTestApp({ db, bulkOpsQueueService });
+      const agent = await authenticatedAgent(app);
+
+      const res = await agent
+        .post(`/api/queues/${QUEUE_ID}/randomize`)
+        .set('Idempotency-Key', idempotencyKey)
+        .send({});
+
+      expect(res.status).toBe(202);
+      expect(res.body).toEqual({ bulkOperationId, jobId: 'job-1', replay: false });
+      expect(db.insert).toHaveBeenCalledTimes(1);
+      expect(insertChain.values).toHaveBeenCalledWith({
+        userId: 'user-1',
+        operationType: JOB_NAMES.bulkQueueRandomize,
+        targetKind: 'queue',
+        targetId: QUEUE_ID,
+        idempotencyKey,
+        payload: {},
+      });
+      expect(bulkOpsQueueService.enqueueBulkOp).toHaveBeenCalledWith(
+        JOB_NAMES.bulkQueueRandomize,
+        expect.objectContaining({
+          bulkOperationId,
+          userId: 'user-1',
+          operationType: JOB_NAMES.bulkQueueRandomize,
+          targetKind: 'queue',
+          targetId: QUEUE_ID,
+          idempotencyKey,
+          params: {},
+        }),
+        expect.any(Number),
       );
     });
   });

--- a/packages/api/src/__tests__/routes/queues.test.ts
+++ b/packages/api/src/__tests__/routes/queues.test.ts
@@ -256,7 +256,8 @@ function resolvedChain<T>(terminal: T) {
   for (const method of ['from', 'where', 'values', 'onConflictDoNothing', 'returning']) {
     chain[method] = vi.fn().mockReturnValue(chain);
   }
-  chain.then = (resolve: (value: T) => void) => resolve(terminal);
+  chain.then = (resolve: (value: T) => void, reject?: (error: unknown) => void) =>
+    Promise.resolve(terminal).then(resolve, reject);
   return chain;
 }
 
@@ -582,6 +583,32 @@ describe('queues routes', () => {
         }),
         expect.any(Number),
       );
+    });
+
+    it('returns 400 when a queue bulk operation has an invalid idempotency key', async () => {
+      const db = {
+        select: vi.fn().mockReturnValueOnce(resolvedChain([{ id: QUEUE_ID, name: SAMPLE_QUEUE.name, userId: 'user-1' }])),
+        insert: vi.fn().mockReturnValue(resolvedChain([])),
+        update: vi.fn().mockReturnValue(resolvedChain([])),
+        delete: vi.fn().mockReturnValue(resolvedChain([])),
+        transaction: vi.fn(),
+      };
+      const bulkOpsQueueService: BulkOpsQueueService = {
+        bulkOpsQueue: {} as never,
+        enqueueBulkOp: vi.fn(),
+      };
+      const app = createTestApp({ db, bulkOpsQueueService });
+      const agent = await authenticatedAgent(app);
+
+      const res = await agent
+        .post(`/api/queues/${QUEUE_ID}/randomize`)
+        .set('Idempotency-Key', 'not-a-uuid')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'Invalid Idempotency-Key header' });
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(bulkOpsQueueService.enqueueBulkOp).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/__tests__/routes/queues.test.ts
+++ b/packages/api/src/__tests__/routes/queues.test.ts
@@ -147,7 +147,7 @@ function createMockSql() {
 function createMockDb() {
   const chainable = (terminal: unknown = []) => {
     const chain: Record<string, any> = {};
-    const methods = ['from', 'where', 'values', 'returning', 'set', 'limit', 'offset', 'orderBy', 'innerJoin', 'leftJoin', 'groupBy'];
+    const methods = ['from', 'where', 'values', 'onConflictDoNothing', 'returning', 'set', 'limit', 'offset', 'orderBy', 'innerJoin', 'leftJoin', 'groupBy'];
     for (const method of methods) {
       chain[method] = vi.fn().mockReturnValue(chain);
     }
@@ -253,7 +253,7 @@ const SAMPLE_QUEUE_LIST_ITEM = {
 
 function resolvedChain<T>(terminal: T) {
   const chain: Record<string, any> = {};
-  for (const method of ['from', 'where', 'values', 'returning']) {
+  for (const method of ['from', 'where', 'values', 'onConflictDoNothing', 'returning']) {
     chain[method] = vi.fn().mockReturnValue(chain);
   }
   chain.then = (resolve: (value: T) => void) => resolve(terminal);

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -120,13 +120,16 @@ export function createApp({
 
   app.use(createProfilesRouter({ db, getTokenVault }));
   app.use(createOAuthRouter({ db, redis, getTokenVault }));
-  if (bulkOpsQueueService) {
+  const bulkOperationFactory = bulkOpsQueueService
+    ? createBulkOperationFactory(db, bulkOpsQueueService)
+    : undefined;
+  if (bulkOperationFactory) {
     app.use('/api/bulk-import', createBulkImportRouter({
       db,
-      bulkOperationFactory: createBulkOperationFactory(db, bulkOpsQueueService),
+      bulkOperationFactory,
     }));
   }
-  app.use(createPostsRouter({ db, publishQueueService, bulkOpsQueueService, notificationQueue }));
+  app.use(createPostsRouter({ db, publishQueueService, bulkOperationFactory, notificationQueue }));
   app.use(createRateLimitRouter({ db }));
   app.use(createTagsRouter({ db }));
   app.use(createSnippetsRouter({ db }));
@@ -135,7 +138,7 @@ export function createApp({
   app.use(createNotificationPrefsRouter({ db }));
   app.use(createEmailLogsRouter({ db }));
   app.use(createSystemRouter());
-  app.use('/api/queues', createQueuesRouter({ db, bulkOpsQueueService }));
+  app.use('/api/queues', createQueuesRouter({ db, bulkOperationFactory }));
 
   if (storage && transcodeQueue) {
     app.use('/api/media', createMediaRouter({ db, storage, transcodeQueue }));

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -35,6 +35,7 @@ import { createEmailLogsRouter } from './routes/email-logs.js';
 import { createSystemRouter } from './routes/system.js';
 import type { PublishQueueService } from './services/publish-queue.service.js';
 import type { BulkOpsQueueService } from './services/bulk-ops-queue.service.js';
+import { createBulkOperationFactory } from './services/bulk-operation.factory.js';
 import { createTokenVault, type TokenVault } from './services/token-vault.service.js';
 import { createBulkImportRouter } from './routes/bulk-import.js';
 interface AppDependencies {
@@ -120,7 +121,10 @@ export function createApp({
   app.use(createProfilesRouter({ db, getTokenVault }));
   app.use(createOAuthRouter({ db, redis, getTokenVault }));
   if (bulkOpsQueueService) {
-    app.use('/api/bulk-import', createBulkImportRouter({ db, bulkOpsQueueService }));
+    app.use('/api/bulk-import', createBulkImportRouter({
+      db,
+      bulkOperationFactory: createBulkOperationFactory(db, bulkOpsQueueService),
+    }));
   }
   app.use(createPostsRouter({ db, publishQueueService, bulkOpsQueueService, notificationQueue }));
   app.use(createRateLimitRouter({ db }));

--- a/packages/api/src/routes/bulk-import.ts
+++ b/packages/api/src/routes/bulk-import.ts
@@ -71,11 +71,6 @@ export function createBulkImportRouter({ db, bulkOperationFactory }: BulkImportR
     bulkOperationsLimiter,
     csvUpload.single('file'),
     async (req, res) => {
-      if (!req.file) {
-        res.status(400).json({ error: 'CSV file is required' });
-        return;
-      }
-
       const parsedBody = bulkImportRequestSchema.safeParse(req.body);
       if (!parsedBody.success) {
         res.status(400).json({ error: 'Validation failed', details: parsedBody.error.issues });
@@ -84,6 +79,29 @@ export function createBulkImportRouter({ db, bulkOperationFactory }: BulkImportR
 
       const userId = req.session.userId!;
       const { target, profileId, queueId } = parsedBody.data;
+      const idempotencyKey = req.get('Idempotency-Key');
+
+      try {
+        const replayedBulkOperation = await bulkOperationFactory.findExistingBulkOperation({
+          userId,
+          idempotencyKey,
+        });
+        if (replayedBulkOperation) {
+          res.status(202).json(replayedBulkOperation);
+          return;
+        }
+      } catch (err) {
+        if (err instanceof InvalidIdempotencyKeyError) {
+          res.status(400).json({ error: err.message });
+          return;
+        }
+        throw err;
+      }
+
+      if (!req.file) {
+        res.status(400).json({ error: 'CSV file is required' });
+        return;
+      }
 
       const [profile] = await db
         .select({ id: socialProfiles.id, platform: socialProfiles.platform })
@@ -165,14 +183,13 @@ export function createBulkImportRouter({ db, bulkOperationFactory }: BulkImportR
       try {
         const bulkOperation = await bulkOperationFactory.startBulkOperation({
           userId,
-          idempotencyKey: req.get('Idempotency-Key'),
-          type: operationType,
+          idempotencyKey,
+          operationType,
           targetKind: target === 'scheduled' ? 'profile' : 'queue',
           targetId,
           params: target === 'scheduled'
             ? { profileId, rows: parsedCsv.rows, errors: parsedCsv.errors }
             : { profileId, queueId, rows: parsedCsv.rows, errors: parsedCsv.errors },
-          jobName: operationType,
           correlationId: requestCorrelationId(req as { id?: string }),
         });
 

--- a/packages/api/src/routes/bulk-import.ts
+++ b/packages/api/src/routes/bulk-import.ts
@@ -4,31 +4,23 @@ import multer from 'multer';
 import { DateTime } from 'luxon';
 import { and, eq } from 'drizzle-orm';
 import { bulkImportRequestSchema, csvQueueRowSchema, csvScheduledRowSchema, JOB_NAMES } from '@sms/shared';
-import { bulkOperations, queues, socialProfiles } from '@sms/db';
+import { queues, socialProfiles } from '@sms/db';
 import type { Db } from '@sms/db';
 import { requireAuth } from '../middleware/auth-guard.js';
 import { bulkOperationsLimiter } from '../middleware/rate-limiter.js';
 import { csvUpload } from '../middleware/csv-upload.js';
 import { checkBulkBudgetWithDb } from '../services/rate-limit.service.js';
-import { CsvParseError, parseCsvBuffer, writeErrorReport } from '../services/bulk-import.service.js';
+import { CsvParseError, parseCsvBuffer } from '../services/bulk-import.service.js';
 import type { CsvRowError } from '../services/bulk-import.service.js';
-import type { BulkOpsQueueService } from '../services/bulk-ops-queue.service.js';
+import { InvalidIdempotencyKeyError, type BulkOperationFactory } from '../services/bulk-operation.factory.js';
 
 interface BulkImportRouterDeps {
   db: Db;
-  bulkOpsQueueService: BulkOpsQueueService;
+  bulkOperationFactory: BulkOperationFactory;
 }
-
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function requestCorrelationId(req: { id?: string }): string {
   return req.id ?? randomUUID();
-}
-
-function parseIdempotencyKey(rawHeader: string | undefined): string | null {
-  if (rawHeader === undefined) return randomUUID();
-  const idempotencyKey = rawHeader.trim();
-  return UUID_PATTERN.test(idempotencyKey) ? idempotencyKey : null;
 }
 
 function csvValidationDetails(errors: CsvRowError[]) {
@@ -70,7 +62,7 @@ function rejectInvalidCsv(res: Response, parsedCsv: { rows: unknown[]; errors: C
   return false;
 }
 
-export function createBulkImportRouter({ db, bulkOpsQueueService }: BulkImportRouterDeps): Router {
+export function createBulkImportRouter({ db, bulkOperationFactory }: BulkImportRouterDeps): Router {
   const router = Router();
 
   router.post(
@@ -92,27 +84,6 @@ export function createBulkImportRouter({ db, bulkOpsQueueService }: BulkImportRo
 
       const userId = req.session.userId!;
       const { target, profileId, queueId } = parsedBody.data;
-      const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-      if (!idempotencyKey) {
-        res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-        return;
-      }
-
-      const [existingBulkOperation] = await db
-        .select({ id: bulkOperations.id })
-        .from(bulkOperations)
-        .where(and(
-          eq(bulkOperations.userId, userId),
-          eq(bulkOperations.idempotencyKey, idempotencyKey),
-        ));
-      if (existingBulkOperation) {
-        res.status(202).json({
-          bulkOperationId: existingBulkOperation.id,
-          jobId: null,
-          replay: true,
-        });
-        return;
-      }
 
       const [profile] = await db
         .select({ id: socialProfiles.id, platform: socialProfiles.platform })
@@ -131,7 +102,6 @@ export function createBulkImportRouter({ db, bulkOpsQueueService }: BulkImportRo
         return;
       }
 
-      let queueName: string | null = null;
       if (target === 'queue') {
         const [queue] = await db
           .select({ id: queues.id, name: queues.name, profileId: queues.profileId })
@@ -145,7 +115,6 @@ export function createBulkImportRouter({ db, bulkOpsQueueService }: BulkImportRo
           res.status(404).json({ error: 'Queue not found' });
           return;
         }
-        queueName = queue.name;
         const mismatchedRows = parsedCsv.rows.filter((row) => {
           const queueRow = row as { queue_name?: string };
           return queueRow.queue_name !== queue.name;
@@ -192,60 +161,35 @@ export function createBulkImportRouter({ db, bulkOpsQueueService }: BulkImportRo
         ? JOB_NAMES.bulkCsvImportScheduled
         : JOB_NAMES.bulkCsvImportQueue;
       const targetId = target === 'scheduled' ? profileId : queueId!;
-      const [bulkOperation] = await db
-        .insert(bulkOperations)
-        .values({
+
+      try {
+        const bulkOperation = await bulkOperationFactory.startBulkOperation({
           userId,
-          operationType,
+          idempotencyKey: req.get('Idempotency-Key'),
+          type: operationType,
           targetKind: target === 'scheduled' ? 'profile' : 'queue',
           targetId,
-          idempotencyKey,
-          payload: {
-            target,
-            profileId,
-            queueId,
-            queueName,
-            parsedCount: parsedCsv.rows.length,
-            errorCount: parsedCsv.errors.length,
-          },
-        })
-        .returning();
-
-      const errorReportPath = await writeErrorReport(
-        process.env.MEDIA_DIR || './data/media',
-        bulkOperation.id,
-        parsedCsv.errors,
-      );
-      if (errorReportPath) {
-        await db
-          .update(bulkOperations)
-          .set({ errorReportPath, failureCount: parsedCsv.errors.length })
-          .where(eq(bulkOperations.id, bulkOperation.id));
-      }
-
-      const job = await bulkOpsQueueService.enqueueBulkOp(
-        operationType,
-        {
-          bulkOperationId: bulkOperation.id,
-          userId,
-          operationType,
-          targetKind: target === 'scheduled' ? 'profile' : 'queue',
-          targetId,
-          idempotencyKey,
           params: target === 'scheduled'
             ? { profileId, rows: parsedCsv.rows, errors: parsedCsv.errors }
             : { profileId, queueId, rows: parsedCsv.rows, errors: parsedCsv.errors },
+          jobName: operationType,
           correlationId: requestCorrelationId(req as { id?: string }),
-        },
-        Math.floor(Date.now() / 1000),
-      );
+        });
 
-      res.status(202).json({
-        bulkOperationId: bulkOperation.id,
-        jobId: job.id,
-        parsedCount: parsedCsv.rows.length,
-        errorCount: parsedCsv.errors.length,
-      });
+        res.status(202).json(bulkOperation.replay
+          ? bulkOperation
+          : {
+              ...bulkOperation,
+              parsedCount: parsedCsv.rows.length,
+              errorCount: parsedCsv.errors.length,
+            });
+      } catch (err) {
+        if (err instanceof InvalidIdempotencyKeyError) {
+          res.status(400).json({ error: err.message });
+          return;
+        }
+        throw err;
+      }
     },
   );
 

--- a/packages/api/src/routes/bulk-import.ts
+++ b/packages/api/src/routes/bulk-import.ts
@@ -120,6 +120,7 @@ export function createBulkImportRouter({ db, bulkOperationFactory }: BulkImportR
         return;
       }
 
+      let queueName: string | null = null;
       if (target === 'queue') {
         const [queue] = await db
           .select({ id: queues.id, name: queues.name, profileId: queues.profileId })
@@ -133,6 +134,7 @@ export function createBulkImportRouter({ db, bulkOperationFactory }: BulkImportR
           res.status(404).json({ error: 'Queue not found' });
           return;
         }
+        queueName = queue.name;
         const mismatchedRows = parsedCsv.rows.filter((row) => {
           const queueRow = row as { queue_name?: string };
           return queueRow.queue_name !== queue.name;
@@ -187,6 +189,14 @@ export function createBulkImportRouter({ db, bulkOperationFactory }: BulkImportR
           operationType,
           targetKind: target === 'scheduled' ? 'profile' : 'queue',
           targetId,
+          payload: {
+            target,
+            profileId,
+            queueId,
+            queueName,
+            parsedCount: parsedCsv.rows.length,
+            errorCount: parsedCsv.errors.length,
+          },
           params: target === 'scheduled'
             ? { profileId, rows: parsedCsv.rows, errors: parsedCsv.errors }
             : { profileId, queueId, rows: parsedCsv.rows, errors: parsedCsv.errors },
@@ -196,7 +206,8 @@ export function createBulkImportRouter({ db, bulkOperationFactory }: BulkImportR
         res.status(202).json(bulkOperation.replay
           ? bulkOperation
           : {
-              ...bulkOperation,
+              bulkOperationId: bulkOperation.bulkOperationId,
+              jobId: bulkOperation.jobId,
               parsedCount: parsedCsv.rows.length,
               errorCount: parsedCsv.errors.length,
             });

--- a/packages/api/src/routes/posts.ts
+++ b/packages/api/src/routes/posts.ts
@@ -191,11 +191,10 @@ export function createPostsRouter({
     return bulkOperationFactory.startBulkOperation({
       userId: args.userId,
       idempotencyKey: args.idempotencyKey,
-      type: args.operationType,
+      operationType: args.operationType,
       targetKind: args.targetKind ?? 'scheduled-list',
       targetId: args.targetId ?? null,
       params: args.params,
-      jobName: args.operationType,
       correlationId: args.correlationId,
     });
   }

--- a/packages/api/src/routes/posts.ts
+++ b/packages/api/src/routes/posts.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { Router } from 'express';
+import { Router, type Response } from 'express';
 import { DateTime } from 'luxon';
 import { and, eq, ilike, inArray, sql } from 'drizzle-orm';
 import type { Queue } from 'bullmq';
@@ -14,11 +14,12 @@ import {
   planRetryFailedPost,
   JOB_NAMES,
   AppError,
+  type JobName,
   type PostStatus,
 } from '@sms/shared';
 import { createLogger } from '@sms/shared/logger';
 import type { Db } from '@sms/db';
-import { bulkOperations, posts, postAttempts, postTags, socialProfiles, tags } from '@sms/db';
+import { posts, postAttempts, postTags, socialProfiles, tags } from '@sms/db';
 
 import {
   createPost,
@@ -35,8 +36,8 @@ import {
   type FacebookRateLimitExceededBody,
 } from '../services/rate-limit.service.js';
 import type { PublishQueueService } from '../services/publish-queue.service.js';
-import type { BulkOpsQueueService } from '../services/bulk-ops-queue.service.js';
 import { beginCsvDownload, writeCsvRows } from '../services/bulk-export.service.js';
+import { InvalidIdempotencyKeyError, type BulkOperationFactory } from '../services/bulk-operation.factory.js';
 import { requireAuth } from '../middleware/auth-guard.js';
 import { bulkOperationsLimiter } from '../middleware/rate-limiter.js';
 import { validateUuidParam } from '../middleware/validation.js';
@@ -77,7 +78,7 @@ interface PostsDependencies {
   // paths can keep omitting BullMQ. Handlers that require enqueue will
   // degrade gracefully when the dependency is missing (see below).
   publishQueueService?: PublishQueueService;
-  bulkOpsQueueService?: BulkOpsQueueService;
+  bulkOperationFactory?: BulkOperationFactory;
   notificationQueue?: Queue;
 }
 
@@ -131,12 +132,6 @@ function requestCorrelationId(req: { id?: string }): string {
   return req.id && UUID_PATTERN.test(req.id) ? req.id : randomUUID();
 }
 
-function parseIdempotencyKey(rawHeader: string | undefined): string | null {
-  if (rawHeader === undefined) return randomUUID();
-  const idempotencyKey = rawHeader.trim();
-  return UUID_PATTERN.test(idempotencyKey) ? idempotencyKey : null;
-}
-
 async function enqueueRateLimitReachedNotification(
   notificationQueue: Queue,
   params: {
@@ -176,60 +171,46 @@ async function enqueueRateLimitReachedNotification(
 export function createPostsRouter({
   db,
   publishQueueService,
-  bulkOpsQueueService,
+  bulkOperationFactory,
   notificationQueue,
 }: PostsDependencies) {
   const router = Router();
 
-  async function enqueuePostBulkOperation(args: {
+  async function startPostBulkOperation(args: {
     userId: string;
-    operationType: string;
+    operationType: JobName;
     params: Record<string, unknown>;
     targetKind?: 'profile' | 'queue' | 'scheduled-list';
     targetId?: string | null;
-    idempotencyKey: string;
+    idempotencyKey: string | undefined;
     correlationId: string;
   }) {
-    if (!bulkOpsQueueService) {
+    if (!bulkOperationFactory) {
       throw new Error('Bulk operations queue is not configured');
     }
-    const [existingBulkOperation] = await db
-      .select({ id: bulkOperations.id })
-      .from(bulkOperations)
-      .where(and(
-        eq(bulkOperations.userId, args.userId),
-        eq(bulkOperations.idempotencyKey, args.idempotencyKey),
-      ));
-    if (existingBulkOperation) {
-      return { bulkOperationId: existingBulkOperation.id, jobId: null, replay: true };
-    }
+    return bulkOperationFactory.startBulkOperation({
+      userId: args.userId,
+      idempotencyKey: args.idempotencyKey,
+      type: args.operationType,
+      targetKind: args.targetKind ?? 'scheduled-list',
+      targetId: args.targetId ?? null,
+      params: args.params,
+      jobName: args.operationType,
+      correlationId: args.correlationId,
+    });
+  }
 
-    const [bulkOperation] = await db
-      .insert(bulkOperations)
-      .values({
-        userId: args.userId,
-        operationType: args.operationType,
-        targetKind: args.targetKind ?? 'scheduled-list',
-        targetId: args.targetId ?? null,
-        idempotencyKey: args.idempotencyKey,
-        payload: args.params,
-      })
-      .returning();
-    const job = await bulkOpsQueueService.enqueueBulkOp(
-      args.operationType as typeof JOB_NAMES[keyof typeof JOB_NAMES],
-      {
-        bulkOperationId: bulkOperation.id,
-        userId: args.userId,
-        operationType: args.operationType,
-        targetKind: args.targetKind ?? 'scheduled-list',
-        targetId: args.targetId ?? null,
-        idempotencyKey: args.idempotencyKey,
-        params: args.params,
-        correlationId: args.correlationId,
-      },
-      Math.floor(Date.now() / 1000),
-    );
-    return { bulkOperationId: bulkOperation.id, jobId: job.id };
+  async function sendPostBulkOperation(args: Parameters<typeof startPostBulkOperation>[0], res: Response) {
+    try {
+      const result = await startPostBulkOperation(args);
+      res.status(202).json(result);
+    } catch (err) {
+      if (err instanceof InvalidIdempotencyKeyError) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
   }
 
   async function resolveSelectedPostIds(
@@ -480,57 +461,40 @@ export function createPostsRouter({
   });
 
   router.post('/api/posts/bulk-pause', requireAuth, bulkOperationsLimiter, async (req, res) => {
-    const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-    if (!idempotencyKey) {
-      res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-      return;
-    }
     const parsed = bulkPauseInputSchema.safeParse(req.body);
     if (!parsed.success) {
       res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
       return;
     }
-    const result = await enqueuePostBulkOperation({
+    await sendPostBulkOperation({
       userId: req.session.userId!,
       operationType: JOB_NAMES.bulkProfilePause,
       params: parsed.data,
       targetKind: 'profile',
       targetId: parsed.data.profileId,
-      idempotencyKey,
+      idempotencyKey: req.get('Idempotency-Key'),
       correlationId: requestCorrelationId(req as { id?: string }),
-    });
-    res.status(202).json(result);
+    }, res);
   });
 
   router.post('/api/posts/bulk-resume', requireAuth, bulkOperationsLimiter, async (req, res) => {
-    const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-    if (!idempotencyKey) {
-      res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-      return;
-    }
     const parsed = bulkPauseInputSchema.safeParse(req.body);
     if (!parsed.success) {
       res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
       return;
     }
-    const result = await enqueuePostBulkOperation({
+    await sendPostBulkOperation({
       userId: req.session.userId!,
       operationType: JOB_NAMES.bulkProfileResume,
       params: parsed.data,
       targetKind: 'profile',
       targetId: parsed.data.profileId,
-      idempotencyKey,
+      idempotencyKey: req.get('Idempotency-Key'),
       correlationId: requestCorrelationId(req as { id?: string }),
-    });
-    res.status(202).json(result);
+    }, res);
   });
 
   router.post('/api/posts/bulk-delete', requireAuth, bulkOperationsLimiter, async (req, res) => {
-    const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-    if (!idempotencyKey) {
-      res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-      return;
-    }
     const parsed = bulkDeleteInputSchema.safeParse(req.body);
     if (!parsed.success) {
       res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
@@ -543,35 +507,28 @@ export function createPostsRouter({
       res.status(400).json({ error: 'typedConfirmation_mismatch', expected });
       return;
     }
-    const result = await enqueuePostBulkOperation({
+    await sendPostBulkOperation({
       userId: req.session.userId!,
       operationType: JOB_NAMES.bulkProfileBulkDelete,
       params: { postIds, typedConfirmation: parsed.data.typedConfirmation, postCount },
-      idempotencyKey,
+      idempotencyKey: req.get('Idempotency-Key'),
       correlationId: requestCorrelationId(req as { id?: string }),
-    });
-    res.status(202).json(result);
+    }, res);
   });
 
   router.post('/api/posts/bulk-modify-tags', requireAuth, bulkOperationsLimiter, async (req, res) => {
-    const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-    if (!idempotencyKey) {
-      res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-      return;
-    }
     const parsed = bulkModifyTagsInputSchema.safeParse(req.body);
     if (!parsed.success) {
       res.status(400).json({ error: 'Validation failed', details: parsed.error.issues });
       return;
     }
-    const result = await enqueuePostBulkOperation({
+    await sendPostBulkOperation({
       userId: req.session.userId!,
       operationType: JOB_NAMES.bulkProfileModifyTags,
       params: parsed.data,
-      idempotencyKey,
+      idempotencyKey: req.get('Idempotency-Key'),
       correlationId: requestCorrelationId(req as { id?: string }),
-    });
-    res.status(202).json(result);
+    }, res);
   });
 
   router.get('/api/posts/conflicts', requireAuth, async (req, res) => {

--- a/packages/api/src/routes/queues.ts
+++ b/packages/api/src/routes/queues.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { DateTime } from 'luxon';
 import { and, eq, inArray } from 'drizzle-orm';
@@ -13,9 +13,10 @@ import {
   queueRandomizeInputSchema,
   queueTextModifyInputSchema,
   JOB_NAMES,
+  type JobName,
 } from '@sms/shared';
 import type { Db } from '@sms/db';
-import { bulkOperations, posts, postTags, queues, tags } from '@sms/db';
+import { posts, postTags, queues, tags } from '@sms/db';
 
 import {
   createQueue,
@@ -33,16 +34,10 @@ import {
 import { requireAuth } from '../middleware/auth-guard.js';
 import { validateUuidParam } from '../middleware/validation.js';
 import { bulkOperationsLimiter, queueMutationLimiter } from '../middleware/rate-limiter.js';
-import type { BulkOpsQueueService } from '../services/bulk-ops-queue.service.js';
 import { beginCsvDownload, writeCsvRows } from '../services/bulk-export.service.js';
+import { InvalidIdempotencyKeyError, type BulkOperationFactory } from '../services/bulk-operation.factory.js';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-function parseIdempotencyKey(rawHeader: string | undefined): string | null {
-  if (rawHeader === undefined) return randomUUID();
-  const idempotencyKey = rawHeader.trim();
-  return UUID_PATTERN.test(idempotencyKey) ? idempotencyKey : null;
-}
 
 function requestCorrelationId(req: { id?: string }): string {
   return req.id && UUID_PATTERN.test(req.id) ? req.id : randomUUID();
@@ -50,10 +45,10 @@ function requestCorrelationId(req: { id?: string }): string {
 
 interface QueuesDependencies {
   db: Db;
-  bulkOpsQueueService?: BulkOpsQueueService;
+  bulkOperationFactory?: BulkOperationFactory;
 }
 
-export function createQueuesRouter({ db, bulkOpsQueueService }: QueuesDependencies) {
+export function createQueuesRouter({ db, bulkOperationFactory }: QueuesDependencies) {
   const router = Router();
 
   async function loadTagNamesByPostId(postIds: string[]): Promise<Record<string, string>> {
@@ -79,54 +74,40 @@ export function createQueuesRouter({ db, bulkOpsQueueService }: QueuesDependenci
     );
   }
 
-  async function enqueueQueueBulkOperation(args: {
+  async function startQueueBulkOperation(args: {
     userId: string;
     queueId: string;
-    operationType: string;
+    operationType: JobName;
     params: Record<string, unknown>;
-    idempotencyKey: string;
+    idempotencyKey: string | undefined;
     correlationId: string;
   }) {
-    if (!bulkOpsQueueService) {
+    if (!bulkOperationFactory) {
       throw new Error('Bulk operations queue is not configured');
     }
-    const [existingBulkOperation] = await db
-      .select({ id: bulkOperations.id })
-      .from(bulkOperations)
-      .where(and(
-        eq(bulkOperations.userId, args.userId),
-        eq(bulkOperations.idempotencyKey, args.idempotencyKey),
-      ));
-    if (existingBulkOperation) {
-      return { bulkOperationId: existingBulkOperation.id, jobId: null, replay: true };
-    }
+    return bulkOperationFactory.startBulkOperation({
+      userId: args.userId,
+      idempotencyKey: args.idempotencyKey,
+      type: args.operationType,
+      targetKind: 'queue',
+      targetId: args.queueId,
+      params: args.params,
+      jobName: args.operationType,
+      correlationId: args.correlationId,
+    });
+  }
 
-    const [bulkOperation] = await db
-      .insert(bulkOperations)
-      .values({
-        userId: args.userId,
-        operationType: args.operationType,
-        targetKind: 'queue',
-        targetId: args.queueId,
-        idempotencyKey: args.idempotencyKey,
-        payload: args.params,
-      })
-      .returning();
-    const job = await bulkOpsQueueService.enqueueBulkOp(
-      args.operationType as typeof JOB_NAMES[keyof typeof JOB_NAMES],
-      {
-        bulkOperationId: bulkOperation.id,
-        userId: args.userId,
-        operationType: args.operationType,
-        targetKind: 'queue',
-        targetId: args.queueId,
-        idempotencyKey: args.idempotencyKey,
-        params: args.params,
-        correlationId: args.correlationId,
-      },
-      Math.floor(Date.now() / 1000),
-    );
-    return { bulkOperationId: bulkOperation.id, jobId: job.id };
+  async function sendQueueBulkOperation(args: Parameters<typeof startQueueBulkOperation>[0], res: Response) {
+    try {
+      const result = await startQueueBulkOperation(args);
+      res.status(202).json(result);
+    } catch (err) {
+      if (err instanceof InvalidIdempotencyKeyError) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
   }
 
   async function loadOwnedQueue(userId: string, queueId: string) {
@@ -239,11 +220,6 @@ export function createQueuesRouter({ db, bulkOpsQueueService }: QueuesDependenci
   });
 
   router.post('/:id/randomize', requireAuth, bulkOperationsLimiter, async (req, res) => {
-    const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-    if (!idempotencyKey) {
-      res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-      return;
-    }
     const queueId = validateUuidParam(req.params.id as string);
     const parsed = queueRandomizeInputSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -255,23 +231,17 @@ export function createQueuesRouter({ db, bulkOpsQueueService }: QueuesDependenci
       res.status(404).json({ error: 'Queue not found' });
       return;
     }
-    const result = await enqueueQueueBulkOperation({
+    await sendQueueBulkOperation({
       userId: req.session.userId!,
       queueId,
       operationType: JOB_NAMES.bulkQueueRandomize,
       params: parsed.data,
-      idempotencyKey,
+      idempotencyKey: req.get('Idempotency-Key'),
       correlationId: requestCorrelationId(req as { id?: string }),
-    });
-    res.status(202).json(result);
+    }, res);
   });
 
   router.post('/:id/purge', requireAuth, bulkOperationsLimiter, async (req, res) => {
-    const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-    if (!idempotencyKey) {
-      res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-      return;
-    }
     const queueId = validateUuidParam(req.params.id as string);
     const parsed = queuePurgeInputSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -287,23 +257,17 @@ export function createQueuesRouter({ db, bulkOpsQueueService }: QueuesDependenci
       res.status(400).json({ error: 'typedConfirmation_mismatch', expected: queue.name });
       return;
     }
-    const result = await enqueueQueueBulkOperation({
+    await sendQueueBulkOperation({
       userId: req.session.userId!,
       queueId,
       operationType: JOB_NAMES.bulkQueuePurge,
       params: parsed.data,
-      idempotencyKey,
+      idempotencyKey: req.get('Idempotency-Key'),
       correlationId: requestCorrelationId(req as { id?: string }),
-    });
-    res.status(202).json(result);
+    }, res);
   });
 
   router.post('/:id/copy', requireAuth, bulkOperationsLimiter, async (req, res) => {
-    const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-    if (!idempotencyKey) {
-      res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-      return;
-    }
     const queueId = validateUuidParam(req.params.id as string);
     const parsed = queueCopyInputSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -315,23 +279,17 @@ export function createQueuesRouter({ db, bulkOpsQueueService }: QueuesDependenci
       res.status(404).json({ error: 'Queue not found' });
       return;
     }
-    const result = await enqueueQueueBulkOperation({
+    await sendQueueBulkOperation({
       userId: req.session.userId!,
       queueId,
       operationType: JOB_NAMES.bulkQueueCopy,
       params: parsed.data,
-      idempotencyKey,
+      idempotencyKey: req.get('Idempotency-Key'),
       correlationId: requestCorrelationId(req as { id?: string }),
-    });
-    res.status(202).json(result);
+    }, res);
   });
 
   router.post('/:id/modify-text', requireAuth, bulkOperationsLimiter, async (req, res) => {
-    const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-    if (!idempotencyKey) {
-      res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-      return;
-    }
     const queueId = validateUuidParam(req.params.id as string);
     const parsed = queueTextModifyInputSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -343,23 +301,17 @@ export function createQueuesRouter({ db, bulkOpsQueueService }: QueuesDependenci
       res.status(404).json({ error: 'Queue not found' });
       return;
     }
-    const result = await enqueueQueueBulkOperation({
+    await sendQueueBulkOperation({
       userId: req.session.userId!,
       queueId,
       operationType: JOB_NAMES.bulkQueueTextModify,
       params: parsed.data,
-      idempotencyKey,
+      idempotencyKey: req.get('Idempotency-Key'),
       correlationId: requestCorrelationId(req as { id?: string }),
-    });
-    res.status(202).json(result);
+    }, res);
   });
 
   router.post('/:id/dedupe', requireAuth, bulkOperationsLimiter, async (req, res) => {
-    const idempotencyKey = parseIdempotencyKey(req.get('Idempotency-Key'));
-    if (!idempotencyKey) {
-      res.status(400).json({ error: 'Invalid Idempotency-Key header' });
-      return;
-    }
     const queueId = validateUuidParam(req.params.id as string);
     const parsed = queueDedupeInputSchema.safeParse(req.body);
     if (!parsed.success) {
@@ -371,15 +323,14 @@ export function createQueuesRouter({ db, bulkOpsQueueService }: QueuesDependenci
       res.status(404).json({ error: 'Queue not found' });
       return;
     }
-    const result = await enqueueQueueBulkOperation({
+    await sendQueueBulkOperation({
       userId: req.session.userId!,
       queueId,
       operationType: JOB_NAMES.bulkQueueDedupe,
       params: parsed.data,
-      idempotencyKey,
+      idempotencyKey: req.get('Idempotency-Key'),
       correlationId: requestCorrelationId(req as { id?: string }),
-    });
-    res.status(202).json(result);
+    }, res);
   });
 
   router.post('/:id/posts', requireAuth, queueMutationLimiter, async (req, res) => {

--- a/packages/api/src/routes/queues.ts
+++ b/packages/api/src/routes/queues.ts
@@ -88,11 +88,10 @@ export function createQueuesRouter({ db, bulkOperationFactory }: QueuesDependenc
     return bulkOperationFactory.startBulkOperation({
       userId: args.userId,
       idempotencyKey: args.idempotencyKey,
-      type: args.operationType,
+      operationType: args.operationType,
       targetKind: 'queue',
       targetId: args.queueId,
       params: args.params,
-      jobName: args.operationType,
       correlationId: args.correlationId,
     });
   }

--- a/packages/api/src/services/__tests__/bulk-operation.factory.test.ts
+++ b/packages/api/src/services/__tests__/bulk-operation.factory.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest';
+import { JOB_NAMES } from '@sms/shared';
+import {
+  createBulkOperationFactory,
+  InvalidIdempotencyKeyError,
+  type StartBulkOperationArgs,
+} from '../bulk-operation.factory.js';
+
+const userId = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa';
+const targetId = 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb';
+const idempotencyKey = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const bulkOperationId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const correlationId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+
+const baseArgs: StartBulkOperationArgs = {
+  userId,
+  idempotencyKey,
+  type: JOB_NAMES.bulkQueueRandomize,
+  targetKind: 'queue',
+  targetId,
+  params: { mode: 'shuffle' },
+  jobName: JOB_NAMES.bulkQueueRandomize,
+  correlationId,
+};
+
+function selectChain(rows: Array<{ id: string }>) {
+  const chain: Record<string, any> = {};
+  chain.from = vi.fn().mockReturnValue(chain);
+  chain.where = vi.fn().mockResolvedValue(rows);
+  return chain;
+}
+
+function insertChain(row: { id: string }, calls: string[]) {
+  const chain: Record<string, any> = {};
+  chain.values = vi.fn().mockReturnValue(chain);
+  chain.returning = vi.fn().mockImplementation(() => {
+    calls.push('insert:returning');
+    return Promise.resolve([row]);
+  });
+  return chain;
+}
+
+function createDb(args: {
+  existingRows?: Array<{ id: string }>;
+  insertedRow?: { id: string };
+  calls?: string[];
+}) {
+  return {
+    select: vi.fn().mockReturnValue(selectChain(args.existingRows ?? [])),
+    insert: vi.fn().mockReturnValue(insertChain(args.insertedRow ?? { id: bulkOperationId }, args.calls ?? [])),
+    transaction: vi.fn(),
+  };
+}
+
+function createQueueService(args?: {
+  jobId?: string;
+  reject?: Error;
+  calls?: string[];
+}) {
+  return {
+    bulkOpsQueue: {} as never,
+    enqueueBulkOp: vi.fn().mockImplementation(() => {
+      args?.calls?.push('enqueue');
+      if (args?.reject) {
+        return Promise.reject(args.reject);
+      }
+      return Promise.resolve({ id: args?.jobId ?? 'job-1' });
+    }),
+  };
+}
+
+describe('createBulkOperationFactory', () => {
+  it('creates a bulk operation row and enqueues the job', async () => {
+    const db = createDb({});
+    const queueService = createQueueService({ jobId: 'job-123' });
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await expect(factory.startBulkOperation(baseArgs)).resolves.toEqual({
+      bulkOperationId,
+      jobId: 'job-123',
+      replay: false,
+    });
+
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    expect(db.insert.mock.results[0]?.value.values).toHaveBeenCalledWith({
+      userId,
+      operationType: JOB_NAMES.bulkQueueRandomize,
+      targetKind: 'queue',
+      targetId,
+      idempotencyKey,
+      payload: { mode: 'shuffle' },
+    });
+    expect(queueService.enqueueBulkOp).toHaveBeenCalledWith(
+      JOB_NAMES.bulkQueueRandomize,
+      {
+        bulkOperationId,
+        userId,
+        operationType: JOB_NAMES.bulkQueueRandomize,
+        targetKind: 'queue',
+        targetId,
+        idempotencyKey,
+        params: { mode: 'shuffle' },
+        correlationId,
+      },
+      expect.any(Number),
+    );
+  });
+
+  it('generates an idempotency key when the header is absent', async () => {
+    const db = createDb({});
+    const queueService = createQueueService();
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await factory.startBulkOperation({ ...baseArgs, idempotencyKey: undefined });
+
+    const values = db.insert.mock.results[0]?.value.values.mock.calls[0]?.[0];
+    expect(values.idempotencyKey).toMatch(/^[0-9a-f-]{36}$/);
+    expect(queueService.enqueueBulkOp.mock.calls[0]?.[1].idempotencyKey).toBe(values.idempotencyKey);
+  });
+
+  it('returns replay metadata for an existing idempotency key', async () => {
+    const db = createDb({ existingRows: [{ id: bulkOperationId }] });
+    const queueService = createQueueService();
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await expect(factory.startBulkOperation(baseArgs)).resolves.toEqual({
+      bulkOperationId,
+      jobId: null,
+      replay: true,
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(queueService.enqueueBulkOp).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid idempotency keys before touching storage', async () => {
+    const db = createDb({});
+    const queueService = createQueueService();
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await expect(factory.startBulkOperation({ ...baseArgs, idempotencyKey: 'not-a-uuid' }))
+      .rejects
+      .toBeInstanceOf(InvalidIdempotencyKeyError);
+    expect(db.select).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(queueService.enqueueBulkOp).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing insert-before-enqueue semantics when enqueue fails', async () => {
+    const calls: string[] = [];
+    const db = createDb({ calls });
+    const queueError = new Error('queue unavailable');
+    const queueService = createQueueService({ reject: queueError, calls });
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await expect(factory.startBulkOperation(baseArgs)).rejects.toThrow(queueError);
+
+    expect(calls).toEqual(['insert:returning', 'enqueue']);
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/__tests__/bulk-operation.factory.test.ts
+++ b/packages/api/src/services/__tests__/bulk-operation.factory.test.ts
@@ -48,6 +48,11 @@ function createDb(args: {
 }) {
   let selectCalls = 0;
   const existingRowBatches = args.existingRowBatches ?? [args.existingRows ?? []];
+  const deleteChain: Record<string, any> = {};
+  deleteChain.where = vi.fn().mockImplementation(() => {
+    args.calls?.push('delete');
+    return Promise.resolve([]);
+  });
   return {
     select: vi.fn().mockImplementation(() => {
       const batch = existingRowBatches[Math.min(selectCalls, existingRowBatches.length - 1)] ?? [];
@@ -55,6 +60,7 @@ function createDb(args: {
       return selectChain(batch);
     }),
     insert: vi.fn().mockReturnValue(insertChain(args.insertedRows ?? [{ id: bulkOperationId }], args.calls ?? [])),
+    delete: vi.fn().mockReturnValue(deleteChain),
     transaction: vi.fn(),
   };
 }
@@ -125,6 +131,37 @@ describe('createBulkOperationFactory', () => {
     expect(queueService.enqueueBulkOp.mock.calls[0]?.[1].idempotencyKey).toBe(values.idempotencyKey);
   });
 
+  it('accepts newer UUID versions for client idempotency keys', async () => {
+    const uuidV7Key = '018f6d5e-9b8c-7c2d-9a1b-abcdefabcdef';
+    const db = createDb({});
+    const queueService = createQueueService();
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await factory.startBulkOperation({ ...baseArgs, idempotencyKey: uuidV7Key });
+
+    const values = db.insert.mock.results[0]?.value.values.mock.calls[0]?.[0];
+    expect(values.idempotencyKey).toBe(uuidV7Key);
+  });
+
+  it('stores compact metadata payload separately from the queue job params', async () => {
+    const db = createDb({});
+    const queueService = createQueueService();
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await factory.startBulkOperation({
+      ...baseArgs,
+      payload: { parsedCount: 2 },
+      params: { rows: [{ text: 'one' }, { text: 'two' }] },
+    });
+
+    expect(db.insert.mock.results[0]?.value.values).toHaveBeenCalledWith(expect.objectContaining({
+      payload: { parsedCount: 2 },
+    }));
+    expect(queueService.enqueueBulkOp.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      params: { rows: [{ text: 'one' }, { text: 'two' }] },
+    }));
+  });
+
   it('returns replay metadata for an existing idempotency key', async () => {
     const db = createDb({ existingRows: [{ id: bulkOperationId }] });
     const queueService = createQueueService();
@@ -188,7 +225,7 @@ describe('createBulkOperationFactory', () => {
     expect(queueService.enqueueBulkOp).not.toHaveBeenCalled();
   });
 
-  it('preserves existing insert-before-enqueue semantics when enqueue fails', async () => {
+  it('deletes the created operation row when enqueue fails', async () => {
     const calls: string[] = [];
     const db = createDb({ calls });
     const queueError = new Error('queue unavailable');
@@ -197,7 +234,7 @@ describe('createBulkOperationFactory', () => {
 
     await expect(factory.startBulkOperation(baseArgs)).rejects.toThrow(queueError);
 
-    expect(calls).toEqual(['insert:returning', 'enqueue']);
-    expect(db.transaction).not.toHaveBeenCalled();
+    expect(calls).toEqual(['insert:returning', 'enqueue', 'delete']);
+    expect(db.delete).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/api/src/services/__tests__/bulk-operation.factory.test.ts
+++ b/packages/api/src/services/__tests__/bulk-operation.factory.test.ts
@@ -15,11 +15,10 @@ const correlationId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
 const baseArgs: StartBulkOperationArgs = {
   userId,
   idempotencyKey,
-  type: JOB_NAMES.bulkQueueRandomize,
+  operationType: JOB_NAMES.bulkQueueRandomize,
   targetKind: 'queue',
   targetId,
   params: { mode: 'shuffle' },
-  jobName: JOB_NAMES.bulkQueueRandomize,
   correlationId,
 };
 
@@ -30,24 +29,32 @@ function selectChain(rows: Array<{ id: string }>) {
   return chain;
 }
 
-function insertChain(row: { id: string }, calls: string[]) {
+function insertChain(rows: Array<{ id: string }>, calls: string[]) {
   const chain: Record<string, any> = {};
   chain.values = vi.fn().mockReturnValue(chain);
+  chain.onConflictDoNothing = vi.fn().mockReturnValue(chain);
   chain.returning = vi.fn().mockImplementation(() => {
     calls.push('insert:returning');
-    return Promise.resolve([row]);
+    return Promise.resolve(rows);
   });
   return chain;
 }
 
 function createDb(args: {
   existingRows?: Array<{ id: string }>;
-  insertedRow?: { id: string };
+  existingRowBatches?: Array<Array<{ id: string }>>;
+  insertedRows?: Array<{ id: string }>;
   calls?: string[];
 }) {
+  let selectCalls = 0;
+  const existingRowBatches = args.existingRowBatches ?? [args.existingRows ?? []];
   return {
-    select: vi.fn().mockReturnValue(selectChain(args.existingRows ?? [])),
-    insert: vi.fn().mockReturnValue(insertChain(args.insertedRow ?? { id: bulkOperationId }, args.calls ?? [])),
+    select: vi.fn().mockImplementation(() => {
+      const batch = existingRowBatches[Math.min(selectCalls, existingRowBatches.length - 1)] ?? [];
+      selectCalls += 1;
+      return selectChain(batch);
+    }),
+    insert: vi.fn().mockReturnValue(insertChain(args.insertedRows ?? [{ id: bulkOperationId }], args.calls ?? [])),
     transaction: vi.fn(),
   };
 }
@@ -128,6 +135,42 @@ describe('createBulkOperationFactory', () => {
       jobId: null,
       replay: true,
     });
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(queueService.enqueueBulkOp).not.toHaveBeenCalled();
+  });
+
+  it('returns replay metadata when a concurrent insert wins the idempotency race', async () => {
+    const db = createDb({
+      existingRowBatches: [[], [{ id: bulkOperationId }]],
+      insertedRows: [],
+    });
+    const queueService = createQueueService();
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await expect(factory.startBulkOperation(baseArgs)).resolves.toEqual({
+      bulkOperationId,
+      jobId: null,
+      replay: true,
+    });
+
+    expect(db.select).toHaveBeenCalledTimes(2);
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    expect(db.insert.mock.results[0]?.value.onConflictDoNothing).toHaveBeenCalledTimes(1);
+    expect(queueService.enqueueBulkOp).not.toHaveBeenCalled();
+  });
+
+  it('looks up replay metadata without creating a generated idempotency key', async () => {
+    const db = createDb({ existingRows: [{ id: bulkOperationId }] });
+    const queueService = createQueueService();
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await expect(factory.findExistingBulkOperation({ userId, idempotencyKey })).resolves.toEqual({
+      bulkOperationId,
+      jobId: null,
+      replay: true,
+    });
+    await expect(factory.findExistingBulkOperation({ userId, idempotencyKey: undefined })).resolves.toBeNull();
+
     expect(db.insert).not.toHaveBeenCalled();
     expect(queueService.enqueueBulkOp).not.toHaveBeenCalled();
   });

--- a/packages/api/src/services/bulk-operation.factory.ts
+++ b/packages/api/src/services/bulk-operation.factory.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { bulkOperations, type Db } from '@sms/db';
+import type { JobName } from '@sms/shared';
+import type { BulkOpsQueueService } from './bulk-ops-queue.service.js';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type BulkOperationTargetKind = 'profile' | 'queue' | 'scheduled-list';
+
+export class InvalidIdempotencyKeyError extends Error {
+  constructor() {
+    super('Invalid Idempotency-Key header');
+    this.name = 'InvalidIdempotencyKeyError';
+  }
+}
+
+export interface StartBulkOperationArgs {
+  userId: string;
+  idempotencyKey: string | undefined;
+  type: string;
+  targetKind: BulkOperationTargetKind;
+  targetId: string | null;
+  params: Record<string, unknown>;
+  jobName: JobName;
+  correlationId?: string;
+}
+
+export interface StartBulkOperationResult {
+  bulkOperationId: string;
+  jobId: string | null;
+  replay: boolean;
+}
+
+export interface BulkOperationFactory {
+  startBulkOperation(args: StartBulkOperationArgs): Promise<StartBulkOperationResult>;
+}
+
+function parseIdempotencyKey(rawHeader: string | undefined): string {
+  if (rawHeader === undefined) return randomUUID();
+  const idempotencyKey = rawHeader.trim();
+  if (!UUID_PATTERN.test(idempotencyKey)) {
+    throw new InvalidIdempotencyKeyError();
+  }
+  return idempotencyKey;
+}
+
+export function createBulkOperationFactory(
+  db: Db,
+  bulkOpsQueueService: BulkOpsQueueService,
+): BulkOperationFactory {
+  return {
+    async startBulkOperation(args): Promise<StartBulkOperationResult> {
+      const idempotencyKey = parseIdempotencyKey(args.idempotencyKey);
+
+      const [existingBulkOperation] = await db
+        .select({ id: bulkOperations.id })
+        .from(bulkOperations)
+        .where(and(
+          eq(bulkOperations.userId, args.userId),
+          eq(bulkOperations.idempotencyKey, idempotencyKey),
+        ));
+      if (existingBulkOperation) {
+        return {
+          bulkOperationId: existingBulkOperation.id,
+          jobId: null,
+          replay: true,
+        };
+      }
+
+      const [bulkOperation] = await db
+        .insert(bulkOperations)
+        .values({
+          userId: args.userId,
+          operationType: args.type,
+          targetKind: args.targetKind,
+          targetId: args.targetId,
+          idempotencyKey,
+          payload: args.params,
+        })
+        .returning();
+
+      const job = await bulkOpsQueueService.enqueueBulkOp(
+        args.jobName,
+        {
+          bulkOperationId: bulkOperation.id,
+          userId: args.userId,
+          operationType: args.type,
+          targetKind: args.targetKind,
+          targetId: args.targetId,
+          idempotencyKey,
+          params: args.params,
+          correlationId: args.correlationId ?? randomUUID(),
+        },
+        Math.floor(Date.now() / 1000),
+      );
+
+      return {
+        bulkOperationId: bulkOperation.id,
+        jobId: job.id ?? null,
+        replay: false,
+      };
+    },
+  };
+}

--- a/packages/api/src/services/bulk-operation.factory.ts
+++ b/packages/api/src/services/bulk-operation.factory.ts
@@ -4,7 +4,7 @@ import { bulkOperations, type Db } from '@sms/db';
 import type { JobName } from '@sms/shared';
 import type { BulkOpsQueueService } from './bulk-ops-queue.service.js';
 
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 type BulkOperationTargetKind = 'profile' | 'queue' | 'scheduled-list';
 
@@ -21,6 +21,7 @@ export interface StartBulkOperationArgs {
   operationType: JobName;
   targetKind: BulkOperationTargetKind;
   targetId: string | null;
+  payload?: Record<string, unknown>;
   params: Record<string, unknown>;
   correlationId?: string;
 }
@@ -100,7 +101,7 @@ export function createBulkOperationFactory(
           targetKind: args.targetKind,
           targetId: args.targetId,
           idempotencyKey,
-          payload: args.params,
+          payload: args.payload ?? args.params,
         })
         .onConflictDoNothing({
           target: [bulkOperations.userId, bulkOperations.idempotencyKey],
@@ -120,20 +121,26 @@ export function createBulkOperationFactory(
         throw new Error('Bulk operation insert conflict could not be reloaded');
       }
 
-      const job = await bulkOpsQueueService.enqueueBulkOp(
-        args.operationType,
-        {
-          bulkOperationId: bulkOperation.id,
-          userId: args.userId,
-          operationType: args.operationType,
-          targetKind: args.targetKind,
-          targetId: args.targetId,
-          idempotencyKey,
-          params: args.params,
-          correlationId: args.correlationId ?? randomUUID(),
-        },
-        Math.floor(Date.now() / 1000),
-      );
+      let job;
+      try {
+        job = await bulkOpsQueueService.enqueueBulkOp(
+          args.operationType,
+          {
+            bulkOperationId: bulkOperation.id,
+            userId: args.userId,
+            operationType: args.operationType,
+            targetKind: args.targetKind,
+            targetId: args.targetId,
+            idempotencyKey,
+            params: args.params,
+            correlationId: args.correlationId ?? randomUUID(),
+          },
+          Math.floor(Date.now() / 1000),
+        );
+      } catch (err) {
+        await db.delete(bulkOperations).where(eq(bulkOperations.id, bulkOperation.id));
+        throw err;
+      }
 
       return {
         bulkOperationId: bulkOperation.id,

--- a/packages/api/src/services/bulk-operation.factory.ts
+++ b/packages/api/src/services/bulk-operation.factory.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { bulkOperations, type Db } from '@sms/db';
 import type { JobName } from '@sms/shared';
 import type { BulkOpsQueueService } from './bulk-ops-queue.service.js';
@@ -18,11 +18,10 @@ export class InvalidIdempotencyKeyError extends Error {
 export interface StartBulkOperationArgs {
   userId: string;
   idempotencyKey: string | undefined;
-  type: string;
+  operationType: JobName;
   targetKind: BulkOperationTargetKind;
   targetId: string | null;
   params: Record<string, unknown>;
-  jobName: JobName;
   correlationId?: string;
 }
 
@@ -33,11 +32,12 @@ export interface StartBulkOperationResult {
 }
 
 export interface BulkOperationFactory {
+  findExistingBulkOperation(args: Pick<StartBulkOperationArgs, 'userId' | 'idempotencyKey'>): Promise<StartBulkOperationResult | null>;
   startBulkOperation(args: StartBulkOperationArgs): Promise<StartBulkOperationResult>;
 }
 
-function parseIdempotencyKey(rawHeader: string | undefined): string {
-  if (rawHeader === undefined) return randomUUID();
+function parseClientIdempotencyKey(rawHeader: string | undefined): string | null {
+  if (rawHeader === undefined) return null;
   const idempotencyKey = rawHeader.trim();
   if (!UUID_PATTERN.test(idempotencyKey)) {
     throw new InvalidIdempotencyKeyError();
@@ -45,21 +45,45 @@ function parseIdempotencyKey(rawHeader: string | undefined): string {
   return idempotencyKey;
 }
 
+function parseOrGenerateIdempotencyKey(rawHeader: string | undefined): string {
+  return parseClientIdempotencyKey(rawHeader) ?? randomUUID();
+}
+
 export function createBulkOperationFactory(
   db: Db,
   bulkOpsQueueService: BulkOpsQueueService,
 ): BulkOperationFactory {
-  return {
-    async startBulkOperation(args): Promise<StartBulkOperationResult> {
-      const idempotencyKey = parseIdempotencyKey(args.idempotencyKey);
+  async function findExistingBulkOperationRow(userId: string, idempotencyKey: string) {
+    const [existingBulkOperation] = await db
+      .select({ id: bulkOperations.id })
+      .from(bulkOperations)
+      .where(and(
+        eq(bulkOperations.userId, userId),
+        eq(bulkOperations.idempotencyKey, idempotencyKey),
+      ));
 
-      const [existingBulkOperation] = await db
-        .select({ id: bulkOperations.id })
-        .from(bulkOperations)
-        .where(and(
-          eq(bulkOperations.userId, args.userId),
-          eq(bulkOperations.idempotencyKey, idempotencyKey),
-        ));
+    return existingBulkOperation ?? null;
+  }
+
+  return {
+    async findExistingBulkOperation(args): Promise<StartBulkOperationResult | null> {
+      const idempotencyKey = parseClientIdempotencyKey(args.idempotencyKey);
+      if (!idempotencyKey) return null;
+
+      const existingBulkOperation = await findExistingBulkOperationRow(args.userId, idempotencyKey);
+      if (!existingBulkOperation) return null;
+
+      return {
+        bulkOperationId: existingBulkOperation.id,
+        jobId: null,
+        replay: true,
+      };
+    },
+
+    async startBulkOperation(args): Promise<StartBulkOperationResult> {
+      const idempotencyKey = parseOrGenerateIdempotencyKey(args.idempotencyKey);
+
+      const existingBulkOperation = await findExistingBulkOperationRow(args.userId, idempotencyKey);
       if (existingBulkOperation) {
         return {
           bulkOperationId: existingBulkOperation.id,
@@ -72,20 +96,36 @@ export function createBulkOperationFactory(
         .insert(bulkOperations)
         .values({
           userId: args.userId,
-          operationType: args.type,
+          operationType: args.operationType,
           targetKind: args.targetKind,
           targetId: args.targetId,
           idempotencyKey,
           payload: args.params,
         })
+        .onConflictDoNothing({
+          target: [bulkOperations.userId, bulkOperations.idempotencyKey],
+          where: sql`${bulkOperations.idempotencyKey} is not null`,
+        })
         .returning();
 
+      if (!bulkOperation) {
+        const conflictedBulkOperation = await findExistingBulkOperationRow(args.userId, idempotencyKey);
+        if (conflictedBulkOperation) {
+          return {
+            bulkOperationId: conflictedBulkOperation.id,
+            jobId: null,
+            replay: true,
+          };
+        }
+        throw new Error('Bulk operation insert conflict could not be reloaded');
+      }
+
       const job = await bulkOpsQueueService.enqueueBulkOp(
-        args.jobName,
+        args.operationType,
         {
           bulkOperationId: bulkOperation.id,
           userId: args.userId,
-          operationType: args.type,
+          operationType: args.operationType,
           targetKind: args.targetKind,
           targetId: args.targetId,
           idempotencyKey,

--- a/packages/db/drizzle/0011_bulk-operation-idempotency-unique.sql
+++ b/packages/db/drizzle/0011_bulk-operation-idempotency-unique.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS "bulk_operations_idempotency_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "bulk_operations_user_idempotency_uniq" ON "bulk_operations" USING btree ("user_id","idempotency_key") WHERE "idempotency_key" IS NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778933495000,
       "tag": "0010_post-media-user-id",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1779364448000,
+      "tag": "0011_bulk-operation-idempotency-unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/bulk-operations.ts
+++ b/packages/db/src/schema/bulk-operations.ts
@@ -1,4 +1,4 @@
-import { pgTable, pgEnum, uuid, text, varchar, timestamp, integer, jsonb, index } from 'drizzle-orm/pg-core';
+import { pgTable, pgEnum, uuid, text, varchar, timestamp, integer, jsonb, index, uniqueIndex } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 import { users } from './users.js';
 
@@ -38,7 +38,9 @@ export const bulkOperations = pgTable(
   (table) => [
     index('bulk_operations_user_status_idx').on(table.userId, table.status),
     index('bulk_operations_user_created_idx').on(table.userId, table.createdAt.desc()),
-    index('bulk_operations_idempotency_idx').on(table.idempotencyKey),
+    uniqueIndex('bulk_operations_user_idempotency_uniq')
+      .on(table.userId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} is not null`),
   ],
 );
 


### PR DESCRIPTION
## Summary
- Add `BulkOperationFactory` to centralize idempotency-key parsing, existing-operation replay, `bulk_operations` inserts, and queue enqueueing.
- Route bulk import, queue bulk operations, and post bulk operations through the factory.
- Add focused regression coverage for the factory and queue route integration.

## Validation
- `pnpm --filter @sms/api exec vitest run src/services/__tests__/bulk-operation.factory.test.ts`
- `pnpm --filter @sms/api exec vitest run src/__tests__/routes/bulk-import.test.ts src/__tests__/routes/bulk-csrf-auth.test.ts src/services/__tests__/bulk-operation.factory.test.ts`
- `pnpm --filter @sms/api exec vitest run src/__tests__/routes/queues.test.ts src/__tests__/routes/bulk-import.test.ts src/services/__tests__/bulk-operation.factory.test.ts`
- `rg "bulkOperations\)\.values" packages/api/src/routes/` returns no matches

## Known unrelated issue
- `pnpm --filter @sms/api typecheck` still fails on existing `packages/api/src/services/post-crud.service.ts(107,13): Type `scheduled_at_invalid` is not assignable to type `never`.

Ready for review.