### PR TITLE
Fix scheduledAt invalid API error mapping

### DIFF
--- a/packages/api/src/__tests__/services/post.test.ts
+++ b/packages/api/src/__tests__/services/post.test.ts
@@ -622,6 +622,26 @@ describe('post.service', () => {
       }
     });
 
+    it('rejects invalid scheduledAt values with 400', async () => {
+      const db = createPostUpdateMockDb({
+        updateResult: [],
+        existingPost: { id: 'post-1', status: 'draft', postVersion: 1, scheduledAt: null },
+      });
+
+      try {
+        await updatePost(db, 'user-1', 'post-1', {
+          status: 'scheduled',
+          scheduledAt: 'not-a-date',
+          postVersion: 1,
+        });
+        expect.unreachable('should have thrown');
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(AppError);
+        expect(err.message).toContain('valid datetime');
+        expect(err.statusCode).toBe(400);
+      }
+    });
+
     it('rejects updates to posts in auto_destructing state', async () => {
       const db = createPostUpdateMockDb({
         updateResult: [],

--- a/packages/api/src/services/post-crud.service.ts
+++ b/packages/api/src/services/post-crud.service.ts
@@ -101,6 +101,7 @@ function toPostAppError(err: PostInvariantError): AppError {
     case 'not_scheduled':
       return new AppError(err.message, 409);
     case 'scheduled_at_required':
+    case 'scheduled_at_invalid':
     case 'scheduled_at_must_be_future':
       return new AppError(err.message, 400);
     default: {


### PR DESCRIPTION
## Summary
- Map `scheduled_at_invalid` from `PostInvariantError` to a 400 `AppError`.
- Add a regression test proving invalid scheduled datetimes return a client error instead of falling through the exhaustiveness guard.

## Cause
`planUpdate()` can throw `scheduled_at_invalid` for unparsable scheduled datetimes, but `toPostAppError()` handled only missing and past scheduled timestamps. The `never` exhaustiveness guard correctly exposed the missing case during API typecheck.

## Validation
- `pnpm --filter @sms/api typecheck`
- `pnpm --filter @sms/api exec vitest run src/__tests__/services/post.test.ts`
- RoboRev branch review: no issues found

Ready for review.