### PR TITLE
Fix bulk import completion notifications

### DIFF
--- a/packages/web/src/components/notifications/NotificationRow.tsx
+++ b/packages/web/src/components/notifications/NotificationRow.tsx
@@ -23,7 +23,9 @@ const severityDotClass: Record<NotificationRowData['severity'], string> = {
 
 function isSafeLinkPath(linkPath: string | null): linkPath is string {
   // Match route prefixes exactly; uppercase prefixes would miss the router and 404.
-  return Boolean(linkPath && /^\/(?:posts|profiles|queues|notifications)(?:\/[a-zA-Z0-9-]+)?$/.test(linkPath));
+  const safeEntityPath = /^\/(?:posts|profiles|queues|notifications)(?:\/[a-zA-Z0-9-]+)?$/;
+  const safeBulkOpPath = /^\/posts\?bulkOp=[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return Boolean(linkPath && (safeEntityPath.test(linkPath) || safeBulkOpPath.test(linkPath)));
 }
 
 function getErrorReportUrl(payload: Record<string, unknown>): string | null {

--- a/packages/web/src/components/notifications/NotificationRow.tsx
+++ b/packages/web/src/components/notifications/NotificationRow.tsx
@@ -24,7 +24,7 @@ const severityDotClass: Record<NotificationRowData['severity'], string> = {
 function isSafeLinkPath(linkPath: string | null): linkPath is string {
   // Match route prefixes exactly; uppercase prefixes would miss the router and 404.
   const safeEntityPath = /^\/(?:posts|profiles|queues|notifications)(?:\/[a-zA-Z0-9-]+)?$/;
-  const safeBulkOpPath = /^\/posts\?bulkOp=[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const safeBulkOpPath = /^\/posts\?bulkOp=[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
   return Boolean(linkPath && (safeEntityPath.test(linkPath) || safeBulkOpPath.test(linkPath)));
 }
 

--- a/packages/web/src/components/notifications/__tests__/NotificationRow.test.tsx
+++ b/packages/web/src/components/notifications/__tests__/NotificationRow.test.tsx
@@ -60,4 +60,24 @@ describe('NotificationRow', () => {
 
     expect(onNavigate).toHaveBeenCalledWith('/posts?bulkOp=55555555-5555-4555-8555-555555555555');
   });
+
+  it('does not navigate uppercase bulk operation route or query keys', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+
+    render(
+      <NotificationRow
+        notification={makeNotification({
+          eventType: 'bulk_completed',
+          title: 'Import complete',
+          linkPath: '/POSTS?BULKOP=55555555-5555-4555-8555-555555555555',
+        })}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss Import complete' }));
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/components/notifications/__tests__/NotificationRow.test.tsx
+++ b/packages/web/src/components/notifications/__tests__/NotificationRow.test.tsx
@@ -40,4 +40,24 @@ describe('NotificationRow', () => {
     expect(onMarkRead).toHaveBeenCalledWith('notification-1');
     expect(onNavigate).toHaveBeenCalledWith('/queues/queue-1');
   });
+
+  it('allows bulk import completion links with bulk operation ids', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+
+    render(
+      <NotificationRow
+        notification={makeNotification({
+          eventType: 'bulk_completed',
+          title: 'Import complete',
+          linkPath: '/posts?bulkOp=55555555-5555-4555-8555-555555555555',
+        })}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'View' }));
+
+    expect(onNavigate).toHaveBeenCalledWith('/posts?bulkOp=55555555-5555-4555-8555-555555555555');
+  });
 });

--- a/packages/web/src/pages/posts/PostsPage.tsx
+++ b/packages/web/src/pages/posts/PostsPage.tsx
@@ -270,7 +270,15 @@ export default function PostsPage() {
     const timer = setTimeout(() => {
       const trimmedSearch = searchInput.trim();
       setFilters((prev) => ({ ...prev, search: trimmedSearch || undefined, page: 1 }));
-      setSearchParams(trimmedSearch ? { search: trimmedSearch } : {}, { replace: true });
+      setSearchParams((currentParams) => {
+        const nextParams = new URLSearchParams(currentParams);
+        if (trimmedSearch) {
+          nextParams.set("search", trimmedSearch);
+        } else {
+          nextParams.delete("search");
+        }
+        return nextParams;
+      }, { replace: true });
     }, 300);
     return () => clearTimeout(timer);
   }, [searchInput, setSearchParams]);

--- a/packages/web/src/pages/posts/__tests__/PostsPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/PostsPage.test.tsx
@@ -146,10 +146,12 @@ describe('PostsPage URL-state', () => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(setSearchParams).toHaveBeenLastCalledWith(
-      { search: 'announcement' },
-      { replace: true },
-    );
+    const [updateParams, options] = setSearchParams.mock.lastCall ?? [];
+    expect(options).toEqual({ replace: true });
+    expect(updateParams).toBeInstanceOf(Function);
+    const nextParams = updateParams(new URLSearchParams('bulkOp=55555555-5555-4555-8555-555555555555'));
+    expect(nextParams.get('search')).toBe('announcement');
+    expect(nextParams.get('bulkOp')).toBe('55555555-5555-4555-8555-555555555555');
   });
 
   it('removes the search param when the input is cleared', () => {
@@ -165,7 +167,12 @@ describe('PostsPage URL-state', () => {
       vi.advanceTimersByTime(300);
     });
 
-    expect(setSearchParams).toHaveBeenLastCalledWith({}, { replace: true });
+    const [updateParams, options] = setSearchParams.mock.lastCall ?? [];
+    expect(options).toEqual({ replace: true });
+    expect(updateParams).toBeInstanceOf(Function);
+    const nextParams = updateParams(new URLSearchParams('bulkOp=55555555-5555-4555-8555-555555555555&search=announcement'));
+    expect(nextParams.has('search')).toBe(false);
+    expect(nextParams.get('bulkOp')).toBe('55555555-5555-4555-8555-555555555555');
   });
 
   it('shows every lifecycle status filter from the shared status model', () => {

--- a/packages/worker/src/__tests__/queue-scanner.test.ts
+++ b/packages/worker/src/__tests__/queue-scanner.test.ts
@@ -324,7 +324,7 @@ describe('Queue Scanner', () => {
           queueName: 'Test Queue',
           profileId,
           correlationId: expect.any(String),
-          occurredAt: expect.any(String),
+          occurredAt: NOW.toJSDate().toISOString(),
         }),
       );
       const payload = vi.mocked(notificationQueue.add).mock.calls[0]?.[1];

--- a/packages/worker/src/__tests__/queue-scanner.test.ts
+++ b/packages/worker/src/__tests__/queue-scanner.test.ts
@@ -41,6 +41,7 @@ import {
   hasIntervalElapsed,
   isWithinSeasonalWindow,
   resolveSpinnableText,
+  queueEmptyNotificationSchema,
 } from '@sms/shared';
 import { evaluateQueues, QUEUE_SCANNER_QUEUE_NAME, QUEUE_SCAN_INTERVAL_MS } from '../queue-scanner.js';
 
@@ -306,8 +307,10 @@ describe('Queue Scanner', () => {
     it('emits queue-empty notification when no posts available', async () => {
       const publishQueue = createMockQueue();
       const notificationQueue = createMockQueue();
+      const queueId = '55555555-5555-4555-8555-555555555555';
+      const profileId = '22222222-2222-4222-8222-222222222222';
       const db = createMockDb({
-        activeQueues: [makeQueue()],
+        activeQueues: [makeQueue({ id: queueId, profileId })],
         nextPost: null,
       });
 
@@ -317,10 +320,15 @@ describe('Queue Scanner', () => {
       expect(notificationQueue.add).toHaveBeenCalledWith(
         'queue-empty',
         expect.objectContaining({
-          queueId: 'queue-1',
+          queueId,
           queueName: 'Test Queue',
+          profileId,
+          correlationId: expect.any(String),
+          occurredAt: expect.any(String),
         }),
       );
+      const payload = vi.mocked(notificationQueue.add).mock.calls[0]?.[1];
+      expect(queueEmptyNotificationSchema.safeParse(payload).success).toBe(true);
     });
 
     it('advances cursor from position N to next queued post via transaction', async () => {

--- a/packages/worker/src/notifications/handlers/__tests__/bulk-completed.test.ts
+++ b/packages/worker/src/notifications/handlers/__tests__/bulk-completed.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { performNotificationSideEffects } from '../common.js';
 import { handleBulkCompletedNotification } from '../bulk-completed.handler.js';
 
 describe('handleBulkCompletedNotification', () => {
@@ -26,5 +27,23 @@ describe('handleBulkCompletedNotification', () => {
       title: 'Randomize queue complete',
     }));
     expect(store.insertEmailLog).not.toHaveBeenCalled();
+  });
+
+  it('rejects bulk operation links with uppercase route or query key', async () => {
+    const store = { insertNotification: vi.fn() };
+
+    await performNotificationSideEffects({
+      ctx: { store },
+      userId: '44444444-4444-4444-4444-444444444444',
+      eventType: 'bulk_completed',
+      title: 'Import complete',
+      body: '1 succeeded, 0 failed.',
+      linkPath: '/POSTS?BULKOP=55555555-5555-4555-8555-555555555555',
+      payload: { correlationId: '33333333-3333-4333-8333-333333333333' },
+    });
+
+    expect(store.insertNotification).toHaveBeenCalledWith(expect.objectContaining({
+      linkPath: null,
+    }));
   });
 });

--- a/packages/worker/src/notifications/handlers/__tests__/bulk-completed.test.ts
+++ b/packages/worker/src/notifications/handlers/__tests__/bulk-completed.test.ts
@@ -22,6 +22,7 @@ describe('handleBulkCompletedNotification', () => {
 
     expect(store.insertNotification).toHaveBeenCalledWith(expect.objectContaining({
       eventType: 'bulk_completed',
+      linkPath: '/posts?bulkOp=55555555-5555-4555-8555-555555555555',
       title: 'Randomize queue complete',
     }));
     expect(store.insertEmailLog).not.toHaveBeenCalled();

--- a/packages/worker/src/notifications/handlers/common.ts
+++ b/packages/worker/src/notifications/handlers/common.ts
@@ -119,7 +119,9 @@ export function truncateNotificationText(input: string, maxLength = 1000): strin
 
 function safeLinkPath(linkPath: string | null): string | null {
   if (!linkPath) return null;
-  if (!/^\/(?:posts|profiles|queues)(?:\/[a-z0-9-]+)?$/i.test(linkPath)) {
+  const safeEntityPath = /^\/(?:posts|profiles|queues)(?:\/[a-z0-9-]+)?$/i;
+  const safeBulkOpPath = /^\/posts\?bulkOp=[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (!safeEntityPath.test(linkPath) && !safeBulkOpPath.test(linkPath)) {
     return null;
   }
   return linkPath;

--- a/packages/worker/src/notifications/handlers/common.ts
+++ b/packages/worker/src/notifications/handlers/common.ts
@@ -120,7 +120,7 @@ export function truncateNotificationText(input: string, maxLength = 1000): strin
 function safeLinkPath(linkPath: string | null): string | null {
   if (!linkPath) return null;
   const safeEntityPath = /^\/(?:posts|profiles|queues)(?:\/[a-z0-9-]+)?$/i;
-  const safeBulkOpPath = /^\/posts\?bulkOp=[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const safeBulkOpPath = /^\/posts\?bulkOp=[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
   if (!safeEntityPath.test(linkPath) && !safeBulkOpPath.test(linkPath)) {
     return null;
   }

--- a/packages/worker/src/queue-scanner.ts
+++ b/packages/worker/src/queue-scanner.ts
@@ -275,7 +275,7 @@ export async function evaluateQueues(
           queueName: queue.name,
           profileId: queue.profileId,
           correlationId: randomUUID(),
-          occurredAt: new Date().toISOString(),
+          occurredAt: currentNow.toJSDate().toISOString(),
         }).catch((err: unknown) => {
           notificationThrottle.set(queue.id, Date.now());
           logger.error({ err, queueId: queue.id }, 'Failed to enqueue queue-empty notification');

--- a/packages/worker/src/queue-scanner.ts
+++ b/packages/worker/src/queue-scanner.ts
@@ -271,10 +271,11 @@ export async function evaluateQueues(
           continue;
         }
         await notificationQueue.add(JOB_NAMES.queueEmptyNotification, {
-          kind: 'queue_empty',
           queueId: queue.id,
           queueName: queue.name,
-          at: new Date().toISOString(),
+          profileId: queue.profileId,
+          correlationId: randomUUID(),
+          occurredAt: new Date().toISOString(),
         }).catch((err: unknown) => {
           notificationThrottle.set(queue.id, Date.now());
           logger.error({ err, queueId: queue.id }, 'Failed to enqueue queue-empty notification');


### PR DESCRIPTION
## Summary
- Fix bulk completion notifications so safe `/posts?bulkOp=...` links are preserved by worker and web notification link sanitizers.
- Preserve existing Posts page query params when the search debounce updates `search`, so notification navigation does not collapse back to `/posts`.
- Emit queue-empty notification jobs with the schema fields the notification worker expects.

## Validation
- `pnpm --filter @sms/web exec vitest run src/components/notifications/__tests__/NotificationRow.test.tsx src/pages/posts/__tests__/PostsPage.test.tsx --reporter=verbose`
- `pnpm --filter @sms/worker exec vitest run src/notifications/handlers/__tests__/bulk-completed.test.ts src/__tests__/queue-scanner.test.ts --reporter=verbose`
- `pnpm --filter @sms/web typecheck`
- `pnpm --filter @sms/worker typecheck`
- `git diff --check`
- Real Chrome browser verification: imported a CSV into a queue, confirmed the queued post appeared, confirmed the bulk-completed notification appeared, clicked `View`, and confirmed navigation to `/posts?bulkOp=...` preserved the query.
