### PR TITLE
[codex] Fix bulk job correlation ids

### DIFF
--- a/packages/api/src/services/__tests__/bulk-operation.factory.test.ts
+++ b/packages/api/src/services/__tests__/bulk-operation.factory.test.ts
@@ -131,6 +131,21 @@ describe('createBulkOperationFactory', () => {
     expect(queueService.enqueueBulkOp.mock.calls[0]?.[1].idempotencyKey).toBe(values.idempotencyKey);
   });
 
+  it('generates a UUID correlation id when the incoming request id is not a UUID', async () => {
+    const db = createDb({});
+    const queueService = createQueueService();
+    const factory = createBulkOperationFactory(db as never, queueService);
+
+    await factory.startBulkOperation({
+      ...baseArgs,
+      correlationId: 'b810e1a0aa0f8d2ff3cbf90ac24eb9bb',
+    });
+
+    const payload = queueService.enqueueBulkOp.mock.calls[0]?.[1];
+    expect(payload.correlationId).not.toBe('b810e1a0aa0f8d2ff3cbf90ac24eb9bb');
+    expect(payload.correlationId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
   it('accepts newer UUID versions for client idempotency keys', async () => {
     const uuidV7Key = '018f6d5e-9b8c-7c2d-9a1b-abcdefabcdef';
     const db = createDb({});

--- a/packages/api/src/services/bulk-operation.factory.ts
+++ b/packages/api/src/services/bulk-operation.factory.ts
@@ -50,6 +50,14 @@ function parseOrGenerateIdempotencyKey(rawHeader: string | undefined): string {
   return parseClientIdempotencyKey(rawHeader) ?? randomUUID();
 }
 
+function resolveCorrelationId(rawCorrelationId: string | undefined): string {
+  const correlationId = rawCorrelationId?.trim();
+  if (correlationId && UUID_PATTERN.test(correlationId)) {
+    return correlationId;
+  }
+  return randomUUID();
+}
+
 export function createBulkOperationFactory(
   db: Db,
   bulkOpsQueueService: BulkOpsQueueService,
@@ -133,7 +141,7 @@ export function createBulkOperationFactory(
             targetId: args.targetId,
             idempotencyKey,
             params: args.params,
-            correlationId: args.correlationId ?? randomUUID(),
+            correlationId: resolveCorrelationId(args.correlationId),
           },
           Math.floor(Date.now() / 1000),
         );


### PR DESCRIPTION
## Summary

Bulk CSV imports could enqueue a bulk operation job with a non-UUID `correlationId` when the incoming `X-Request-Id` header used a compact trace-id format. The worker validates bulk job payloads with a UUID-only schema, so those jobs failed as unrecoverable before row processing began.

This change normalizes the bulk job correlation id at the bulk operation factory boundary: valid UUID request ids are preserved, and missing or non-UUID values are replaced with a fresh `randomUUID()` before enqueueing.

## Validation

- `pnpm -r build`
- `pnpm exec vitest run src/services/__tests__/bulk-operation.factory.test.ts` from `packages/api`
- `pnpm --filter @sms/api typecheck`

Roborev reviewed the original single-commit fix against its immediate base and reported no issues.