### PR TITLE
[codex] Show queued posts on dashboard

### DIFF
--- a/packages/api/src/__tests__/services/post.test.ts
+++ b/packages/api/src/__tests__/services/post.test.ts
@@ -16,13 +16,19 @@ function makeTableStub(tableName: string, columns: string[]) {
 const mockPosts = makeTableStub('posts', [
   'id', 'userId', 'profileId', 'text', 'isThread', 'status', 'scheduledAt',
   'publishedAt', 'failedAt', 'failureReason', 'platformPostId', 'postVersion',
-  'hasSpinnableText', 'autoDestructAfter', 'notes', 'createdAt', 'updatedAt',
-  'searchVector', 'tagSearchVector',
+  'hasSpinnableText', 'autoDestructAfter', 'queueId', 'queuePosition', 'notes',
+  'createdAt', 'updatedAt', 'searchVector', 'tagSearchVector',
 ]);
 
 const mockTags = makeTableStub('tags', ['id', 'name', 'color', 'userId', 'createdAt', 'updatedAt']);
 const mockPostTags = makeTableStub('post_tags', ['postId', 'tagId']);
 const mockSocialProfiles = makeTableStub('social_profiles', ['id', 'userId']);
+const mockQueues = makeTableStub('queues', [
+  'id', 'userId', 'isPaused', 'cursorPosition', 'intervalType', 'intervalValue',
+  'intervalUnit', 'daysOfWeek', 'hourSlots', 'startDate', 'lastPublishedAt',
+  'nextRunAt',
+]);
+const mockUsers = makeTableStub('users', ['id', 'timezone']);
 const mockPostMedia = makeTableStub('post_media', [
   'id', 'userId', 'postId', 'filePath', 'fileName', 'mimeType', 'fileSize', 'width', 'height',
   'thumbnailPath', 'sortOrder', 'transcodeStatus', 'transcodeError', 'deletedAt', 'createdAt',
@@ -33,6 +39,8 @@ vi.mock('@sms/db', () => ({
   tags: mockTags,
   postTags: mockPostTags,
   socialProfiles: mockSocialProfiles,
+  queues: mockQueues,
+  users: mockUsers,
   postMedia: mockPostMedia,
 }));
 
@@ -342,11 +350,50 @@ function createCheckConflictsMockDb(options: {
   } as any;
 }
 
+function createDashboardStatsMockDb(options: {
+  scheduled24Rows?: unknown[];
+  scheduledInRangeRows?: unknown[];
+  queuedCandidateRows?: unknown[];
+  failed24Rows?: unknown[];
+  failed7dCount?: number;
+}) {
+  const scheduled24Rows = options.scheduled24Rows ?? [];
+  const scheduledInRangeRows = options.scheduledInRangeRows ?? [];
+  const queuedCandidateRows = options.queuedCandidateRows ?? [];
+  const failed24Rows = options.failed24Rows ?? [];
+  const failed7dCount = options.failed7dCount ?? 0;
+  let selectCallIndex = 0;
+
+  function makeSelectChain(result: unknown[]) {
+    const chain: Record<string, any> = {};
+    chain.from = vi.fn().mockReturnValue(chain);
+    chain.where = vi.fn().mockReturnValue(chain);
+    chain.innerJoin = vi.fn().mockReturnValue(chain);
+    chain.orderBy = vi.fn().mockReturnValue(chain);
+    chain.limit = vi.fn().mockReturnValue(chain);
+    chain.then = (resolve: (v: unknown) => void) => resolve(result);
+    return chain;
+  }
+
+  return {
+    select: vi.fn().mockImplementation(() => {
+      selectCallIndex++;
+      if (selectCallIndex === 1) return makeSelectChain(scheduled24Rows);
+      if (selectCallIndex === 2) return makeSelectChain(scheduledInRangeRows);
+      if (selectCallIndex === 3) return makeSelectChain(queuedCandidateRows);
+      if (selectCallIndex === 4) return makeSelectChain(failed24Rows);
+      if (selectCallIndex === 5) return makeSelectChain([{ failed7dCount }]);
+      return makeSelectChain([]);
+    }),
+  } as any;
+}
+
 describe('post.service', () => {
   let createPost: typeof import('../../services/post.service.js').createPost;
   let updatePost: typeof import('../../services/post.service.js').updatePost;
   let deletePost: typeof import('../../services/post.service.js').deletePost;
   let getPosts: typeof import('../../services/post.service.js').getPosts;
+  let getDashboardPostStats: typeof import('../../services/post.service.js').getDashboardPostStats;
   let checkConflicts: typeof import('../../services/post.service.js').checkConflicts;
   let PostServiceError: typeof import('../../services/post.service.js').PostServiceError;
   let getPostById: typeof import('../../services/post.service.js').getPostById;
@@ -367,6 +414,7 @@ describe('post.service', () => {
     updatePost = mod.updatePost;
     deletePost = mod.deletePost;
     getPosts = mod.getPosts;
+    getDashboardPostStats = mod.getDashboardPostStats;
     checkConflicts = mod.checkConflicts;
     PostServiceError = mod.PostServiceError;
     getPostById = mod.getPostById;
@@ -904,6 +952,62 @@ describe('post.service', () => {
       await getPosts(db, 'user-1', { search: 'hello', searchScope: 'queue' });
 
       expect(db.select).toHaveBeenCalled();
+    });
+  });
+
+  describe('getDashboardPostStats', () => {
+    it('merges one-off scheduled posts with queued posts projected from active queues', async () => {
+      const now = new Date('2026-05-26T12:00:00.000Z');
+      const scheduledPost = {
+        id: 'scheduled-1',
+        userId: 'user-1',
+        profileId: 'profile-1',
+        text: 'One-off scheduled',
+        status: 'scheduled',
+        scheduledAt: new Date('2026-05-26T15:00:00.000Z'),
+        createdAt: now,
+        updatedAt: now,
+      };
+      const queuedPost = {
+        id: 'queued-1',
+        userId: 'user-1',
+        profileId: 'profile-1',
+        text: 'Queued import item',
+        status: 'queued',
+        scheduledAt: null,
+        queueId: 'queue-1',
+        queuePosition: 1,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const db = createDashboardStatsMockDb({
+        scheduled24Rows: [scheduledPost],
+        scheduledInRangeRows: [scheduledPost],
+        queuedCandidateRows: [{
+          post: queuedPost,
+          queue: {
+            id: 'queue-1',
+            intervalType: 'fixed',
+            intervalValue: 4,
+            intervalUnit: 'hours',
+            daysOfWeek: [0, 1, 2, 3, 4, 5, 6],
+            hourSlots: [14, 18],
+            startDate: null,
+            lastPublishedAt: null,
+            nextRunAt: new Date('2026-05-26T14:00:00.000Z'),
+          },
+          user: { timezone: 'UTC' },
+        }],
+      });
+
+      const result = await getDashboardPostStats(db, 'user-1', '24h', now);
+
+      expect(result.scheduled24Count).toBe(2);
+      expect(result.scheduled24.map((post) => post.id)).toEqual(['queued-1', 'scheduled-1']);
+      expect(result.scheduled24[0].status).toBe('queued');
+      expect(result.scheduled24[0].scheduledAt?.toISOString()).toBe('2026-05-26T14:00:00.000Z');
+      expect(result.scheduledInRange.map((post) => post.id)).toEqual(['queued-1', 'scheduled-1']);
+      expect(result.scheduledProfileCount).toBe(1);
     });
   });
 

--- a/packages/api/src/__tests__/services/post.test.ts
+++ b/packages/api/src/__tests__/services/post.test.ts
@@ -353,16 +353,19 @@ function createCheckConflictsMockDb(options: {
 function createDashboardStatsMockDb(options: {
   scheduled24Rows?: unknown[];
   scheduledInRangeRows?: unknown[];
-  queuedCandidateRows?: unknown[];
+  queuedDashboardQueueRows?: unknown[];
+  queuedPostRowsBySelect?: unknown[][];
   failed24Rows?: unknown[];
   failed7dCount?: number;
 }) {
   const scheduled24Rows = options.scheduled24Rows ?? [];
   const scheduledInRangeRows = options.scheduledInRangeRows ?? [];
-  const queuedCandidateRows = options.queuedCandidateRows ?? [];
+  const queuedDashboardQueueRows = options.queuedDashboardQueueRows ?? [];
+  const queuedPostRowsBySelect = [...(options.queuedPostRowsBySelect ?? [])];
   const failed24Rows = options.failed24Rows ?? [];
   const failed7dCount = options.failed7dCount ?? 0;
   let selectCallIndex = 0;
+  const chains: Array<Record<string, any>> = [];
 
   function makeSelectChain(result: unknown[]) {
     const chain: Record<string, any> = {};
@@ -372,6 +375,7 @@ function createDashboardStatsMockDb(options: {
     chain.orderBy = vi.fn().mockReturnValue(chain);
     chain.limit = vi.fn().mockReturnValue(chain);
     chain.then = (resolve: (v: unknown) => void) => resolve(result);
+    chains.push(chain);
     return chain;
   }
 
@@ -380,11 +384,13 @@ function createDashboardStatsMockDb(options: {
       selectCallIndex++;
       if (selectCallIndex === 1) return makeSelectChain(scheduled24Rows);
       if (selectCallIndex === 2) return makeSelectChain(scheduledInRangeRows);
-      if (selectCallIndex === 3) return makeSelectChain(queuedCandidateRows);
-      if (selectCallIndex === 4) return makeSelectChain(failed24Rows);
-      if (selectCallIndex === 5) return makeSelectChain([{ failed7dCount }]);
+      if (selectCallIndex === 3) return makeSelectChain(queuedDashboardQueueRows);
+      if (queuedPostRowsBySelect.length > 0) return makeSelectChain(queuedPostRowsBySelect.shift()!);
+      if (selectCallIndex === queuedDashboardQueueRows.length + 4) return makeSelectChain(failed24Rows);
+      if (selectCallIndex === queuedDashboardQueueRows.length + 5) return makeSelectChain([{ failed7dCount }]);
       return makeSelectChain([]);
     }),
+    _chains: chains,
   } as any;
 }
 
@@ -983,10 +989,10 @@ describe('post.service', () => {
       const db = createDashboardStatsMockDb({
         scheduled24Rows: [scheduledPost],
         scheduledInRangeRows: [scheduledPost],
-        queuedCandidateRows: [{
-          post: queuedPost,
+        queuedDashboardQueueRows: [{
           queue: {
             id: 'queue-1',
+            cursorPosition: 0,
             intervalType: 'fixed',
             intervalValue: 4,
             intervalUnit: 'hours',
@@ -998,6 +1004,7 @@ describe('post.service', () => {
           },
           user: { timezone: 'UTC' },
         }],
+        queuedPostRowsBySelect: [[queuedPost]],
       });
 
       const result = await getDashboardPostStats(db, 'user-1', '24h', now);
@@ -1008,6 +1015,7 @@ describe('post.service', () => {
       expect(result.scheduled24[0].scheduledAt?.toISOString()).toBe('2026-05-26T14:00:00.000Z');
       expect(result.scheduledInRange.map((post) => post.id)).toEqual(['queued-1', 'scheduled-1']);
       expect(result.scheduledProfileCount).toBe(1);
+      expect(db._chains[3].limit).toHaveBeenCalledWith(2);
     });
   });
 

--- a/packages/api/src/services/post-crud.service.ts
+++ b/packages/api/src/services/post-crud.service.ts
@@ -74,6 +74,8 @@ interface PostQuery {
 
 type DashboardWindowRange = '24h' | '7d' | '30d';
 type SerializedPostForList = ReturnType<typeof serializePostForList>;
+const DASHBOARD_UPCOMING_PREVIEW_LIMIT = 4;
+const DASHBOARD_MAX_QUEUED_SLOTS_PER_QUEUE = 24 * 60;
 
 type PostServiceErrorKind = 'profile_not_found' | 'tag_not_found';
 
@@ -152,10 +154,10 @@ function sortDashboardPosts(postsForDashboard: SerializedPostForList[]): Seriali
   });
 }
 
-type QueuedDashboardCandidate = {
-  post: typeof posts.$inferSelect;
+type QueuedDashboardQueue = {
   queue: {
     id: string;
+    cursorPosition: number;
     intervalType: string;
     intervalValue: number;
     intervalUnit: string;
@@ -174,54 +176,56 @@ function numberArray(value: unknown): number[] {
   return Array.isArray(value) ? value.filter((item): item is number => typeof item === 'number') : [];
 }
 
-function projectQueuedDashboardPosts(
-  candidates: QueuedDashboardCandidate[],
+function dashboardQueueSlots(
+  queue: QueuedDashboardQueue['queue'],
+  timezone: string,
+  next24End: Date,
   rangeEnd: Date,
-): SerializedPostForList[] {
-  const candidatesByQueueId = new Map<string, QueuedDashboardCandidate[]>();
-  for (const candidate of candidates) {
-    const queueId = candidate.queue.id;
-    const queueCandidates = candidatesByQueueId.get(queueId) ?? [];
-    queueCandidates.push(candidate);
-    candidatesByQueueId.set(queueId, queueCandidates);
-  }
-
-  const projectedPosts: SerializedPostForList[] = [];
+): Date[] {
+  const slots: Date[] = [];
+  let nextRunAt = queue.nextRunAt;
+  const next24EndTime = next24End.getTime();
   const rangeEndTime = rangeEnd.getTime();
 
-  for (const queueCandidates of candidatesByQueueId.values()) {
-    const firstCandidate = queueCandidates[0];
-    const queue = firstCandidate.queue;
-    const timezone = firstCandidate.user.timezone ?? 'UTC';
-    let nextRunAt = queue.nextRunAt;
+  while (
+    nextRunAt &&
+    nextRunAt.getTime() <= rangeEndTime &&
+    slots.length < DASHBOARD_MAX_QUEUED_SLOTS_PER_QUEUE &&
+    (nextRunAt.getTime() <= next24EndTime || slots.length < DASHBOARD_UPCOMING_PREVIEW_LIMIT)
+  ) {
+    slots.push(nextRunAt);
 
-    for (const candidate of queueCandidates) {
-      if (!nextRunAt || nextRunAt.getTime() > rangeEndTime) break;
-
-      projectedPosts.push(serializePostForList({
-        ...candidate.post,
-        scheduledAt: nextRunAt,
-      }));
-
-      const nextSlot = calculateNextRunAt(
-        {
-          intervalType: queue.intervalType,
-          intervalValue: queue.intervalValue,
-          intervalUnit: queue.intervalUnit,
-          hourSlots: numberArray(queue.hourSlots),
-          daysOfWeek: numberArray(queue.daysOfWeek),
-          lastPublishedAt: nextRunAt,
-          startDate: queue.startDate,
-        },
-        timezone,
-        DateTime.fromJSDate(nextRunAt).setZone(timezone),
-      );
-
-      nextRunAt = nextSlot?.toJSDate() ?? null;
+    const nextSlot = calculateNextRunAt(
+      {
+        intervalType: queue.intervalType,
+        intervalValue: queue.intervalValue,
+        intervalUnit: queue.intervalUnit,
+        hourSlots: numberArray(queue.hourSlots),
+        daysOfWeek: numberArray(queue.daysOfWeek),
+        lastPublishedAt: nextRunAt,
+        startDate: queue.startDate,
+      },
+      timezone,
+      DateTime.fromJSDate(nextRunAt).setZone(timezone),
+    );
+    const nextSlotDate = nextSlot?.toJSDate() ?? null;
+    if (nextSlotDate && nextSlotDate.getTime() <= nextRunAt.getTime()) {
+      break;
     }
+    nextRunAt = nextSlotDate;
   }
 
-  return projectedPosts;
+  return slots;
+}
+
+function projectQueuedDashboardPosts(
+  queuedPosts: Array<typeof posts.$inferSelect>,
+  slots: Date[],
+): SerializedPostForList[] {
+  return queuedPosts.slice(0, slots.length).map((post, index) => serializePostForList({
+    ...post,
+    scheduledAt: slots[index],
+  }));
 }
 
 function toPostAppError(err: PostInvariantError): AppError {
@@ -741,13 +745,13 @@ export async function getDashboardPostStats(
       sql`${posts.scheduledAt} <= ${rangeEndIso}::timestamptz`,
     ))
     .orderBy(sql`${posts.scheduledAt} ASC`)
-    .limit(4);
+    .limit(DASHBOARD_UPCOMING_PREVIEW_LIMIT);
 
-  const queuedCandidates = await db
+  const queuedDashboardQueues = await db
     .select({
-      post: posts,
       queue: {
         id: queues.id,
+        cursorPosition: queues.cursorPosition,
         intervalType: queues.intervalType,
         intervalValue: queues.intervalValue,
         intervalUnit: queues.intervalUnit,
@@ -761,24 +765,36 @@ export async function getDashboardPostStats(
         timezone: users.timezone,
       },
     })
-    .from(posts)
-    .innerJoin(queues, eq(posts.queueId, queues.id))
+    .from(queues)
     .innerJoin(users, eq(queues.userId, users.id))
     .where(and(
-      eq(posts.userId, userId),
-      eq(posts.status, 'queued'),
       eq(queues.userId, userId),
       eq(queues.isPaused, false),
       sql`${queues.nextRunAt} >= ${nowIso}::timestamptz`,
       sql`${queues.nextRunAt} <= ${rangeEndIso}::timestamptz`,
-      sql`${posts.queuePosition} > ${queues.cursorPosition}`,
     ))
-    .orderBy(sql`${queues.nextRunAt} ASC, ${queues.id} ASC, ${posts.queuePosition} ASC`);
+    .orderBy(sql`${queues.nextRunAt} ASC, ${queues.id} ASC`);
 
-  const queuedUpcoming = projectQueuedDashboardPosts(
-    queuedCandidates as QueuedDashboardCandidate[],
-    rangeEnd,
-  );
+  const queuedUpcoming: SerializedPostForList[] = [];
+  for (const queueRow of queuedDashboardQueues as QueuedDashboardQueue[]) {
+    const timezone = queueRow.user.timezone ?? 'UTC';
+    const slots = dashboardQueueSlots(queueRow.queue, timezone, next24End, rangeEnd);
+    if (slots.length === 0) continue;
+
+    const queuedPosts = await db
+      .select()
+      .from(posts)
+      .where(and(
+        eq(posts.userId, userId),
+        eq(posts.status, 'queued'),
+        eq(posts.queueId, queueRow.queue.id),
+        sql`${posts.queuePosition} > ${queueRow.queue.cursorPosition}`,
+      ))
+      .orderBy(sql`${posts.queuePosition} ASC`)
+      .limit(slots.length);
+
+    queuedUpcoming.push(...projectQueuedDashboardPosts(queuedPosts, slots));
+  }
   const queued24 = queuedUpcoming.filter((post) => {
     const scheduledAt = post.scheduledAt?.getTime();
     return scheduledAt !== undefined && scheduledAt >= now.getTime() && scheduledAt <= next24End.getTime();
@@ -791,7 +807,7 @@ export async function getDashboardPostStats(
   const scheduledInRange = sortDashboardPosts([
     ...scheduledInRangeRows.map(serializePostForList),
     ...queuedUpcoming,
-  ]).slice(0, 4);
+  ]).slice(0, DASHBOARD_UPCOMING_PREVIEW_LIMIT);
 
   const failed24Rows = await db
     .select()

--- a/packages/api/src/services/post-crud.service.ts
+++ b/packages/api/src/services/post-crud.service.ts
@@ -1,9 +1,10 @@
+import { DateTime } from 'luxon';
 import { eq, and, sql, inArray, gte, lte, ne, count as drizzleCount, isNull, type SQL } from 'drizzle-orm';
-import { AppError, DELETABLE_STATES, PostInvariantError, planDelete, planUpdate } from '@sms/shared';
+import { AppError, calculateNextRunAt, DELETABLE_STATES, PostInvariantError, planDelete, planUpdate } from '@sms/shared';
 import { createLogger } from '@sms/shared/logger';
 import type { PostStatus } from '@sms/shared';
 import type { Db } from '@sms/db';
-import { posts, postTags, tags, socialProfiles, postMedia } from '@sms/db';
+import { posts, postTags, tags, socialProfiles, postMedia, queues, users } from '@sms/db';
 
 import { softDeleteMediaForPost, associateMediaToPost } from './media.service.js';
 
@@ -72,6 +73,7 @@ interface PostQuery {
 }
 
 type DashboardWindowRange = '24h' | '7d' | '30d';
+type SerializedPostForList = ReturnType<typeof serializePostForList>;
 
 type PostServiceErrorKind = 'profile_not_found' | 'tag_not_found';
 
@@ -140,6 +142,86 @@ function serializePostForList(post: typeof posts.$inferSelect) {
     ...post,
     tags: [],
   };
+}
+
+function sortDashboardPosts(postsForDashboard: SerializedPostForList[]): SerializedPostForList[] {
+  return [...postsForDashboard].sort((a, b) => {
+    const aTime = a.scheduledAt?.getTime() ?? Number.POSITIVE_INFINITY;
+    const bTime = b.scheduledAt?.getTime() ?? Number.POSITIVE_INFINITY;
+    return aTime - bTime;
+  });
+}
+
+type QueuedDashboardCandidate = {
+  post: typeof posts.$inferSelect;
+  queue: {
+    id: string;
+    intervalType: string;
+    intervalValue: number;
+    intervalUnit: string;
+    daysOfWeek: unknown;
+    hourSlots: unknown;
+    startDate: Date | null;
+    lastPublishedAt: Date | null;
+    nextRunAt: Date | null;
+  };
+  user: {
+    timezone: string | null;
+  };
+};
+
+function numberArray(value: unknown): number[] {
+  return Array.isArray(value) ? value.filter((item): item is number => typeof item === 'number') : [];
+}
+
+function projectQueuedDashboardPosts(
+  candidates: QueuedDashboardCandidate[],
+  rangeEnd: Date,
+): SerializedPostForList[] {
+  const candidatesByQueueId = new Map<string, QueuedDashboardCandidate[]>();
+  for (const candidate of candidates) {
+    const queueId = candidate.queue.id;
+    const queueCandidates = candidatesByQueueId.get(queueId) ?? [];
+    queueCandidates.push(candidate);
+    candidatesByQueueId.set(queueId, queueCandidates);
+  }
+
+  const projectedPosts: SerializedPostForList[] = [];
+  const rangeEndTime = rangeEnd.getTime();
+
+  for (const queueCandidates of candidatesByQueueId.values()) {
+    const firstCandidate = queueCandidates[0];
+    const queue = firstCandidate.queue;
+    const timezone = firstCandidate.user.timezone ?? 'UTC';
+    let nextRunAt = queue.nextRunAt;
+
+    for (const candidate of queueCandidates) {
+      if (!nextRunAt || nextRunAt.getTime() > rangeEndTime) break;
+
+      projectedPosts.push(serializePostForList({
+        ...candidate.post,
+        scheduledAt: nextRunAt,
+      }));
+
+      const nextSlot = calculateNextRunAt(
+        {
+          intervalType: queue.intervalType,
+          intervalValue: queue.intervalValue,
+          intervalUnit: queue.intervalUnit,
+          hourSlots: numberArray(queue.hourSlots),
+          daysOfWeek: numberArray(queue.daysOfWeek),
+          lastPublishedAt: nextRunAt,
+          startDate: queue.startDate,
+        },
+        timezone,
+        DateTime.fromJSDate(nextRunAt).setZone(timezone),
+      );
+
+      nextRunAt = nextSlot?.toJSDate() ?? null;
+    }
+  }
+
+  return projectedPosts;
 }
 
 function toPostAppError(err: PostInvariantError): AppError {
@@ -649,16 +731,6 @@ export async function getDashboardPostStats(
     ))
     .orderBy(sql`${posts.scheduledAt} ASC`);
 
-  const [{ scheduled24Count = 0 } = { scheduled24Count: 0 }] = await db
-    .select({ scheduled24Count: drizzleCount() })
-    .from(posts)
-    .where(and(
-      eq(posts.userId, userId),
-      eq(posts.status, 'scheduled'),
-      sql`${posts.scheduledAt} >= ${nowIso}::timestamptz`,
-      sql`${posts.scheduledAt} <= ${next24EndIso}::timestamptz`,
-    ));
-
   const scheduledInRangeRows = await db
     .select()
     .from(posts)
@@ -670,6 +742,56 @@ export async function getDashboardPostStats(
     ))
     .orderBy(sql`${posts.scheduledAt} ASC`)
     .limit(4);
+
+  const queuedCandidates = await db
+    .select({
+      post: posts,
+      queue: {
+        id: queues.id,
+        intervalType: queues.intervalType,
+        intervalValue: queues.intervalValue,
+        intervalUnit: queues.intervalUnit,
+        daysOfWeek: queues.daysOfWeek,
+        hourSlots: queues.hourSlots,
+        startDate: queues.startDate,
+        lastPublishedAt: queues.lastPublishedAt,
+        nextRunAt: queues.nextRunAt,
+      },
+      user: {
+        timezone: users.timezone,
+      },
+    })
+    .from(posts)
+    .innerJoin(queues, eq(posts.queueId, queues.id))
+    .innerJoin(users, eq(queues.userId, users.id))
+    .where(and(
+      eq(posts.userId, userId),
+      eq(posts.status, 'queued'),
+      eq(queues.userId, userId),
+      eq(queues.isPaused, false),
+      sql`${queues.nextRunAt} >= ${nowIso}::timestamptz`,
+      sql`${queues.nextRunAt} <= ${rangeEndIso}::timestamptz`,
+      sql`${posts.queuePosition} > ${queues.cursorPosition}`,
+    ))
+    .orderBy(sql`${queues.nextRunAt} ASC, ${queues.id} ASC, ${posts.queuePosition} ASC`);
+
+  const queuedUpcoming = projectQueuedDashboardPosts(
+    queuedCandidates as QueuedDashboardCandidate[],
+    rangeEnd,
+  );
+  const queued24 = queuedUpcoming.filter((post) => {
+    const scheduledAt = post.scheduledAt?.getTime();
+    return scheduledAt !== undefined && scheduledAt >= now.getTime() && scheduledAt <= next24End.getTime();
+  });
+
+  const scheduled24 = sortDashboardPosts([
+    ...scheduled24Rows.map(serializePostForList),
+    ...queued24,
+  ]);
+  const scheduledInRange = sortDashboardPosts([
+    ...scheduledInRangeRows.map(serializePostForList),
+    ...queuedUpcoming,
+  ]).slice(0, 4);
 
   const failed24Rows = await db
     .select()
@@ -693,12 +815,12 @@ export async function getDashboardPostStats(
     ));
 
   return {
-    scheduled24Count: Number(scheduled24Count),
-    scheduled24: scheduled24Rows.map(serializePostForList),
-    scheduledInRange: scheduledInRangeRows.map(serializePostForList),
+    scheduled24Count: scheduled24.length,
+    scheduled24,
+    scheduledInRange,
     failed24: failed24Rows.map(serializePostForList),
     failed7dCount: Number(failed7dCount),
-    scheduledProfileCount: new Set(scheduled24Rows.map((post) => post.profileId).filter(Boolean)).size,
+    scheduledProfileCount: new Set(scheduled24.map((post) => post.profileId).filter(Boolean)).size,
   };
 }
 

--- a/packages/web/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/web/src/pages/dashboard/DashboardPage.tsx
@@ -144,24 +144,24 @@ function DashboardSkeleton() {
 }
 
 function Timeline({
-  scheduledPosts,
+  upcomingPosts,
   failedPosts,
   now,
 }: {
-  scheduledPosts: Post[];
+  upcomingPosts: Post[];
   failedPosts: Post[];
   now: Date;
 }) {
   const currentHour = now.getHours();
   const markerLeft = ((currentHour + now.getMinutes() / 60) / 24) * 100;
 
-  const scheduledByHour = new Map<number, number>();
+  const upcomingByHour = new Map<number, number>();
   const failedByHour = new Map<number, number>();
 
-  scheduledPosts.forEach((post) => {
+  upcomingPosts.forEach((post) => {
     const date = toDate(post.scheduledAt);
     if (date && date.toDateString() === now.toDateString()) {
-      scheduledByHour.set(date.getHours(), (scheduledByHour.get(date.getHours()) ?? 0) + 1);
+      upcomingByHour.set(date.getHours(), (upcomingByHour.get(date.getHours()) ?? 0) + 1);
     }
   });
 
@@ -188,10 +188,10 @@ function Timeline({
         </div>
         <div className="grid h-20 grid-cols-[repeat(24,minmax(0,1fr))] gap-px overflow-hidden rounded-md border border-border bg-border">
           {Array.from({ length: 24 }, (_, hour) => {
-            const scheduledCount = scheduledByHour.get(hour) ?? 0;
+            const upcomingCount = upcomingByHour.get(hour) ?? 0;
             const failedCount = failedByHour.get(hour) ?? 0;
             const isPast = hour < currentHour;
-            const title = `${format(new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour), "HH:00")} · ${scheduledCount} scheduled · ${failedCount} failed`;
+            const title = `${format(new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour), "HH:00")} · ${upcomingCount} upcoming · ${failedCount} failed`;
 
             return (
               <button
@@ -201,7 +201,7 @@ function Timeline({
                 aria-label={title}
                 className={cn(
                   "h-full min-w-0 bg-[var(--bg-elevated)] transition-opacity focus-visible:z-20 focus-visible:outline-none focus-visible:shadow-[var(--shadow-focus)]",
-                  scheduledCount > 0 && "bg-[var(--brand-accent)]",
+                  upcomingCount > 0 && "bg-[var(--brand-accent)]",
                   failedCount > 0 &&
                     "bg-[repeating-linear-gradient(135deg,var(--status-danger)_0,var(--status-danger)_4px,var(--status-danger-soft)_4px,var(--status-danger-soft)_8px)]",
                   isPast && "opacity-40",
@@ -217,7 +217,7 @@ function Timeline({
         ))}
       </div>
       <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
-        <LegendSwatch className="bg-[var(--brand-accent)]" label="Scheduled" />
+        <LegendSwatch className="bg-[var(--brand-accent)]" label="Upcoming" />
         <LegendSwatch
           className="bg-[repeating-linear-gradient(135deg,var(--status-danger)_0,var(--status-danger)_4px,var(--status-danger-soft)_4px,var(--status-danger-soft)_8px)]"
           label="Failed"
@@ -249,14 +249,16 @@ function LegendSwatch({
 function UpcomingPosts({
   posts,
   profiles,
+  now,
 }: {
   posts: Post[];
   profiles: SocialProfile[];
+  now: Date;
 }) {
   if (posts.length === 0) {
     return (
       <div className="rounded-md border border-dashed border-input px-4 py-5 text-center text-sm text-muted-foreground">
-        No posts scheduled in this window.
+        No posts queued or scheduled in this window.
       </div>
     );
   }
@@ -265,20 +267,21 @@ function UpcomingPosts({
     <div className="divide-y divide-border">
       {posts.slice(0, 4).map((post) => {
         const scheduledAt = toDate(post.scheduledAt);
+        const isToday = scheduledAt?.toDateString() === now.toDateString();
         return (
           <Link
             key={post.id}
             to={`/posts/${post.id}/edit`}
-            className="grid grid-cols-[54px_minmax(0,1fr)_auto] items-center gap-3 py-3 text-sm transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:shadow-[var(--shadow-focus)]"
+            className="grid grid-cols-[86px_minmax(0,1fr)_auto] items-center gap-3 py-3 text-sm transition-colors hover:bg-[var(--bg-hover)] focus-visible:outline-none focus-visible:shadow-[var(--shadow-focus)]"
           >
             <span className="text-xs font-medium text-muted-foreground">
-              {scheduledAt ? format(scheduledAt, "HH:mm") : "--:--"}
+              {scheduledAt ? format(scheduledAt, isToday ? "HH:mm" : "MMM d, HH:mm") : "--:--"}
             </span>
             <span className="flex min-w-0 items-center gap-2">
               <PlatformGlyph platform={postPlatform(post, profiles)} size={14} />
               <span className="truncate text-foreground">{postTitle(post)}</span>
             </span>
-            <StatusPill status="scheduled" />
+            <StatusPill status={post.status === "queued" ? "queued" : "scheduled"} />
           </Link>
         );
       })}
@@ -456,9 +459,9 @@ export default function DashboardPage() {
   const profiles = profilesQuery.data ?? [];
   const rateRows = (rateLimitsQuery.data ?? []) as RateLimitRow[];
 
-  const scheduled24 = postStatsQuery.data?.scheduled24 ?? [];
-  const scheduled24Count = postStatsQuery.data?.scheduled24Count ?? 0;
-  const scheduledInRange = postStatsQuery.data?.scheduledInRange ?? [];
+  const upcoming24 = postStatsQuery.data?.scheduled24 ?? [];
+  const upcoming24Count = postStatsQuery.data?.scheduled24Count ?? 0;
+  const upcomingInRange = postStatsQuery.data?.scheduledInRange ?? [];
   const failed24 = postStatsQuery.data?.failed24 ?? [];
   const failed7dCount = postStatsQuery.data?.failed7dCount ?? 0;
   const activeQueues = queues.filter((queue) => !queue.isPaused);
@@ -504,8 +507,8 @@ export default function DashboardPage() {
 
       <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         <StatCard
-          title="Scheduled (24h)"
-          value={String(scheduled24Count)}
+          title="Upcoming (24h)"
+          value={String(upcoming24Count)}
           meta={`Across ${scheduledProfileCount} profile${scheduledProfileCount === 1 ? "" : "s"}`}
           tone="info"
           icon={Info}
@@ -539,7 +542,7 @@ export default function DashboardPage() {
 
       <section className="mt-6 grid gap-6 xl:grid-cols-[2fr_1fr]">
         <Card
-          title="Next 24 hours"
+          title="Upcoming schedule"
           action={
             <Segmented
               label="Schedule window"
@@ -554,7 +557,7 @@ export default function DashboardPage() {
           ) : (
             <div className="space-y-6">
               <Timeline
-                scheduledPosts={scheduled24}
+                upcomingPosts={upcoming24}
                 failedPosts={failed24}
                 now={now}
               />
@@ -569,7 +572,7 @@ export default function DashboardPage() {
                         : "Next 30d"}
                   </Pill>
                 </div>
-                <UpcomingPosts posts={scheduledInRange} profiles={profiles} />
+                <UpcomingPosts posts={upcomingInRange} profiles={profiles} now={now} />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary

Fixes the dashboard upcoming-window view so imported queue posts are included alongside one-off scheduled posts.

## What changed

- Project queued posts into dashboard windows from active queue cadence and `nextRunAt`.
- Merge projected queued posts with one-off scheduled posts for the 24h count, timeline, and selected 24h/7d/30d upcoming lists.
- Show queued items with a `Queued` pill and update dashboard copy from scheduled-only language to upcoming language.
- Add dates for non-today upcoming rows so 7d/30d windows are readable.
- Add service coverage for merging one-off scheduled posts with projected queued posts.

## Root cause

The dashboard stats endpoint only queried posts with `status = 'scheduled'`. Imported queue posts use `status = 'queued'` and inherit timing from their queue, so they had no `scheduledAt` row value for the dashboard windows to find.

## Validation

- `pnpm --filter @sms/api exec vitest run src/__tests__/services/post.test.ts`
- `pnpm --filter @sms/api typecheck`
- `pnpm --filter @sms/web typecheck`
- Browser validation against this branch's Vite app with fixture API data for 24h, 7d, and 30d dashboard windows.