### PR TITLE
[codex] Allow editing queued posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "pnpm -r build",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "pnpm --filter @sms/shared build && pnpm --filter @sms/db build && pnpm -r typecheck",
     "pretest": "pnpm -r build",
     "test": "pnpm -r test -- --run",
     "clawpatch:import-gh": "node scripts/import-github-issues-to-clawpatch.mjs",

--- a/packages/api/src/__tests__/services/post-state-machine.test.ts
+++ b/packages/api/src/__tests__/services/post-state-machine.test.ts
@@ -80,10 +80,11 @@ describe('post state machine', () => {
   });
 
   describe('EDITABLE_STATES', () => {
-    it('includes draft, scheduled, queued, failed', () => {
+    it('includes draft, scheduled, queued, paused, failed', () => {
       expect(EDITABLE_STATES).toContain('draft');
       expect(EDITABLE_STATES).toContain('scheduled');
       expect(EDITABLE_STATES).toContain('queued');
+      expect(EDITABLE_STATES).toContain('paused');
       expect(EDITABLE_STATES).toContain('failed');
     });
 

--- a/packages/api/src/__tests__/services/post-state-machine.test.ts
+++ b/packages/api/src/__tests__/services/post-state-machine.test.ts
@@ -80,9 +80,10 @@ describe('post state machine', () => {
   });
 
   describe('EDITABLE_STATES', () => {
-    it('includes draft, scheduled, failed', () => {
+    it('includes draft, scheduled, queued, failed', () => {
       expect(EDITABLE_STATES).toContain('draft');
       expect(EDITABLE_STATES).toContain('scheduled');
+      expect(EDITABLE_STATES).toContain('queued');
       expect(EDITABLE_STATES).toContain('failed');
     });
 

--- a/packages/api/src/__tests__/services/post.test.ts
+++ b/packages/api/src/__tests__/services/post.test.ts
@@ -46,13 +46,14 @@ const mockCreateLogger = vi.fn().mockReturnValue({
 vi.mock('@sms/shared', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sms/shared')>();
 
-  const EDITABLE: readonly string[] = ['draft', 'scheduled', 'queued', 'failed'];
-  const DELETABLE: readonly string[] = ['draft', 'scheduled', 'published', 'failed'];
+  const EDITABLE: readonly string[] = ['draft', 'scheduled', 'queued', 'paused', 'failed'];
+  const DELETABLE: readonly string[] = ['draft', 'scheduled', 'paused', 'published', 'failed'];
 
   const POST_STATE_TRANSITIONS: Record<string, readonly string[]> = {
     draft: ['scheduled', 'queued', 'publishing'],
-    scheduled: ['draft', 'queued', 'publishing'],
+    scheduled: ['draft', 'queued', 'publishing', 'paused'],
     queued: ['draft', 'publishing'],
+    paused: ['scheduled', 'draft'],
     publishing: ['published', 'failed'],
     published: ['queued', 'auto_destructing'],
     failed: ['draft', 'scheduled'],

--- a/packages/api/src/__tests__/services/post.test.ts
+++ b/packages/api/src/__tests__/services/post.test.ts
@@ -705,6 +705,31 @@ describe('post.service', () => {
       expect(setCall.scheduledAt).toBeUndefined();
     });
 
+    it('moves queued posts back to draft when requested', async () => {
+      const updatedPost = {
+        id: 'post-1', userId: 'user-1', profileId: 'profile-1',
+        text: 'queued text', status: 'draft', postVersion: 2,
+        isThread: false, scheduledAt: null, hasSpinnableText: false,
+        autoDestructAfter: null, notes: null,
+        createdAt: new Date(), updatedAt: new Date(),
+      };
+
+      const db = createPostUpdateMockDb({
+        updateResult: [updatedPost],
+        existingPost: { id: 'post-1', status: 'queued', postVersion: 1, scheduledAt: null },
+      });
+
+      await updatePost(db, 'user-1', 'post-1', {
+        status: 'draft',
+        scheduledAt: null,
+        postVersion: 1,
+      });
+
+      const setCall = db._updateChain.set.mock.calls[0][0];
+      expect(setCall.status).toBe('draft');
+      expect(setCall.scheduledAt).toBeNull();
+    });
+
     it('clears old associations and calls associateMediaToPost when mediaIds provided', async () => {
       const db = createPostUpdateMockDb({
         updateResult: [{ id: 'post-1' }],

--- a/packages/api/src/__tests__/services/post.test.ts
+++ b/packages/api/src/__tests__/services/post.test.ts
@@ -46,15 +46,15 @@ const mockCreateLogger = vi.fn().mockReturnValue({
 vi.mock('@sms/shared', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@sms/shared')>();
 
-  const EDITABLE: readonly string[] = ['draft', 'scheduled', 'failed'];
+  const EDITABLE: readonly string[] = ['draft', 'scheduled', 'queued', 'failed'];
   const DELETABLE: readonly string[] = ['draft', 'scheduled', 'published', 'failed'];
 
   const POST_STATE_TRANSITIONS: Record<string, readonly string[]> = {
-    draft: ['scheduled', 'publishing'],
+    draft: ['scheduled', 'queued', 'publishing'],
     scheduled: ['draft', 'queued', 'publishing'],
-    queued: ['publishing'],
+    queued: ['draft', 'publishing'],
     publishing: ['published', 'failed'],
-    published: ['auto_destructing'],
+    published: ['queued', 'auto_destructing'],
     failed: ['draft', 'scheduled'],
     auto_destructing: ['destroyed'],
     destroyed: [],
@@ -678,6 +678,31 @@ describe('post.service', () => {
       const setCall = db._updateChain.set.mock.calls[0][0];
       expect(setCall.text).toBe('new text');
       expect(setCall.notes).toBe('a note');
+    });
+
+    it('updates queued posts without changing their queue status', async () => {
+      const updatedPost = {
+        id: 'post-1', userId: 'user-1', profileId: 'profile-1',
+        text: 'typo fixed', status: 'queued', postVersion: 2,
+        isThread: false, scheduledAt: null, hasSpinnableText: false,
+        autoDestructAfter: null, notes: null,
+        createdAt: new Date(), updatedAt: new Date(),
+      };
+
+      const db = createPostUpdateMockDb({
+        updateResult: [updatedPost],
+        existingPost: { id: 'post-1', status: 'queued', postVersion: 1, scheduledAt: null },
+      });
+
+      await updatePost(db, 'user-1', 'post-1', {
+        text: 'typo fixed',
+        postVersion: 1,
+      });
+
+      const setCall = db._updateChain.set.mock.calls[0][0];
+      expect(setCall.text).toBe('typo fixed');
+      expect(setCall.status).toBeUndefined();
+      expect(setCall.scheduledAt).toBeUndefined();
     });
 
     it('clears old associations and calls associateMediaToPost when mediaIds provided', async () => {

--- a/packages/shared/src/__tests__/post-aggregate.test.ts
+++ b/packages/shared/src/__tests__/post-aggregate.test.ts
@@ -209,6 +209,32 @@ describe('planUpdate', () => {
     expect(patch).toMatchObject({ bumpVersion: true, text: 'typo fix' });
     expect(patch).not.toHaveProperty('scheduledAt');
   });
+
+  it('allows editing a queued post without changing queue status', () => {
+    const patch = planUpdate(
+      { ...baseState, status: 'queued' },
+      { text: 'typo fix', postVersion: 1 },
+      1,
+    );
+
+    expect(patch).toMatchObject({ bumpVersion: true, text: 'typo fix' });
+    expect(patch).not.toHaveProperty('status');
+    expect(patch).not.toHaveProperty('scheduledAt');
+  });
+
+  it('allows moving a queued post back to draft', () => {
+    expect(
+      planUpdate(
+        { ...baseState, status: 'queued' },
+        { status: 'draft', scheduledAt: null, postVersion: 1 },
+        1,
+      ),
+    ).toMatchObject({
+      bumpVersion: true,
+      status: 'draft',
+      scheduledAt: null,
+    });
+  });
 });
 
 describe('planTransitionToPublishing', () => {

--- a/packages/shared/src/__tests__/post-states.test.ts
+++ b/packages/shared/src/__tests__/post-states.test.ts
@@ -68,23 +68,23 @@ describe('post state machine', () => {
   });
 
   describe('EDITABLE_STATES contains correct values', () => {
-    it('includes draft, scheduled, paused, failed', () => {
+    it('includes draft, scheduled, queued, paused, failed', () => {
       expect(EDITABLE_STATES).toContain('draft');
       expect(EDITABLE_STATES).toContain('scheduled');
+      expect(EDITABLE_STATES).toContain('queued');
       expect(EDITABLE_STATES).toContain('paused');
       expect(EDITABLE_STATES).toContain('failed');
     });
 
-    it('excludes queued, publishing, published, auto_destructing, destroyed', () => {
-      expect(EDITABLE_STATES).not.toContain('queued');
+    it('excludes publishing, published, auto_destructing, destroyed', () => {
       expect(EDITABLE_STATES).not.toContain('publishing');
       expect(EDITABLE_STATES).not.toContain('published');
       expect(EDITABLE_STATES).not.toContain('auto_destructing');
       expect(EDITABLE_STATES).not.toContain('destroyed');
     });
 
-    it('has exactly 4 states', () => {
-      expect(EDITABLE_STATES).toHaveLength(4);
+    it('has exactly 5 states', () => {
+      expect(EDITABLE_STATES).toHaveLength(5);
     });
   });
 

--- a/packages/shared/src/constants/post-states.ts
+++ b/packages/shared/src/constants/post-states.ts
@@ -49,5 +49,5 @@ export function transitionPost(currentStatus: PostStatus, targetStatus: PostStat
   return targetStatus;
 }
 
-export const EDITABLE_STATES: readonly PostStatus[] = ['draft', 'scheduled', 'paused', 'failed'];
+export const EDITABLE_STATES: readonly PostStatus[] = ['draft', 'scheduled', 'queued', 'paused', 'failed'];
 export const DELETABLE_STATES: readonly PostStatus[] = ['draft', 'scheduled', 'paused', 'published', 'failed'];

--- a/packages/web/src/components/posts/SplitButton.tsx
+++ b/packages/web/src/components/posts/SplitButton.tsx
@@ -11,7 +11,7 @@ interface SplitButtonProps {
   onSchedule: () => void;
   onDraft: () => void;
   onPublishNow?: () => void;
-  scheduleLabel?: string;
+  primaryLabel?: string;
   isLoading: boolean;
   disabled: boolean;
 }
@@ -20,7 +20,7 @@ export function SplitButton({
   onSchedule,
   onDraft,
   onPublishNow,
-  scheduleLabel = 'Schedule Post',
+  primaryLabel = 'Schedule Post',
   isLoading,
   disabled,
 }: SplitButtonProps) {
@@ -32,7 +32,7 @@ export function SplitButton({
         className="rounded-r-none"
       >
         {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-        {scheduleLabel}
+        {primaryLabel}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/packages/web/src/components/posts/SplitButton.tsx
+++ b/packages/web/src/components/posts/SplitButton.tsx
@@ -11,6 +11,7 @@ interface SplitButtonProps {
   onSchedule: () => void;
   onDraft: () => void;
   onPublishNow?: () => void;
+  scheduleLabel?: string;
   isLoading: boolean;
   disabled: boolean;
 }
@@ -19,6 +20,7 @@ export function SplitButton({
   onSchedule,
   onDraft,
   onPublishNow,
+  scheduleLabel = 'Schedule Post',
   isLoading,
   disabled,
 }: SplitButtonProps) {
@@ -30,7 +32,7 @@ export function SplitButton({
         className="rounded-r-none"
       >
         {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-        Schedule Post
+        {scheduleLabel}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/packages/web/src/components/posts/SplitButton.tsx
+++ b/packages/web/src/components/posts/SplitButton.tsx
@@ -39,7 +39,7 @@ export function SplitButton({
           <Button
             disabled={disabled || isLoading}
             className="rounded-l-none border-l border-primary-foreground/20 px-2"
-            aria-label="More scheduling options"
+            aria-label="More options"
           >
             <ChevronDown className="h-4 w-4" />
           </Button>

--- a/packages/web/src/components/posts/SplitButton.tsx
+++ b/packages/web/src/components/posts/SplitButton.tsx
@@ -8,7 +8,7 @@ import {
 } from '../ui/dropdown-menu';
 
 interface SplitButtonProps {
-  onSchedule: () => void;
+  onPrimary: () => void;
   onDraft: () => void;
   onPublishNow?: () => void;
   primaryLabel?: string;
@@ -17,7 +17,7 @@ interface SplitButtonProps {
 }
 
 export function SplitButton({
-  onSchedule,
+  onPrimary,
   onDraft,
   onPublishNow,
   primaryLabel = 'Schedule Post',
@@ -27,7 +27,7 @@ export function SplitButton({
   return (
     <div className="flex">
       <Button
-        onClick={onSchedule}
+        onClick={onPrimary}
         disabled={disabled || isLoading}
         className="rounded-r-none"
       >

--- a/packages/web/src/components/posts/__tests__/SplitButton.test.tsx
+++ b/packages/web/src/components/posts/__tests__/SplitButton.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SplitButton } from '../SplitButton';
+
+describe('SplitButton', () => {
+  it('renders a custom primary action label', () => {
+    render(
+      <SplitButton
+        onPrimary={vi.fn()}
+        onDraft={vi.fn()}
+        primaryLabel="Update Queued Post"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Update Queued Post' })).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/posts/__tests__/SplitButton.test.tsx
+++ b/packages/web/src/components/posts/__tests__/SplitButton.test.tsx
@@ -9,6 +9,8 @@ describe('SplitButton', () => {
         onPrimary={vi.fn()}
         onDraft={vi.fn()}
         primaryLabel="Update Queued Post"
+        isLoading={false}
+        disabled={false}
       />,
     );
 

--- a/packages/web/src/components/posts/__tests__/SplitButton.test.tsx
+++ b/packages/web/src/components/posts/__tests__/SplitButton.test.tsx
@@ -15,5 +15,6 @@ describe('SplitButton', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Update Queued Post' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'More options' })).toBeInTheDocument();
   });
 });

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -418,24 +418,28 @@ export default function EditPostPage() {
     }
   }
 
-  function buildUpdatePayload(action: 'schedule' | 'draft', text: string) {
-    const status = action === 'draft' ? ('draft' as const) : ('scheduled' as const);
-    const scheduledAt = action === 'schedule' ? formState.scheduledAt : null;
+  function buildUpdatePayload(action: 'schedule' | 'draft' | 'keepQueued', text: string) {
     const base = {
       text,
-      status,
-      scheduledAt,
       hasSpinnableText: formState.hasSpinnableText,
       autoDestructAfter: formState.autoDestructAfter,
       notes: formState.notes || null,
       tagIds: formState.tagIds,
       mediaIds: mediaItems.map((m) => m.id),
     };
+    const statusFields =
+      action === 'keepQueued'
+        ? {}
+        : {
+            status: action === 'draft' ? ('draft' as const) : ('scheduled' as const),
+            scheduledAt: action === 'schedule' ? formState.scheduledAt : null,
+          };
 
     if (formState.platform === 'twitter') {
       return {
         platform: 'twitter' as const,
         ...base,
+        ...statusFields,
         isThread: formState.isThread,
       };
     }
@@ -443,17 +447,19 @@ export default function EditPostPage() {
       return {
         platform: 'linkedin' as const,
         ...base,
+        ...statusFields,
         visibility: formState.visibility,
       };
     }
     return {
       platform: 'facebook' as const,
       ...base,
+      ...statusFields,
       linkUrl: formState.linkUrl ? formState.linkUrl : null,
     };
   }
 
-  function handleSubmit(action: 'schedule' | 'draft') {
+  function handleSubmit(action: 'schedule' | 'draft' | 'keepQueued') {
     const text = formState.isThread ? serializeThread(tweets) : formState.text;
 
     if (!text.trim() && mediaItems.length === 0 && !(formState.platform === 'facebook' && formState.linkUrl)) {
@@ -533,6 +539,7 @@ export default function EditPostPage() {
     .filter((m) => m.mimeType.startsWith('image/'))
     .map((m) => m.thumbnailUrl ?? '');
   const previewVideoUrl = mediaItems.find((m) => m.mimeType.startsWith('video/'))?.thumbnailUrl ?? null;
+  const primaryAction = post.status === 'queued' ? 'keepQueued' : 'schedule';
 
   return (
     <main className="px-4 py-6 sm:px-6 lg:px-8">
@@ -674,8 +681,9 @@ export default function EditPostPage() {
 
             const submitContent = (
               <SplitButton
-                onSchedule={() => handleSubmit('schedule')}
+                onSchedule={() => handleSubmit(primaryAction)}
                 onDraft={() => handleSubmit('draft')}
+                scheduleLabel={post.status === 'queued' ? 'Update Queued Post' : 'Schedule Post'}
                 isLoading={updatePostMutation.isPending}
                 disabled={scheduleDisabled}
               />

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -540,6 +540,7 @@ export default function EditPostPage() {
     .map((m) => m.thumbnailUrl ?? '');
   const previewVideoUrl = mediaItems.find((m) => m.mimeType.startsWith('video/'))?.thumbnailUrl ?? null;
   const primaryAction = post.status === 'queued' ? 'keepQueued' : 'schedule';
+  const primaryLabel = primaryAction === 'keepQueued' ? 'Update Queued Post' : 'Schedule Post';
 
   return (
     <main className="px-4 py-6 sm:px-6 lg:px-8">
@@ -681,9 +682,9 @@ export default function EditPostPage() {
 
             const submitContent = (
               <SplitButton
-                onSchedule={() => handleSubmit(primaryAction)}
+                onPrimary={() => handleSubmit(primaryAction)}
                 onDraft={() => handleSubmit('draft')}
-                primaryLabel={post.status === 'queued' ? 'Update Queued Post' : 'Schedule Post'}
+                primaryLabel={primaryLabel}
                 isLoading={updatePostMutation.isPending}
                 disabled={scheduleDisabled}
               />

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -652,7 +652,7 @@ export default function EditPostPage() {
 
           {/* SHARED POST-CMN BLOCK (B-03) — every common control lives here */}
           <SharedPostFields
-            mode="edit"
+            mode={post.status === 'queued' ? 'queue' : 'edit'}
             platform={formState.platform}
             userTimezone={userTimezone}
             effectiveProfileId={formState.profileId}

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -683,7 +683,7 @@ export default function EditPostPage() {
               <SplitButton
                 onSchedule={() => handleSubmit(primaryAction)}
                 onDraft={() => handleSubmit('draft')}
-                scheduleLabel={post.status === 'queued' ? 'Update Queued Post' : 'Schedule Post'}
+                primaryLabel={post.status === 'queued' ? 'Update Queued Post' : 'Schedule Post'}
                 isLoading={updatePostMutation.isPending}
                 disabled={scheduleDisabled}
               />

--- a/packages/web/src/pages/posts/NewPostPage.tsx
+++ b/packages/web/src/pages/posts/NewPostPage.tsx
@@ -614,7 +614,7 @@ export default function NewPostPage() {
               </Button>
             ) : (
               <SplitButton
-                onSchedule={() => validateAndSubmit('schedule')}
+                onPrimary={() => validateAndSubmit('schedule')}
                 onDraft={() => validateAndSubmit('draft')}
                 isLoading={createPostMutation.isPending}
                 disabled={scheduleDisabled}

--- a/packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import EditPostPage from '../EditPostPage';
@@ -85,13 +86,25 @@ vi.mock('../../../components/posts/ProfilePicker', () => ({
 }));
 
 vi.mock('../../../components/posts/TwitterPostFields', () => ({
-  TwitterPostFields: ({ text }: { text: string }) => (
-    <textarea aria-label="Tweet text" readOnly value={text} />
+  TwitterPostFields: ({
+    text,
+    onTextChange,
+  }: {
+    text: string;
+    onTextChange: (value: string) => void;
+  }) => (
+    <textarea
+      aria-label="Tweet text"
+      value={text}
+      onChange={(event) => onTextChange(event.target.value)}
+    />
   ),
 }));
 
 vi.mock('../../../components/posts/SharedPostFields', () => ({
-  SharedPostFields: () => <div>Shared fields</div>,
+  SharedPostFields: ({ mode }: { mode: string }) => (
+    <div data-testid="shared-fields-mode">{mode}</div>
+  ),
 }));
 
 vi.mock('../../../components/posts/TweetPreview', () => ({
@@ -159,5 +172,31 @@ describe('EditPostPage', () => {
     renderPage();
 
     expect(screen.getByRole('button', { name: 'Update Queued Post' })).toBeInTheDocument();
+  });
+
+  it('keeps queued edits queued when the primary action is submitted', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(screen.getByTestId('shared-fields-mode')).toHaveTextContent('queue');
+
+    const textarea = await screen.findByDisplayValue('Queued import with typo');
+    await user.clear(textarea);
+    await user.type(textarea, 'Queued import typo fixed');
+    await user.click(screen.getByRole('button', { name: 'Update Queued Post' }));
+
+    expect(updatePostMutate).toHaveBeenCalledTimes(1);
+    const [mutationInput] = updatePostMutate.mock.calls[0];
+    expect(mutationInput).toMatchObject({
+      postId: 'post-1',
+      postVersion: 1,
+      postInput: {
+        platform: 'twitter',
+        text: 'Queued import typo fixed',
+        isThread: false,
+      },
+    });
+    expect(mutationInput.postInput).not.toHaveProperty('status');
+    expect(mutationInput.postInput).not.toHaveProperty('scheduledAt');
   });
 });

--- a/packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx
@@ -1,0 +1,163 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import EditPostPage from '../EditPostPage';
+
+const navigate = vi.fn();
+const updatePostMutate = vi.fn();
+const mocks = vi.hoisted(() => ({
+  post: {
+    id: 'post-1',
+    profileId: 'profile-1',
+    text: 'Queued import with typo',
+    isThread: false,
+    status: 'queued',
+    scheduledAt: '2026-06-01T14:00:00.000Z',
+    publishedAt: null,
+    platformPostId: null,
+    postVersion: 1,
+    hasSpinnableText: false,
+    autoDestructAfter: null,
+    notes: null,
+    failureReason: null,
+    createdAt: '2026-05-21T00:00:00.000Z',
+    updatedAt: '2026-05-21T00:00:00.000Z',
+    tags: [],
+  },
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    useParams: () => ({ id: 'post-1' }),
+  };
+});
+
+vi.mock('../../../hooks/use-auth', () => ({
+  useAuth: () => ({ data: { timezone: 'UTC' } }),
+}));
+
+vi.mock('../../../hooks/use-profiles', () => ({
+  useProfiles: () => ({
+    data: [
+      {
+        id: 'profile-1',
+        platform: 'twitter',
+        displayName: 'Codex Repro Twitter',
+        handle: 'codexrepro',
+        avatarUrl: '',
+      },
+    ],
+  }),
+}));
+
+vi.mock('../../../hooks/use-posts', () => ({
+  usePost: () => ({
+    data: mocks.post,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useUpdatePost: () => ({
+    mutate: updatePostMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock('../../../hooks/use-media-upload', () => ({
+  useMediaUpload: () => ({
+    upload: vi.fn(),
+    uploadingFiles: new Map(),
+    isUploading: false,
+  }),
+}));
+
+vi.mock('../../../hooks/use-media', () => ({
+  useDeleteMedia: () => ({ mutate: vi.fn() }),
+  useRetryTranscode: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('../../../components/posts/ProfilePicker', () => ({
+  ProfilePicker: () => <div>Profile picker</div>,
+}));
+
+vi.mock('../../../components/posts/TwitterPostFields', () => ({
+  TwitterPostFields: ({ text }: { text: string }) => (
+    <textarea aria-label="Tweet text" readOnly value={text} />
+  ),
+}));
+
+vi.mock('../../../components/posts/SharedPostFields', () => ({
+  SharedPostFields: () => <div>Shared fields</div>,
+}));
+
+vi.mock('../../../components/posts/TweetPreview', () => ({
+  TweetPreview: () => null,
+}));
+
+vi.mock('../../../components/posts/LinkedInPreview', () => ({
+  LinkedInPreview: () => null,
+}));
+
+vi.mock('../../../components/posts/FacebookPreview', () => ({
+  FacebookPreview: () => null,
+}));
+
+vi.mock('../../../components/posts/TagManagementDialog', () => ({
+  TagManagementDialog: () => null,
+}));
+
+vi.mock('../../../components/posts/RateLimitBanner', () => ({
+  RateLimitBanner: () => null,
+}));
+
+vi.mock('../../../components/profiles/RateLimitSettingsDialog', () => ({
+  RateLimitSettingsDialog: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <EditPostPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('EditPostPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the queued update label for queued post edits', () => {
+    renderPage();
+
+    expect(screen.getByRole('button', { name: 'Update Queued Post' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Allows queued posts to be edited by including `queued` in the shared editable state list.
- Adds a queued edit save path that updates post content without changing `status` or `scheduledAt`.
- Updates the edit form UX so queued posts show `Update Queued Post` and hide scheduling controls, while still allowing `Save as Draft`.
- Adds focused shared, API, service, aggregate, and web coverage for queued edit behavior.

## Why

Bulk imported tweets can land in the queued state before the user notices a typo or content issue. Previously the edit screen treated queued posts as read-only, forcing users to delete and recreate the post. This keeps the queued workflow intact while allowing content corrections before publish.

## Validation

- `pnpm --filter @sms/shared test -- post-states post-aggregate`
- `pnpm --filter @sms/api exec vitest run src/__tests__/services/post-state-machine.test.ts src/__tests__/services/post.test.ts`
- `pnpm --filter @sms/web exec vitest run src/components/posts/__tests__/SplitButton.test.tsx src/pages/posts/__tests__/EditPostPage.test.tsx src/pages/posts/__tests__/PostsPage.test.tsx src/pages/posts/__tests__/NewPostPage.test.tsx`
- Browser validation with a temporary local mock API confirmed queued edit opens, saves text changes, keeps the post queued, hides schedule controls, and sends no `status` or `scheduledAt` in the PATCH payload.
- RoboRev branch review job 170 passed with no findings.

Note: live Docker API validation was blocked by an unrelated `defaultLandingPageSchema` shared export issue, so browser UX validation used a temporary local mock API.