### PR TITLE
[codex] Fix media cleanup ordering and batching

### DIFF
--- a/.clawpatch/features/feat_gh-16_a4a815281e.json
+++ b/.clawpatch/features/feat_gh-16_a4a815281e.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-16_a4a815281e",
+  "title": "gh#16: Perf: N+1 DELETE and unbounded SELECT in media-cleanup-worker",
+  "summary": "Imported from GitHub issue gh#16 in BACKLOG.md section \"Performance\".",
+  "kind": "job",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/worker/src/media-cleanup-worker.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/worker/src/media-cleanup-worker.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#16"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#16",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/16",
+    "backlog-order:0044",
+    "backlog-section:performance"
+  ],
+  "trustBoundaries": [
+    "filesystem",
+    "concurrency"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-16-af256e6111_9de04d4970"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260527T040617-93c83b",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#16",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-27T04:06:17.910Z"
+    }
+  ],
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T04:31:24.381Z"
+}

--- a/.clawpatch/features/feat_gh-18_93a07c6332.json
+++ b/.clawpatch/features/feat_gh-18_93a07c6332.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-18_93a07c6332",
+  "title": "gh#18: Fix: Media cleanup deletes storage before DB row — ordering risk",
+  "summary": "Imported from GitHub issue gh#18 in BACKLOG.md section \"P1 — Security & infra correctness\".",
+  "kind": "job",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/worker/src/media-cleanup-worker.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/worker/src/media-cleanup-worker.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#18"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#18",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/18",
+    "backlog-order:0010",
+    "backlog-section:p1-security-infra-correctness"
+  ],
+  "trustBoundaries": [
+    "filesystem",
+    "database",
+    "concurrency"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-18-642750077f_da3fc2d858"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260527T040704-625501",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#18",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-27T04:07:04.328Z"
+    }
+  ],
+  "createdAt": "2026-05-27T04:07:04.328Z",
+  "updatedAt": "2026-05-27T04:18:53.243Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-16-af256e6111_9de04d4970.json
+++ b/.clawpatch/findings/fnd_sig-gh-16-af256e6111_9de04d4970.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-16-af256e6111_9de04d4970",
+  "featureId": "feat_gh-16_a4a815281e",
+  "title": "gh#16: Perf: N+1 DELETE and unbounded SELECT in media-cleanup-worker",
+  "category": "performance",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "packages/worker/src/media-cleanup-worker.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/16.\nBacklog section: Performance.\n\n## Problem\n\n1. Cleanup loops issue one DELETE per row (N round trips). Should batch into a single DELETE with inArray.\n2. SELECT queries fetch all matching rows with no LIMIT — unbounded memory if thousands of rows accumulate between weekly runs.\n\n## Identified by\n\nCode quality review Run 2 — performance-optimizer (perf-001, perf-002)\n\n## Fix\n\n1. Collect IDs after storage deletes, issue single batch DELETE.\n2. Add cursor-based batching with LIMIT 200 per batch.\n\n## Files\n\n- `packages/worker/src/media-cleanup-worker.ts`",
+  "reproduction": "1. Cleanup loops issue one DELETE per row (N round trips). Should batch into a single DELETE with inArray.\n2. SELECT queries fetch all matching rows with no LIMIT — unbounded memory if thousands of rows accumulate between weekly runs.",
+  "recommendation": "1. Collect IDs after storage deletes, issue single batch DELETE.\n2. Add cursor-based batching with LIMIT 200 per batch.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/worker/src/media-cleanup-worker.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260527T041912-11dab7",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence path still exists at packages/worker/src/media-cleanup-worker.ts. Current code still performs unbounded selects for expiredMedia and orphans with select().from(postMedia).where(...) and no limit/cursor batching at lines 41-46 and 87-93. It also still loops those result sets and issues one deps.db.delete(postMedia).where(eq(postMedia.id, ...)) per row at lines 48-51 and 95-98; the file imports eq but not inArray. The current media-cleanup tests reinforce the per-row behavior by expecting two delete calls when two rows are returned. A targeted vitest run was attempted but could not start because the read-only sandbox prevented Vite from writing its .vite-temp config artifact, so the conclusion is based on current source and test code inspection.",
+      "commands": [
+        "pwd && rg --files | rg '(^|/)media-cleanup-worker\\.ts$|package\\.json$|vitest|jest|test'",
+        "git status --short",
+        "nl -ba packages/worker/src/media-cleanup-worker.ts | sed -n '1,260p'",
+        "nl -ba packages/worker/src/__tests__/media-cleanup.test.ts | sed -n '1,360p'",
+        "rg -n \"delete\\(|inArray|limit\\(|MEDIA_CLEANUP|cleanup|mediaCleanup|cleanup\" packages/worker/src/media-cleanup-worker.ts packages/worker/src/__tests__/media-cleanup.test.ts packages -g '*.ts'",
+        "nl -ba package.json | sed -n '1,220p'",
+        "nl -ba packages/worker/package.json | sed -n '1,220p'",
+        "nl -ba packages/worker/src/__tests__/media-cleanup.test.ts | sed -n '359,460p'",
+        "pnpm --filter @sms/worker test -- --run src/__tests__/media-cleanup.test.ts"
+      ],
+      "createdAt": "2026-05-27T04:20:02.662Z"
+    },
+    {
+      "runId": "20260527T043002-a8ca73",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence path still exists, but the relevant implementation has changed. packages/worker/src/media-cleanup-worker.ts now imports inArray/asc/gt, defines MEDIA_CLEANUP_BATCH_SIZE = 200, deletes each fetched batch with one db.delete(postMedia).where(inArray(postMedia.id, mediaIds)), and both expired-media and orphan queries use id cursors with orderBy(asc(postMedia.id)) and limit(MEDIA_CLEANUP_BATCH_SIZE). Current tests include regression coverage for one batched delete and 200-row cursor-limited selects. A targeted Vitest run could not start because the read-only sandbox prevented Vite from writing its .vite-temp config file, but pnpm --filter @sms/worker typecheck passed. Search did not find another media-cleanup implementation still doing per-row postMedia deletes or unbounded cleanup selects.",
+      "commands": [
+        "pwd",
+        "git status --short",
+        "rg --files | rg '(^|/)media-cleanup-worker\\.ts$|(^|/)media-cleanup.*test\\.ts$|(^|/)media-cleanup.*\\.test\\.ts$|package\\.json$|vitest|jest'",
+        "nl -ba packages/worker/src/media-cleanup-worker.ts",
+        "nl -ba packages/worker/src/__tests__/media-cleanup.test.ts",
+        "rg -n \"select\\(|delete\\(|inArray|limit\\(|orderBy|cursor|MEDIA_CLEANUP|cleanupExpiredMedia|cleanupOrphanedMedia|BATCH\" packages/worker/src/media-cleanup-worker.ts packages/worker/src/__tests__/media-cleanup.test.ts",
+        "git diff -- packages/worker/src/media-cleanup-worker.ts packages/worker/src/__tests__/media-cleanup.test.ts .clawpatch/findings/fnd_sig-gh-16-af256e6111_9de04d4970.json",
+        "pnpm --filter @sms/worker test -- --run src/__tests__/media-cleanup.test.ts",
+        "rg -n \"media-cleanup|mediaCleanup|postMedia|delete\\(postMedia\\)|inArray\\(postMedia\\.id|limit\\(MEDIA_CLEANUP_BATCH_SIZE\\)|gt\\(postMedia\\.id\" packages . -g '*.ts' -g '*.json'",
+        "nl -ba packages/worker/package.json",
+        "nl -ba packages/worker/vitest.config.ts",
+        "pnpm --filter @sms/worker typecheck"
+      ],
+      "createdAt": "2026-05-27T04:31:24.339Z"
+    }
+  ],
+  "signature": "sig_gh-16_af256e6111",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260527T040617-93c83b",
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T04:31:24.339Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-18-642750077f_da3fc2d858.json
+++ b/.clawpatch/findings/fnd_sig-gh-18-642750077f_da3fc2d858.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-18-642750077f_da3fc2d858",
+  "featureId": "feat_gh-18_93a07c6332",
+  "title": "gh#18: Fix: Media cleanup deletes storage before DB row — ordering risk",
+  "category": "bug",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "confirmed-bug",
+  "evidence": [
+    {
+      "path": "packages/worker/src/media-cleanup-worker.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/18.\nBacklog section: P1 — Security & infra correctness.\n\n## Problem\n\nCleanup loop deletes storage file first, then DB row. If the worker crashes between steps, the DB row persists pointing to a missing file. Reversing the order (DB first, then storage) is safer — an orphaned storage file is harmless, but a DB row pointing to a missing file confuses the UI.\n\nAlso, db.delete failures inside the loop are uncaught — one failing row aborts the entire batch.\n\n## Identified by\n\nCode quality review Run 2 — security-auditor (finding 3), error-handling-reviewer (finding 3)\n\n## Fix\n\n1. Delete DB row first, then storage (best-effort).\n2. Wrap db.delete in try-catch with continue so remaining rows are processed.\n\n## Files\n\n- `packages/worker/src/media-cleanup-worker.ts:45-71, 83-105`",
+  "reproduction": "Cleanup loop deletes storage file first, then DB row. If the worker crashes between steps, the DB row persists pointing to a missing file. Reversing the order (DB first, then storage) is safer — an orphaned storage file is harmless, but a DB row pointing to a missing file confuses the UI.\n\nAlso, db.delete failures inside the loop are uncaught — one failing row aborts the entire batch.",
+  "recommendation": "1. Delete DB row first, then storage (best-effort).\n2. Wrap db.delete in try-catch with continue so remaining rows are processed.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/worker/src/media-cleanup-worker.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260527T041116-fb4bba",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence path still exists. In packages/worker/src/media-cleanup-worker.ts, expired media still deletes storage first at lines 50 and 60, then deletes the DB row at line 69. Orphan cleanup still deletes storage first at lines 88 and 98, then deletes the DB row at line 107. The DB delete calls are still outside try/catch blocks, so a db.delete failure would still abort the processor instead of continuing through the remaining rows. Existing media-cleanup tests cover storage.delete failure continuation but do not cover DB-delete failure continuation or DB-before-storage ordering. Targeted Vitest execution was attempted, but the read-only sandbox blocked Vite/Vitest temp directory creation with EPERM.",
+      "commands": [
+        "rg -n \"media-cleanup|cleanup|delete.*storage|storage.*delete|db\\\\.delete|delete\\\\(\" packages/worker src packages || true",
+        "nl -ba packages/worker/src/media-cleanup-worker.ts | sed -n '1,180p'",
+        "nl -ba packages/worker/src/__tests__/media-cleanup.test.ts | sed -n '1,340p'",
+        "cat packages/worker/package.json",
+        "cat package.json",
+        "pnpm --filter @sms/worker test -- --run src/__tests__/media-cleanup.test.ts",
+        "pnpm --filter @sms/worker exec vitest run --configLoader runner src/__tests__/media-cleanup.test.ts",
+        "node -e \"const fs=require('fs');const lines=fs.readFileSync('packages/worker/src/media-cleanup-worker.ts','utf8').split('\\\\n');for(const needle of ['await deps.storage.delete(row.filePath)','await deps.storage.delete(row.thumbnailPath)','await deps.db.delete(postMedia).where(eq(postMedia.id, row.id))','await deps.storage.delete(orphan.filePath)','await deps.storage.delete(orphan.thumbnailPath)','await deps.db.delete(postMedia).where(eq(postMedia.id, orphan.id))']){const i=lines.findIndex(l=>l.includes(needle));console.log((i+1)+': '+lines[i].trim())}\""
+      ],
+      "createdAt": "2026-05-27T04:12:38.333Z"
+    },
+    {
+      "runId": "20260527T041743-919aa3",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence path still exists. Current packages/worker/src/media-cleanup-worker.ts now deletes the DB row before storage for both expired media and orphan cleanup: expired media deletes the row at line 50, catches db errors and continues at lines 51-56, then deletes storage at lines 60 and 70; orphan cleanup deletes the row at line 97, catches db errors and continues at lines 98-103, then deletes storage at lines 107 and 117. Regression tests now exist in packages/worker/src/__tests__/media-cleanup.test.ts for DB-before-storage ordering and DB-delete failure continuation at lines 289, 323, and 359. Targeted Vitest execution was attempted but blocked by the read-only sandbox with EPERM creating Vitest temp directories; worker typecheck passed.",
+      "commands": [
+        "rg -n \"media-cleanup|delete\\(|storage\\.delete|db\\.delete|postMedia|thumbnailPath|filePath\" packages/worker/src packages/worker/src/__tests__",
+        "nl -ba packages/worker/src/media-cleanup-worker.ts | sed -n '1,220p'",
+        "nl -ba packages/worker/src/__tests__/media-cleanup.test.ts | sed -n '1,420p'",
+        "cat packages/worker/package.json",
+        "cat package.json",
+        "git status --short",
+        "pnpm --filter @sms/worker exec vitest run --configLoader runner src/__tests__/media-cleanup.test.ts",
+        "rg -n \"await deps\\.db\\.delete|await deps\\.storage\\.delete|catch \\(dbErr\\)|continue;|deletes .* before|continues .*database row fails\" packages/worker/src/media-cleanup-worker.ts packages/worker/src/__tests__/media-cleanup.test.ts",
+        "node -e 'const fs=require(\"fs\");const lines=fs.readFileSync(\"packages/worker/src/media-cleanup-worker.ts\",\"utf8\").split(\"\\n\");for (const [i,l] of lines.entries()) if (/await deps\\.(db\\.delete|storage\\.delete)|catch \\(dbErr\\)|continue;/.test(l)) console.log(`${i+1}: ${l.trim()}`);'",
+        "pnpm --filter @sms/worker typecheck"
+      ],
+      "createdAt": "2026-05-27T04:18:53.189Z"
+    }
+  ],
+  "signature": "sig_gh-18_642750077f",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-18-642750077f-da3fc2d_f6ae4cf443"
+  ],
+  "createdByRunId": "20260527T040704-625501",
+  "createdAt": "2026-05-27T04:07:04.328Z",
+  "updatedAt": "2026-05-27T04:18:53.189Z"
+}

--- a/packages/worker/src/__tests__/media-cleanup.test.ts
+++ b/packages/worker/src/__tests__/media-cleanup.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const logMocks = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
 // Mock logger before any imports that use it
 vi.mock('@sms/shared/logger', () => ({
   createLogger: () => ({
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    child: () => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
+    info: logMocks.info,
+    warn: logMocks.warn,
+    error: logMocks.error,
+    child: () => logMocks,
   }),
 }));
 
@@ -245,7 +247,7 @@ describe('createMediaCleanupWorker', () => {
     expect(deleteFn).not.toHaveBeenCalled();
   });
 
-  it('handles storage.delete() failure gracefully and continues', async () => {
+  it('logs and accepts unreachable storage files after database row deletion succeeds', async () => {
     const { createMediaCleanupWorker } = await import('../media-cleanup-worker.js');
     const mockRedis = {} as never;
     const { db } = createMockDb();
@@ -258,7 +260,8 @@ describe('createMediaCleanupWorker', () => {
 
     mockSelectBatches(db, [expiredRows, [], []]);
 
-    db.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+    const deleteWhere = vi.fn().mockResolvedValue(undefined);
+    db.delete.mockReturnValue({ where: deleteWhere });
 
     // First call fails, second succeeds
     mockStorage.delete
@@ -271,8 +274,20 @@ describe('createMediaCleanupWorker', () => {
     await expect(capturedProcessor!({ data: {} })).resolves.toBeUndefined();
 
     // Both files attempted
+    expect(deleteWhere).toHaveBeenCalledWith({
+      type: 'inArray',
+      col: 'mock_id_col',
+      vals: ['media-1', 'media-2'],
+    });
+    expect(deleteWhere.mock.invocationCallOrder[0]).toBeLessThan(
+      mockStorage.delete.mock.invocationCallOrder[0],
+    );
     expect(mockStorage.delete).toHaveBeenCalledWith('fail/path.jpg');
     expect(mockStorage.delete).toHaveBeenCalledWith('ok/path.jpg');
+    expect(logMocks.error).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaId: 'media-1', filePath: 'fail/path.jpg' }),
+      'Failed to delete file from storage, continuing',
+    );
   });
 
   it('deletes expired media rows in one batch before deleting storage files', async () => {
@@ -319,6 +334,10 @@ describe('createMediaCleanupWorker', () => {
         { id: 'media-2', filePath: 'media/p1/2026/01/def.jpg', thumbnailPath: null },
       ],
       [],
+      [
+        { id: 'orphan-1', filePath: 'media/p2/2026/01/orphan-a.jpg', thumbnailPath: null },
+        { id: 'orphan-2', filePath: 'media/p2/2026/01/orphan-b.jpg', thumbnailPath: null },
+      ],
       [],
     ]);
 
@@ -327,13 +346,18 @@ describe('createMediaCleanupWorker', () => {
     createMediaCleanupWorker({ redis: mockRedis, db: db as never, storage: mockStorage });
     await capturedProcessor!({ data: {} });
 
-    expect(queries).toHaveLength(3);
+    expect(queries).toHaveLength(4);
     for (const query of queries) {
       expect(query.limit).toHaveBeenCalledWith(200);
     }
     expect(queries[1].where).toHaveBeenCalledWith(expect.objectContaining({
       args: expect.arrayContaining([
         { type: 'gt', col: 'mock_id_col', val: 'media-2' },
+      ]),
+    }));
+    expect(queries[3].where).toHaveBeenCalledWith(expect.objectContaining({
+      args: expect.arrayContaining([
+        { type: 'gt', col: 'mock_id_col', val: 'orphan-2' },
       ]),
     }));
   });
@@ -377,6 +401,14 @@ describe('createMediaCleanupWorker', () => {
     expect(mockStorage.delete).not.toHaveBeenCalledWith('batch-1/path-a.jpg');
     expect(mockStorage.delete).not.toHaveBeenCalledWith('batch-1/path-b.jpg');
     expect(mockStorage.delete).toHaveBeenCalledWith('batch-2/path-c.jpg');
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      {
+        firstMediaId: 'media-1',
+        lastMediaId: 'media-2',
+        mediaCount: 2,
+      },
+      'Skipping expired media batch after database delete failure',
+    );
   });
 
   it('deletes orphan rows in one batch before storage even when storage deletion fails', async () => {
@@ -412,6 +444,52 @@ describe('createMediaCleanupWorker', () => {
     expect(mockStorage.delete).toHaveBeenCalledWith('ok/orphan.jpg');
     expect(deleteWhere.mock.invocationCallOrder[0]).toBeLessThan(
       mockStorage.delete.mock.invocationCallOrder[0],
+    );
+    expect(logMocks.info).toHaveBeenCalledWith(
+      { mediaId: 'orphan-1', filePath: 'fail/orphan.jpg' },
+      'Permanently deleted orphaned media',
+    );
+    expect(logMocks.info).toHaveBeenCalledWith(
+      { mediaId: 'orphan-2', filePath: 'ok/orphan.jpg' },
+      'Permanently deleted orphaned media',
+    );
+  });
+
+  it('logs skipped orphan cursor range when an orphan batch database delete fails', async () => {
+    const { createMediaCleanupWorker } = await import('../media-cleanup-worker.js');
+    const mockRedis = {} as never;
+    const { db } = createMockDb();
+    const mockStorage = createMockStorage();
+
+    const orphanRows = [
+      { id: 'orphan-1', filePath: 'batch-1/orphan-a.jpg', thumbnailPath: null },
+      { id: 'orphan-2', filePath: 'batch-1/orphan-b.jpg', thumbnailPath: null },
+    ];
+    const nextOrphanRows = [
+      { id: 'orphan-3', filePath: 'batch-2/orphan-c.jpg', thumbnailPath: null },
+    ];
+
+    mockSelectBatches(db, [[], orphanRows, nextOrphanRows, []]);
+
+    const deleteWhere = vi.fn()
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValue(undefined);
+    db.delete.mockReturnValue({ where: deleteWhere });
+
+    createMediaCleanupWorker({ redis: mockRedis, db: db as never, storage: mockStorage });
+
+    await expect(capturedProcessor!({ data: {} })).resolves.toBeUndefined();
+
+    expect(mockStorage.delete).not.toHaveBeenCalledWith('batch-1/orphan-a.jpg');
+    expect(mockStorage.delete).not.toHaveBeenCalledWith('batch-1/orphan-b.jpg');
+    expect(mockStorage.delete).toHaveBeenCalledWith('batch-2/orphan-c.jpg');
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      {
+        firstMediaId: 'orphan-1',
+        lastMediaId: 'orphan-2',
+        mediaCount: 2,
+      },
+      'Skipping orphan media batch after database delete failure',
     );
   });
 });

--- a/packages/worker/src/__tests__/media-cleanup.test.ts
+++ b/packages/worker/src/__tests__/media-cleanup.test.ts
@@ -25,6 +25,16 @@ vi.mock('@sms/db', () => ({
   },
 }));
 
+vi.mock('@sms/shared', () => ({
+  QUEUE_NAMES: {
+    mediaCleanup: 'media-cleanup',
+  },
+  JOB_NAMES: {
+    mediaCleanupScheduler: 'weekly-media-cleanup',
+    mediaCleanup: 'media-cleanup',
+  },
+}));
+
 vi.mock('@sms/shared/storage', () => ({
   createStorageBackend: vi.fn(),
 }));
@@ -274,6 +284,115 @@ describe('createMediaCleanupWorker', () => {
     // Both files attempted
     expect(mockStorage.delete).toHaveBeenCalledWith('fail/path.jpg');
     expect(mockStorage.delete).toHaveBeenCalledWith('ok/path.jpg');
+  });
+
+  it('deletes expired media rows from the database before deleting storage files', async () => {
+    const { createMediaCleanupWorker } = await import('../media-cleanup-worker.js');
+    const mockRedis = {} as never;
+    const { db } = createMockDb();
+    const mockStorage = createMockStorage();
+
+    const expiredRows = [
+      { id: 'media-1', filePath: 'media/p1/2026/01/abc.jpg', thumbnailPath: null },
+    ];
+
+    let selectCallCount = 0;
+    db.select.mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: () => {
+          selectCallCount++;
+          if (selectCallCount === 1) return Promise.resolve(expiredRows);
+          return Promise.resolve([]);
+        },
+      })),
+    }));
+
+    const deleteWhere = vi.fn().mockResolvedValue(undefined);
+    db.delete.mockReturnValue({ where: deleteWhere });
+
+    createMediaCleanupWorker({ redis: mockRedis, db: db as never, storage: mockStorage });
+    await capturedProcessor!({ data: {} });
+
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(mockStorage.delete).toHaveBeenCalledWith('media/p1/2026/01/abc.jpg');
+    expect(deleteWhere.mock.invocationCallOrder[0]).toBeLessThan(
+      mockStorage.delete.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('continues expired media cleanup when deleting one database row fails', async () => {
+    const { createMediaCleanupWorker } = await import('../media-cleanup-worker.js');
+    const mockRedis = {} as never;
+    const { db } = createMockDb();
+    const mockStorage = createMockStorage();
+
+    const expiredRows = [
+      { id: 'media-1', filePath: 'fail/path.jpg', thumbnailPath: null },
+      { id: 'media-2', filePath: 'ok/path.jpg', thumbnailPath: null },
+    ];
+
+    let selectCallCount = 0;
+    db.select.mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: () => {
+          selectCallCount++;
+          if (selectCallCount === 1) return Promise.resolve(expiredRows);
+          return Promise.resolve([]);
+        },
+      })),
+    }));
+
+    const deleteWhere = vi.fn()
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValue(undefined);
+    db.delete.mockReturnValue({ where: deleteWhere });
+
+    createMediaCleanupWorker({ redis: mockRedis, db: db as never, storage: mockStorage });
+
+    await expect(capturedProcessor!({ data: {} })).resolves.toBeUndefined();
+
+    expect(deleteWhere).toHaveBeenCalledTimes(2);
+    expect(mockStorage.delete).not.toHaveBeenCalledWith('fail/path.jpg');
+    expect(mockStorage.delete).toHaveBeenCalledWith('ok/path.jpg');
+  });
+
+  it('deletes orphan rows before storage and continues when deleting one orphan row fails', async () => {
+    const { createMediaCleanupWorker } = await import('../media-cleanup-worker.js');
+    const mockRedis = {} as never;
+    const { db } = createMockDb();
+    const mockStorage = createMockStorage();
+
+    const orphanRows = [
+      { id: 'orphan-1', filePath: 'fail/orphan.jpg', thumbnailPath: null },
+      { id: 'orphan-2', filePath: 'ok/orphan.jpg', thumbnailPath: null },
+    ];
+
+    let selectCallCount = 0;
+    db.select.mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() => ({
+        where: () => {
+          selectCallCount++;
+          if (selectCallCount === 1) return Promise.resolve([]);
+          return Promise.resolve(orphanRows);
+        },
+      })),
+    }));
+
+    const deleteWhere = vi.fn()
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValue(undefined);
+    db.delete.mockReturnValue({ where: deleteWhere });
+
+    createMediaCleanupWorker({ redis: mockRedis, db: db as never, storage: mockStorage });
+
+    await expect(capturedProcessor!({ data: {} })).resolves.toBeUndefined();
+
+    expect(deleteWhere).toHaveBeenCalledTimes(2);
+    expect(mockStorage.delete).not.toHaveBeenCalledWith('fail/orphan.jpg');
+    expect(mockStorage.delete).toHaveBeenCalledWith('ok/orphan.jpg');
+    expect(deleteWhere.mock.invocationCallOrder[1]).toBeLessThan(
+      mockStorage.delete.mock.invocationCallOrder[0],
+    );
   });
 });
 

--- a/packages/worker/src/__tests__/media-cleanup.test.ts
+++ b/packages/worker/src/__tests__/media-cleanup.test.ts
@@ -74,25 +74,42 @@ vi.mock('drizzle-orm', () => ({
   isNotNull: vi.fn((col: unknown) => ({ type: 'isNotNull', col })),
   isNull: vi.fn((col: unknown) => ({ type: 'isNull', col })),
   lt: vi.fn((col: unknown, val: unknown) => ({ type: 'lt', col, val })),
+  gt: vi.fn((col: unknown, val: unknown) => ({ type: 'gt', col, val })),
   eq: vi.fn((col: unknown, val: unknown) => ({ type: 'eq', col, val })),
+  inArray: vi.fn((col: unknown, vals: unknown[]) => ({ type: 'inArray', col, vals })),
+  asc: vi.fn((col: unknown) => ({ type: 'asc', col })),
 }));
 
 import type { StorageBackend } from '@sms/shared/storage';
+
+type MockRows = Record<string, unknown>[];
+
+function createSelectQuery(rows: MockRows) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const orderBy = vi.fn().mockReturnValue({ limit });
+  const where = vi.fn().mockReturnValue({ orderBy });
+  const from = vi.fn().mockReturnValue({ where });
+
+  return {
+    query: { from },
+    from,
+    where,
+    orderBy,
+    limit,
+  };
+}
 
 function createMockDb() {
   const whereResult = {
     rows: [] as Record<string, unknown>[],
   };
 
+  const deleteWhere = vi.fn().mockResolvedValue(undefined);
   const deleteFn = vi.fn().mockReturnValue({
-    where: vi.fn().mockResolvedValue(undefined),
+    where: deleteWhere,
   });
 
-  const selectFn = vi.fn().mockReturnValue({
-    from: vi.fn().mockReturnValue({
-      where: vi.fn().mockResolvedValue(whereResult.rows),
-    }),
-  });
+  const selectFn = vi.fn(() => createSelectQuery(whereResult.rows).query);
 
   return {
     db: {
@@ -101,8 +118,25 @@ function createMockDb() {
     },
     selectFn,
     deleteFn,
+    deleteWhere,
     whereResult,
   };
+}
+
+function mockSelectBatches(
+  db: ReturnType<typeof createMockDb>['db'],
+  batches: MockRows[],
+) {
+  const pendingBatches = [...batches];
+  const queries: ReturnType<typeof createSelectQuery>[] = [];
+
+  db.select.mockImplementation(() => {
+    const query = createSelectQuery(pendingBatches.shift() ?? []);
+    queries.push(query);
+    return query.query;
+  });
+
+  return queries;
 }
 
 function createMockStorage(): StorageBackend & { delete: ReturnType<typeof vi.fn> } {
@@ -143,21 +177,7 @@ describe('createMediaCleanupWorker', () => {
       { id: 'media-1', filePath: 'media/p1/2026/01/abc.jpg', thumbnailPath: 'media/p1/2026/01/abc_thumb.jpg' },
     ];
 
-    // Mock the first select().from().where() call (expired soft-deleted)
-    const expiredWhereHandler = vi.fn().mockResolvedValue(expiredRows);
-    // Mock the second select().from().where() call (orphans)
-    const orphanWhereHandler = vi.fn().mockResolvedValue([]);
-
-    let selectCallCount = 0;
-    db.select.mockImplementation(() => ({
-      from: vi.fn().mockImplementation(() => ({
-        where: () => {
-          selectCallCount++;
-          if (selectCallCount === 1) return expiredWhereHandler();
-          return orphanWhereHandler();
-        },
-      })),
-    }));
+    mockSelectBatches(db, [expiredRows, [], []]);
 
     createMediaCleanupWorker({ redis: mockRedis, db: db as never, storage: mockStorage });
     expect(capturedProcessor).not.toBeNull();
@@ -177,16 +197,7 @@ describe('createMediaCleanupWorker', () => {
       { id: 'media-1', filePath: 'media/p1/2026/01/abc.jpg', thumbnailPath: 'media/p1/2026/01/abc_thumb.jpg' },
     ];
 
-    let selectCallCount = 0;
-    db.select.mockImplementation(() => ({
-      from: vi.fn().mockImplementation(() => ({
-        where: () => {
-          selectCallCount++;
-          if (selectCallCount === 1) return Promise.resolve(expiredRows);
-          return Promise.resolve([]);
-        },
-      })),
-    }));
+    mockSelectBatches(db, [expiredRows, [], []]);
 
     db.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
 
@@ -207,16 +218,7 @@ describe('createMediaCleanupWorker', () => {
       { id: 'orphan-1', filePath: 'media/p2/2026/01/orphan.mp4', thumbnailPath: null },
     ];
 
-    let selectCallCount = 0;
-    db.select.mockImplementation(() => ({
-      from: vi.fn().mockImplementation(() => ({
-        where: () => {
-          selectCallCount++;
-          if (selectCallCount === 1) return Promise.resolve([]);
-          return Promise.resolve(orphanRows);
-        },
-      })),
-    }));
+    mockSelectBatches(db, [[], orphanRows, []]);
 
     db.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
 
@@ -233,12 +235,8 @@ describe('createMediaCleanupWorker', () => {
     const { db, deleteFn } = createMockDb();
     const mockStorage = createMockStorage();
 
-    // Both queries return empty (no rows match)
-    db.select.mockImplementation(() => ({
-      from: vi.fn().mockImplementation(() => ({
-        where: vi.fn().mockResolvedValue([]),
-      })),
-    }));
+    // Both cleanup loops return empty (no rows match)
+    mockSelectBatches(db, [[], []]);
 
     createMediaCleanupWorker({ redis: mockRedis, db: db as never, storage: mockStorage });
     await capturedProcessor!({ data: {} });
@@ -258,16 +256,7 @@ describe('createMediaCleanupWorker', () => {
       { id: 'media-2', filePath: 'ok/path.jpg', thumbnailPath: null },
     ];
 
-    let selectCallCount = 0;
-    db.select.mockImplementation(() => ({
-      from: vi.fn().mockImplementation(() => ({
-        where: () => {
-          selectCallCount++;
-          if (selectCallCount === 1) return Promise.resolve(expiredRows);
-          return Promise.resolve([]);
-        },
-      })),
-    }));
+    mockSelectBatches(db, [expiredRows, [], []]);
 
     db.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
 
@@ -286,7 +275,7 @@ describe('createMediaCleanupWorker', () => {
     expect(mockStorage.delete).toHaveBeenCalledWith('ok/path.jpg');
   });
 
-  it('deletes expired media rows from the database before deleting storage files', async () => {
+  it('deletes expired media rows in one batch before deleting storage files', async () => {
     const { createMediaCleanupWorker } = await import('../media-cleanup-worker.js');
     const mockRedis = {} as never;
     const { db } = createMockDb();
@@ -294,18 +283,10 @@ describe('createMediaCleanupWorker', () => {
 
     const expiredRows = [
       { id: 'media-1', filePath: 'media/p1/2026/01/abc.jpg', thumbnailPath: null },
+      { id: 'media-2', filePath: 'media/p1/2026/01/def.jpg', thumbnailPath: null },
     ];
 
-    let selectCallCount = 0;
-    db.select.mockImplementation(() => ({
-      from: vi.fn().mockImplementation(() => ({
-        where: () => {
-          selectCallCount++;
-          if (selectCallCount === 1) return Promise.resolve(expiredRows);
-          return Promise.resolve([]);
-        },
-      })),
-    }));
+    mockSelectBatches(db, [expiredRows, [], []]);
 
     const deleteWhere = vi.fn().mockResolvedValue(undefined);
     db.delete.mockReturnValue({ where: deleteWhere });
@@ -314,33 +295,64 @@ describe('createMediaCleanupWorker', () => {
     await capturedProcessor!({ data: {} });
 
     expect(deleteWhere).toHaveBeenCalledTimes(1);
-    expect(mockStorage.delete).toHaveBeenCalledWith('media/p1/2026/01/abc.jpg');
+    expect(deleteWhere).toHaveBeenCalledWith({
+      type: 'inArray',
+      col: 'mock_id_col',
+      vals: ['media-1', 'media-2'],
+    });
     expect(deleteWhere.mock.invocationCallOrder[0]).toBeLessThan(
       mockStorage.delete.mock.invocationCallOrder[0],
     );
+    expect(mockStorage.delete).toHaveBeenCalledWith('media/p1/2026/01/abc.jpg');
+    expect(mockStorage.delete).toHaveBeenCalledWith('media/p1/2026/01/def.jpg');
   });
 
-  it('continues expired media cleanup when deleting one database row fails', async () => {
+  it('uses 200-row id-cursor batches for cleanup selects', async () => {
+    const { createMediaCleanupWorker } = await import('../media-cleanup-worker.js');
+    const mockRedis = {} as never;
+    const { db } = createMockDb();
+    const mockStorage = createMockStorage();
+
+    const queries = mockSelectBatches(db, [
+      [
+        { id: 'media-1', filePath: 'media/p1/2026/01/abc.jpg', thumbnailPath: null },
+        { id: 'media-2', filePath: 'media/p1/2026/01/def.jpg', thumbnailPath: null },
+      ],
+      [],
+      [],
+    ]);
+
+    db.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+
+    createMediaCleanupWorker({ redis: mockRedis, db: db as never, storage: mockStorage });
+    await capturedProcessor!({ data: {} });
+
+    expect(queries).toHaveLength(3);
+    for (const query of queries) {
+      expect(query.limit).toHaveBeenCalledWith(200);
+    }
+    expect(queries[1].where).toHaveBeenCalledWith(expect.objectContaining({
+      args: expect.arrayContaining([
+        { type: 'gt', col: 'mock_id_col', val: 'media-2' },
+      ]),
+    }));
+  });
+
+  it('continues expired media cleanup when a batch database delete fails', async () => {
     const { createMediaCleanupWorker } = await import('../media-cleanup-worker.js');
     const mockRedis = {} as never;
     const { db } = createMockDb();
     const mockStorage = createMockStorage();
 
     const expiredRows = [
-      { id: 'media-1', filePath: 'fail/path.jpg', thumbnailPath: null },
-      { id: 'media-2', filePath: 'ok/path.jpg', thumbnailPath: null },
+      { id: 'media-1', filePath: 'batch-1/path-a.jpg', thumbnailPath: null },
+      { id: 'media-2', filePath: 'batch-1/path-b.jpg', thumbnailPath: null },
+    ];
+    const nextExpiredRows = [
+      { id: 'media-3', filePath: 'batch-2/path-c.jpg', thumbnailPath: null },
     ];
 
-    let selectCallCount = 0;
-    db.select.mockImplementation(() => ({
-      from: vi.fn().mockImplementation(() => ({
-        where: () => {
-          selectCallCount++;
-          if (selectCallCount === 1) return Promise.resolve(expiredRows);
-          return Promise.resolve([]);
-        },
-      })),
-    }));
+    mockSelectBatches(db, [expiredRows, nextExpiredRows, [], []]);
 
     const deleteWhere = vi.fn()
       .mockRejectedValueOnce(new Error('database unavailable'))
@@ -352,11 +364,22 @@ describe('createMediaCleanupWorker', () => {
     await expect(capturedProcessor!({ data: {} })).resolves.toBeUndefined();
 
     expect(deleteWhere).toHaveBeenCalledTimes(2);
-    expect(mockStorage.delete).not.toHaveBeenCalledWith('fail/path.jpg');
-    expect(mockStorage.delete).toHaveBeenCalledWith('ok/path.jpg');
+    expect(deleteWhere).toHaveBeenNthCalledWith(1, {
+      type: 'inArray',
+      col: 'mock_id_col',
+      vals: ['media-1', 'media-2'],
+    });
+    expect(deleteWhere).toHaveBeenNthCalledWith(2, {
+      type: 'inArray',
+      col: 'mock_id_col',
+      vals: ['media-3'],
+    });
+    expect(mockStorage.delete).not.toHaveBeenCalledWith('batch-1/path-a.jpg');
+    expect(mockStorage.delete).not.toHaveBeenCalledWith('batch-1/path-b.jpg');
+    expect(mockStorage.delete).toHaveBeenCalledWith('batch-2/path-c.jpg');
   });
 
-  it('deletes orphan rows before storage and continues when deleting one orphan row fails', async () => {
+  it('deletes orphan rows in one batch before storage even when storage deletion fails', async () => {
     const { createMediaCleanupWorker } = await import('../media-cleanup-worker.js');
     const mockRedis = {} as never;
     const { db } = createMockDb();
@@ -367,30 +390,27 @@ describe('createMediaCleanupWorker', () => {
       { id: 'orphan-2', filePath: 'ok/orphan.jpg', thumbnailPath: null },
     ];
 
-    let selectCallCount = 0;
-    db.select.mockImplementation(() => ({
-      from: vi.fn().mockImplementation(() => ({
-        where: () => {
-          selectCallCount++;
-          if (selectCallCount === 1) return Promise.resolve([]);
-          return Promise.resolve(orphanRows);
-        },
-      })),
-    }));
+    mockSelectBatches(db, [[], orphanRows, []]);
 
-    const deleteWhere = vi.fn()
-      .mockRejectedValueOnce(new Error('database unavailable'))
-      .mockResolvedValue(undefined);
+    const deleteWhere = vi.fn().mockResolvedValue(undefined);
     db.delete.mockReturnValue({ where: deleteWhere });
+    mockStorage.delete
+      .mockRejectedValueOnce(new Error('Storage unreachable'))
+      .mockResolvedValue(undefined);
 
     createMediaCleanupWorker({ redis: mockRedis, db: db as never, storage: mockStorage });
 
     await expect(capturedProcessor!({ data: {} })).resolves.toBeUndefined();
 
-    expect(deleteWhere).toHaveBeenCalledTimes(2);
-    expect(mockStorage.delete).not.toHaveBeenCalledWith('fail/orphan.jpg');
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(deleteWhere).toHaveBeenCalledWith({
+      type: 'inArray',
+      col: 'mock_id_col',
+      vals: ['orphan-1', 'orphan-2'],
+    });
+    expect(mockStorage.delete).toHaveBeenCalledWith('fail/orphan.jpg');
     expect(mockStorage.delete).toHaveBeenCalledWith('ok/orphan.jpg');
-    expect(deleteWhere.mock.invocationCallOrder[1]).toBeLessThan(
+    expect(deleteWhere.mock.invocationCallOrder[0]).toBeLessThan(
       mockStorage.delete.mock.invocationCallOrder[0],
     );
   });

--- a/packages/worker/src/media-cleanup-worker.ts
+++ b/packages/worker/src/media-cleanup-worker.ts
@@ -10,7 +10,7 @@
 
 import { Worker, Queue, type Job } from 'bullmq';
 import type { Redis } from 'ioredis';
-import { and, isNotNull, isNull, lt, eq } from 'drizzle-orm';
+import { and, asc, gt, inArray, isNotNull, isNull, lt } from 'drizzle-orm';
 import { postMedia } from '@sms/db';
 import { QUEUE_NAMES, JOB_NAMES } from '@sms/shared';
 import { createLogger } from '@sms/shared/logger';
@@ -21,6 +21,68 @@ const logger = createLogger('media-cleanup-worker');
 
 const SOFT_DELETE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const ORPHAN_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MEDIA_CLEANUP_BATCH_SIZE = 200;
+
+type MediaCleanupRow = Pick<
+  typeof postMedia.$inferSelect,
+  'id' | 'filePath' | 'thumbnailPath'
+>;
+
+interface StorageCleanupMessages {
+  fileFailure: string;
+  thumbnailFailure: string;
+}
+
+async function deleteStorageFiles(
+  storage: StorageBackend,
+  row: MediaCleanupRow,
+  logError: (metadata: Record<string, unknown>, message: string) => void,
+  messages: StorageCleanupMessages,
+): Promise<void> {
+  try {
+    await storage.delete(row.filePath);
+  } catch (storageErr) {
+    logError(
+      { err: storageErr, mediaId: row.id, filePath: row.filePath },
+      messages.fileFailure,
+    );
+  }
+
+  if (row.thumbnailPath) {
+    try {
+      await storage.delete(row.thumbnailPath);
+    } catch (storageErr) {
+      logError(
+        { err: storageErr, mediaId: row.id, thumbnailPath: row.thumbnailPath },
+        messages.thumbnailFailure,
+      );
+    }
+  }
+}
+
+async function deleteMediaRows(
+  db: WorkerDb,
+  rows: MediaCleanupRow[],
+  logError: (metadata: Record<string, unknown>, message: string) => void,
+  failureMessage: string,
+): Promise<boolean> {
+  if (rows.length === 0) {
+    return false;
+  }
+
+  const mediaIds = rows.map((row) => row.id);
+
+  try {
+    await db.delete(postMedia).where(inArray(postMedia.id, mediaIds));
+    return true;
+  } catch (dbErr) {
+    logError(
+      { err: dbErr, mediaIds },
+      failureMessage,
+    );
+    return false;
+  }
+}
 
 export interface MediaCleanupWorkerDeps {
   redis: Redis;
@@ -38,99 +100,125 @@ export function createMediaCleanupWorker(
 
       // 1. Permanently delete soft-deleted files older than 30 days
       const thirtyDaysAgo = new Date(Date.now() - SOFT_DELETE_RETENTION_MS);
-      const expiredMedia = await deps.db.select()
-        .from(postMedia)
-        .where(and(
-          isNotNull(postMedia.deletedAt),
-          lt(postMedia.deletedAt, thirtyDaysAgo),
-        ));
+      let expiredCursor: string | undefined;
+      let deletedExpiredCount = 0;
 
-      for (const row of expiredMedia) {
-        try {
-          await deps.db.delete(postMedia).where(eq(postMedia.id, row.id));
-        } catch (dbErr) {
-          jobLogger.error(
-            { err: dbErr, mediaId: row.id },
-            'Failed to delete media row from database, continuing',
-          );
+      while (true) {
+        const expiredMedia = await deps.db.select()
+          .from(postMedia)
+          .where(expiredCursor === undefined
+            ? and(
+              isNotNull(postMedia.deletedAt),
+              lt(postMedia.deletedAt, thirtyDaysAgo),
+            )
+            : and(
+              isNotNull(postMedia.deletedAt),
+              lt(postMedia.deletedAt, thirtyDaysAgo),
+              gt(postMedia.id, expiredCursor),
+            ))
+          .orderBy(asc(postMedia.id))
+          .limit(MEDIA_CLEANUP_BATCH_SIZE);
+
+        if (expiredMedia.length === 0) {
+          break;
+        }
+
+        const lastExpired = expiredMedia[expiredMedia.length - 1];
+        expiredCursor = lastExpired.id;
+
+        const rowsDeleted = await deleteMediaRows(
+          deps.db,
+          expiredMedia,
+          (metadata, message) => jobLogger.error(metadata, message),
+          'Failed to delete media rows from database, continuing',
+        );
+
+        if (!rowsDeleted) {
           continue;
         }
 
-        try {
-          await deps.storage.delete(row.filePath);
-        } catch (storageErr) {
-          jobLogger.error(
-            { err: storageErr, mediaId: row.id, filePath: row.filePath },
-            'Failed to delete file from storage, continuing',
+        deletedExpiredCount += expiredMedia.length;
+
+        for (const row of expiredMedia) {
+          await deleteStorageFiles(
+            deps.storage,
+            row,
+            (metadata, message) => jobLogger.error(metadata, message),
+            {
+              fileFailure: 'Failed to delete file from storage, continuing',
+              thumbnailFailure: 'Failed to delete thumbnail from storage, continuing',
+            },
+          );
+          jobLogger.info(
+            { mediaId: row.id, filePath: row.filePath },
+            'Permanently deleted soft-deleted media',
           );
         }
-
-        if (row.thumbnailPath) {
-          try {
-            await deps.storage.delete(row.thumbnailPath);
-          } catch (storageErr) {
-            jobLogger.error(
-              { err: storageErr, mediaId: row.id, thumbnailPath: row.thumbnailPath },
-              'Failed to delete thumbnail from storage, continuing',
-            );
-          }
-        }
-
-        jobLogger.info(
-          { mediaId: row.id, filePath: row.filePath },
-          'Permanently deleted soft-deleted media',
-        );
       }
 
       // 2. Clean up orphaned uploads older than 24 hours
       const twentyFourHoursAgo = new Date(Date.now() - ORPHAN_THRESHOLD_MS);
-      const orphans = await deps.db.select()
-        .from(postMedia)
-        .where(and(
-          isNull(postMedia.postId),
-          isNull(postMedia.deletedAt),
-          lt(postMedia.createdAt, twentyFourHoursAgo),
-        ));
+      let orphanCursor: string | undefined;
+      let deletedOrphanCount = 0;
 
-      for (const orphan of orphans) {
-        try {
-          await deps.db.delete(postMedia).where(eq(postMedia.id, orphan.id));
-        } catch (dbErr) {
-          jobLogger.error(
-            { err: dbErr, mediaId: orphan.id },
-            'Failed to delete orphan media row from database, continuing',
-          );
+      while (true) {
+        const orphans = await deps.db.select()
+          .from(postMedia)
+          .where(orphanCursor === undefined
+            ? and(
+              isNull(postMedia.postId),
+              isNull(postMedia.deletedAt),
+              lt(postMedia.createdAt, twentyFourHoursAgo),
+            )
+            : and(
+              isNull(postMedia.postId),
+              isNull(postMedia.deletedAt),
+              lt(postMedia.createdAt, twentyFourHoursAgo),
+              gt(postMedia.id, orphanCursor),
+            ))
+          .orderBy(asc(postMedia.id))
+          .limit(MEDIA_CLEANUP_BATCH_SIZE);
+
+        if (orphans.length === 0) {
+          break;
+        }
+
+        const lastOrphan = orphans[orphans.length - 1];
+        orphanCursor = lastOrphan.id;
+
+        const rowsDeleted = await deleteMediaRows(
+          deps.db,
+          orphans,
+          (metadata, message) => jobLogger.error(metadata, message),
+          'Failed to delete orphan media rows from database, continuing',
+        );
+
+        if (!rowsDeleted) {
           continue;
         }
 
-        try {
-          await deps.storage.delete(orphan.filePath);
-        } catch (storageErr) {
-          jobLogger.error(
-            { err: storageErr, mediaId: orphan.id, filePath: orphan.filePath },
-            'Failed to delete orphan file from storage, continuing',
-          );
-        }
+        deletedOrphanCount += orphans.length;
 
-        if (orphan.thumbnailPath) {
-          try {
-            await deps.storage.delete(orphan.thumbnailPath);
-          } catch (storageErr) {
-            jobLogger.error(
-              { err: storageErr, mediaId: orphan.id, thumbnailPath: orphan.thumbnailPath },
-              'Failed to delete orphan thumbnail from storage, continuing',
-            );
-          }
+        for (const orphan of orphans) {
+          await deleteStorageFiles(
+            deps.storage,
+            orphan,
+            (metadata, message) => jobLogger.error(metadata, message),
+            {
+              fileFailure: 'Failed to delete orphan file from storage, continuing',
+              thumbnailFailure: 'Failed to delete orphan thumbnail from storage, continuing',
+            },
+          );
         }
       }
 
       jobLogger.info(
-        { orphanCount: orphans.length },
+        { orphanCount: deletedOrphanCount },
         'Cleaned up orphaned uploads',
       );
 
       jobLogger.info(
-        { deletedExpired: expiredMedia.length, deletedOrphans: orphans.length },
+        { deletedExpired: deletedExpiredCount, deletedOrphans: deletedOrphanCount },
         'Media cleanup job completed',
       );
     },

--- a/packages/worker/src/media-cleanup-worker.ts
+++ b/packages/worker/src/media-cleanup-worker.ts
@@ -47,6 +47,16 @@ export function createMediaCleanupWorker(
 
       for (const row of expiredMedia) {
         try {
+          await deps.db.delete(postMedia).where(eq(postMedia.id, row.id));
+        } catch (dbErr) {
+          jobLogger.error(
+            { err: dbErr, mediaId: row.id },
+            'Failed to delete media row from database, continuing',
+          );
+          continue;
+        }
+
+        try {
           await deps.storage.delete(row.filePath);
         } catch (storageErr) {
           jobLogger.error(
@@ -66,7 +76,6 @@ export function createMediaCleanupWorker(
           }
         }
 
-        await deps.db.delete(postMedia).where(eq(postMedia.id, row.id));
         jobLogger.info(
           { mediaId: row.id, filePath: row.filePath },
           'Permanently deleted soft-deleted media',
@@ -84,6 +93,16 @@ export function createMediaCleanupWorker(
         ));
 
       for (const orphan of orphans) {
+        try {
+          await deps.db.delete(postMedia).where(eq(postMedia.id, orphan.id));
+        } catch (dbErr) {
+          jobLogger.error(
+            { err: dbErr, mediaId: orphan.id },
+            'Failed to delete orphan media row from database, continuing',
+          );
+          continue;
+        }
+
         try {
           await deps.storage.delete(orphan.filePath);
         } catch (storageErr) {
@@ -103,8 +122,6 @@ export function createMediaCleanupWorker(
             );
           }
         }
-
-        await deps.db.delete(postMedia).where(eq(postMedia.id, orphan.id));
       }
 
       jobLogger.info(

--- a/packages/worker/src/media-cleanup-worker.ts
+++ b/packages/worker/src/media-cleanup-worker.ts
@@ -4,9 +4,11 @@
 //   1. Soft-deleted files older than 30 days (deletedAt < 30 days ago)
 //   2. Orphaned uploads with no postId older than 24 hours
 //
-// Both storage backend files and database rows are removed. Storage
-// deletion errors are caught and logged — one unreachable file must
-// not prevent cleanup of the rest (T-06-16).
+// Database rows are removed before storage files so cleanup never leaves a
+// database reference to a missing object. If storage deletion then fails, the
+// file can remain unreachable because the row is gone; that leak is logged and
+// accepted so one unreachable object does not block cleanup of the rest
+// (T-06-16).
 
 import { Worker, Queue, type Job } from 'bullmq';
 import type { Redis } from 'ioredis';
@@ -84,6 +86,23 @@ async function deleteMediaRows(
   }
 }
 
+function logSkippedBatch(
+  rows: MediaCleanupRow[],
+  logWarn: (metadata: Record<string, unknown>, message: string) => void,
+  message: string,
+): void {
+  const firstRow = rows[0];
+  const lastRow = rows[rows.length - 1];
+  logWarn(
+    {
+      firstMediaId: firstRow?.id,
+      lastMediaId: lastRow?.id,
+      mediaCount: rows.length,
+    },
+    message,
+  );
+}
+
 export interface MediaCleanupWorkerDeps {
   redis: Redis;
   db: WorkerDb;
@@ -134,6 +153,11 @@ export function createMediaCleanupWorker(
         );
 
         if (!rowsDeleted) {
+          logSkippedBatch(
+            expiredMedia,
+            (metadata, message) => jobLogger.warn(metadata, message),
+            'Skipping expired media batch after database delete failure',
+          );
           continue;
         }
 
@@ -194,6 +218,11 @@ export function createMediaCleanupWorker(
         );
 
         if (!rowsDeleted) {
+          logSkippedBatch(
+            orphans,
+            (metadata, message) => jobLogger.warn(metadata, message),
+            'Skipping orphan media batch after database delete failure',
+          );
           continue;
         }
 
@@ -208,6 +237,10 @@ export function createMediaCleanupWorker(
               fileFailure: 'Failed to delete orphan file from storage, continuing',
               thumbnailFailure: 'Failed to delete orphan thumbnail from storage, continuing',
             },
+          );
+          jobLogger.info(
+            { mediaId: orphan.id, filePath: orphan.filePath },
+            'Permanently deleted orphaned media',
           );
         }
       }


### PR DESCRIPTION
Closes #18
Closes #16

## Summary
- delete expired media rows before deleting storage objects so DB failures do not orphan state
- batch media cleanup queries/deletes to avoid unbounded N+1 behavior
- apply RoboRev follow-up coverage for worker cleanup edge cases

## Validation
- git diff --check origin/develop..HEAD
- pnpm --filter @sms/shared build
- pnpm --filter @sms/db build
- pnpm --filter @sms/worker exec vitest run src/__tests__/media-cleanup.test.ts --maxWorkers=1
- pnpm --filter @sms/worker typecheck
