### PR TITLE
[codex] Refactor post media uploads and response typing

### DIFF
--- a/.clawpatch/features/feat_gh-22_163c9fcc31.json
+++ b/.clawpatch/features/feat_gh-22_163c9fcc31.json
@@ -1,0 +1,68 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-22_163c9fcc31",
+  "title": "gh#22: Refactor: Extract shared usePostMedia hook from NewPostPage/EditPostPage",
+  "summary": "Imported from GitHub issue gh#22 in BACKLOG.md section \"Refactoring / type safety\".",
+  "kind": "ui-flow",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/web/src/pages/posts/NewPostPage.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/web/src/pages/posts/EditPostPage.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/web/src/pages/posts/NewPostPage.tsx",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/web/src/pages/posts/EditPostPage.tsx",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#22"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#22",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/22",
+    "backlog-order:0050",
+    "backlog-section:refactoring-type-safety"
+  ],
+  "trustBoundaries": [
+    "filesystem"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-22-7d002311ef_9bb9359c10"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260527T040617-93c83b",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#22",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-27T04:06:17.910Z"
+    }
+  ],
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T05:37:42.256Z"
+}

--- a/.clawpatch/features/feat_gh-23_202c2d6672.json
+++ b/.clawpatch/features/feat_gh-23_202c2d6672.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-23_202c2d6672",
+  "title": "gh#23: Type safety: Add media field to Post interface instead of as unknown cast",
+  "summary": "Imported from GitHub issue gh#23 in BACKLOG.md section \"Refactoring / type safety\".",
+  "kind": "ui-flow",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/web/src/hooks/use-posts.ts/",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/web/src/hooks/use-posts.ts/",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#23"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#23",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/23",
+    "backlog-order:0051",
+    "backlog-section:refactoring-type-safety"
+  ],
+  "trustBoundaries": [
+    "network",
+    "filesystem"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-23-1a543eb81a_4eac5ef983"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260527T040617-93c83b",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#23",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-27T04:06:17.910Z"
+    }
+  ],
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T05:47:06.674Z"
+}

--- a/.clawpatch/features/feat_gh-24_bde73fe024.json
+++ b/.clawpatch/features/feat_gh-24_bde73fe024.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-24_bde73fe024",
+  "title": "gh#24: Perf: Upload files concurrently instead of sequentially",
+  "summary": "Imported from GitHub issue gh#24 in BACKLOG.md section \"Performance\".",
+  "kind": "ui-flow",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/web/src/pages/posts/NewPostPage.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/web/src/pages/posts/EditPostPage.tsx",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/web/src/pages/posts/NewPostPage.tsx",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/web/src/pages/posts/EditPostPage.tsx",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#24"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#24",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/24",
+    "backlog-order:0045",
+    "backlog-section:performance"
+  ],
+  "trustBoundaries": [
+    "filesystem",
+    "concurrency"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-24-e0126d09e6_385542f774"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260527T040617-93c83b",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#24",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-27T04:06:17.910Z"
+    }
+  ],
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T04:45:05.718Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-22-7d002311ef_9bb9359c10.json
+++ b/.clawpatch/findings/fnd_sig-gh-22-7d002311ef_9bb9359c10.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-22-7d002311ef_9bb9359c10",
+  "featureId": "feat_gh-22_163c9fcc31",
+  "title": "gh#22: Refactor: Extract shared usePostMedia hook from NewPostPage/EditPostPage",
+  "category": "api-contract",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "contract-mismatch",
+  "evidence": [
+    {
+      "path": "packages/web/src/pages/posts/NewPostPage.tsx",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/web/src/pages/posts/EditPostPage.tsx",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/22.\nBacklog section: Refactoring / type safety.\n\n## Problem\n\n~120 lines of identical media logic duplicated between NewPostPage and EditPostPage: mediaItems state, upload/delete/retry hooks, platform limits, hasTranscodingMedia/hasFailedMedia/isMediaBlocking derived state, all handlers, getSubmitDisabledReason(), and the tooltip-wrapped submit button.\n\n## Identified by\n\nCode quality review Run 3 — web comprehensive review (H-3)\n\n## Fix\n\nExtract a usePostMedia(profileId, platform) custom hook encapsulating all media state, handlers, and derived values. Extract the tooltip-wrapped submit into a shared component.\n\n## Files\n\n- `packages/web/src/pages/posts/NewPostPage.tsx`\n- `packages/web/src/pages/posts/EditPostPage.tsx`",
+  "reproduction": "~120 lines of identical media logic duplicated between NewPostPage and EditPostPage: mediaItems state, upload/delete/retry hooks, platform limits, hasTranscodingMedia/hasFailedMedia/isMediaBlocking derived state, all handlers, getSubmitDisabledReason(), and the tooltip-wrapped submit button.",
+  "recommendation": "Extract a usePostMedia(profileId, platform) custom hook encapsulating all media state, handlers, and derived values. Extract the tooltip-wrapped submit into a shared component.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/web/src/pages/posts/NewPostPage.tsx, packages/web/src/pages/posts/EditPostPage.tsx",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260527T052439-d79612",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence paths still exist. Current NewPostPage.tsx still defines its own mediaItems state/upload/delete/retry hooks, platform limits, blocking derived state, media handlers, getSubmitDisabledReason(), and tooltip-wrapped submit at lines 97-100, 124-135, 167-250, 291-298, and 609-650. EditPostPage.tsx still has the same separate media logic and tooltip submit at lines 88-91, 154-165, 167-252, 254-260, and 686-719. rg found no usePostMedia hook or shared post submit component under packages/web/src/hooks or packages/web/src/components/posts. Focused Vitest could not run in the read-only sandbox because Vite tried to write packages/web/node_modules/.vite-temp/vitest.config... and received EPERM, so tests do not contradict the code evidence.",
+      "commands": [
+        "pwd",
+        "git status --short",
+        "rg --files | rg '(^|/)(NewPostPage|EditPostPage|usePostMedia|PostMedia|Submit).*'",
+        "rg -n \"usePostMedia|mediaItems|setMediaItems|upload|delete|retry|hasTranscodingMedia|hasFailedMedia|isMediaBlocking|getSubmitDisabledReason|Tooltip|submit\" packages/web/src/pages/posts/NewPostPage.tsx packages/web/src/pages/posts/EditPostPage.tsx",
+        "sed -n '1,260p' packages/web/src/pages/posts/NewPostPage.tsx",
+        "sed -n '1,320p' packages/web/src/pages/posts/EditPostPage.tsx",
+        "rg -n \"PostMedia|MediaUpload|usePostMedia|SubmitButton|submit button|disabledReason|isMediaBlocking\" packages/web/src",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '88,250p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '84,260p'",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '286,390p;604,652p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '252,265p;486,494p;682,721p'",
+        "sed -n '1,220p' package.json",
+        "sed -n '1,220p' packages/web/package.json",
+        "rg -n \"NewPostPage|EditPostPage|media|transcoding|failed|tooltip|submit-disabled-reason\" packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "pnpm --filter @sms/web test -- --run packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "rg --files packages/web/src/hooks packages/web/src/components/posts | sort",
+        "rg -n \"usePostMedia|PostSubmit|Submit.*Button|getSubmitDisabledReason|submit-disabled-reason|TooltipProvider\" packages/web/src/hooks packages/web/src/components/posts packages/web/src/pages/posts"
+      ],
+      "createdAt": "2026-05-27T05:25:53.525Z"
+    },
+    {
+      "runId": "20260527T053511-098305",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence paths still exist, but the duplicated media logic has been extracted. NewPostPage.tsx imports usePostMedia and destructures shared media state/handlers at lines 11 and 94-108; EditPostPage.tsx does the same at lines 10 and 84-98. The upload/delete/retry hooks, platform limits, mediaItems state, derived blocking flags, and media handlers now live in packages/web/src/hooks/use-post-media.ts lines 9-135. The tooltip-wrapped submit and getPostSubmitDisabledReason now live in packages/web/src/components/posts/PostSubmitActions.tsx lines 19-105, and both pages render PostSubmitActions. rg found none of the prior duplicate useMediaUpload/useDeleteMedia/useRetryTranscode/PLATFORM_MEDIA_LIMITS/getSubmitDisabledReason/TooltipProvider implementations in the two page files. Focused Vitest could not start in the read-only sandbox because Vite tried to write packages/web/node_modules/.vite-temp/vitest.config... and got EPERM, but the @sms/web no-emit TypeScript check passed.",
+      "commands": [
+        "pwd && git status --short && rg --files | rg '(^|/)(NewPostPage|EditPostPage|usePostMedia|PostMedia|Submit).*'",
+        "rg -n \"usePostMedia|use-post-media|mediaItems|setMediaItems|upload|delete|retry|hasTranscodingMedia|hasFailedMedia|isMediaBlocking|getSubmitDisabledReason|PostSubmitActions|Tooltip|submit\" packages/web/src/pages/posts/NewPostPage.tsx packages/web/src/pages/posts/EditPostPage.tsx packages/web/src/hooks/use-post-media.ts packages/web/src/components/posts/PostSubmitActions.tsx",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '1,260p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '1,280p'",
+        "nl -ba packages/web/src/hooks/use-post-media.ts | sed -n '1,320p'",
+        "nl -ba packages/web/src/components/posts/PostSubmitActions.tsx | sed -n '1,180p'",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '340,535p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '430,610p'",
+        "rg -n \"function getSubmitDisabledReason|const getSubmitDisabledReason|Video is still transcoding|Fix or remove failed media|TooltipProvider|useMediaUpload|useDeleteMedia|useRetryTranscode|PLATFORM_MEDIA_LIMITS|const \\\\[mediaItems\" packages/web/src/pages/posts/NewPostPage.tsx packages/web/src/pages/posts/EditPostPage.tsx",
+        "nl -ba packages/web/src/hooks/__tests__/use-post-media.test.ts | sed -n '1,280p'",
+        "nl -ba packages/web/src/components/posts/__tests__/PostSubmitActions.test.tsx | sed -n '1,260p'",
+        "pnpm --filter @sms/web test --run packages/web/src/hooks/__tests__/use-post-media.test.ts packages/web/src/components/posts/__tests__/PostSubmitActions.test.tsx packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "pnpm --filter @sms/web exec tsc -p tsconfig.app.json --noEmit"
+      ],
+      "createdAt": "2026-05-27T05:37:42.201Z"
+    }
+  ],
+  "signature": "sig_gh-22_7d002311ef",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260527T040617-93c83b",
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T05:37:42.201Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-23-1a543eb81a_4eac5ef983.json
+++ b/.clawpatch/findings/fnd_sig-gh-23-1a543eb81a_4eac5ef983.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-23-1a543eb81a_4eac5ef983",
+  "featureId": "feat_gh-23_202c2d6672",
+  "title": "gh#23: Type safety: Add media field to Post interface instead of as unknown cast",
+  "category": "api-contract",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "contract-mismatch",
+  "evidence": [
+    {
+      "path": "packages/web/src/hooks/use-posts.ts/",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/23.\nBacklog section: Refactoring / type safety.\n\n## Problem\n\nEditPostPage uses \\`post as unknown as { media?: Array<...> }\\` to access the media field on a Post response. The Post interface in use-posts.ts doesn't include media. This defeats the type system and will silently break if the API response shape changes.\n\n## Identified by\n\nCode quality review Run 3 — web comprehensive review (H-2)\n\n## Fix\n\nAdd \\`media?: MediaItem[]\\` to the Post interface in use-posts.ts (or a shared type from @sms/shared).\n\n## Files\n\n- \\`packages/web/src/pages/posts/EditPostPage.tsx:112-129\\`\n- \\`packages/web/src/hooks/use-posts.ts\\`",
+  "reproduction": "EditPostPage uses \\`post as unknown as { media?: Array<...> }\\` to access the media field on a Post response. The Post interface in use-posts.ts doesn't include media. This defeats the type system and will silently break if the API response shape changes.",
+  "recommendation": "Add \\`media?: MediaItem[]\\` to the Post interface in use-posts.ts (or a shared type from @sms/shared).",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/web/src/hooks/use-posts.ts/",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260527T053805-595df1",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The trailing-slash evidence path packages/web/src/hooks/use-posts.ts/ does not exist, but the intended file packages/web/src/hooks/use-posts.ts still exists. Its Post interface at lines 17-37 still has no media field. EditPostPage.tsx still uses post as unknown as { media?: Array<...> } at lines 136-145 and then reads postWithMedia.media at lines 146-148. The API still returns a media field from getPostById in packages/api/src/services/post-crud.service.ts:590, so the type contract mismatch remains open. A direct web app tsc check passed, which is consistent with the unsafe cast hiding the mismatch. The package typecheck and focused Vitest run could not complete under the current read-only sandbox because they attempted to write tsbuildinfo/Vite temp files.",
+      "commands": [
+        "sed -n '1,220p' /Users/slaughterassistant/.codex/skills/clawpatch-fix-loop/SKILL.md",
+        "git status --short",
+        "rg --files | rg 'packages/web/src/(hooks/use-posts|pages/posts/EditPostPage)\\\\.tsx?$|package\\\\.json$|pnpm-lock\\\\.yaml$|yarn\\\\.lock$|package-lock\\\\.json$'",
+        "rg -n \"as unknown as|interface Post|type Post|media\\\\??:|MediaItem|post\\\\.media|\\\\.media\" packages/web/src packages/shared src 2>/dev/null",
+        "nl -ba packages/web/src/hooks/use-posts.ts | sed -n '1,140p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '1,220p'",
+        "test -e packages/web/src/hooks/use-posts.ts/ && printf exists || printf missing; printf '\\\\n'; test -f packages/web/src/hooks/use-posts.ts && printf file-exists || printf file-missing",
+        "sed -n '1,220p' package.json; sed -n '1,220p' packages/web/package.json",
+        "nl -ba packages/web/src/hooks/use-posts.ts | sed -n '140,320p'",
+        "rg --files packages/web | rg 'tsconfig|vitest|vite\\\\.config|__tests__|\\\\.test\\\\.'",
+        "sed -n '1,220p' packages/web/tsconfig.json; sed -n '1,220p' packages/web/tsconfig.app.json 2>/dev/null; sed -n '1,220p' packages/web/tsconfig.node.json 2>/dev/null",
+        "rg -n \"PostListItem|postListItemSchema|media\" packages/shared/src/schemas/posts.ts packages/api/src packages/web/src/hooks/use-posts.ts packages/web/src/pages/posts/EditPostPage.tsx",
+        "nl -ba packages/shared/src/schemas/posts.ts | sed -n '250,310p'",
+        "nl -ba packages/web/src/components/posts/MediaThumbnail.tsx | sed -n '1,50p'",
+        "nl -ba packages/api/src/services/post-crud.service.ts | sed -n '560,600p'",
+        "pnpm --filter @sms/web typecheck",
+        "pnpm --filter @sms/web exec tsc -p tsconfig.app.json --noEmit --pretty false",
+        "pnpm --filter @sms/web test -- --run src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "pnpm --filter @sms/web exec vitest --help | rg -n \"configLoader|cache|run\"",
+        "pnpm --filter @sms/web exec vitest run --configLoader runner src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "pnpm --filter @sms/web exec vitest run --configLoader native src/pages/posts/__tests__/EditPostPage.test.tsx"
+      ],
+      "createdAt": "2026-05-27T05:40:01.470Z"
+    },
+    {
+      "runId": "20260527T054454-a852cd",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original trailing-slash evidence path still does not exist, but the intended file does. In current packages/web/src/hooks/use-posts.ts, Post imports MediaItem and includes media?: MediaItem[] at line 35, and usePost still returns apiClient.get<Post>. In current EditPostPage.tsx, the previous postWithMedia/media?: Array<...> unknown cast is gone; media hydration now reads post.media directly at lines 136-138. The remaining post as unknown as cast at lines 112-115 is only for visibility/linkUrl and is outside this finding. The API still returns media from getPostById at packages/api/src/services/post-crud.service.ts:590, so the Post contract now covers that field. Direct app TypeScript validation passed. Package typecheck was blocked by read-only sandbox tsbuildinfo writes, and focused Vitest was blocked by the existing ESM __dirname config startup error, not by this media typing change.",
+      "commands": [
+        "git status --short",
+        "test -e packages/web/src/hooks/use-posts.ts/ && printf 'evidence-path-exists\\n' || printf 'evidence-path-missing\\n'; test -f packages/web/src/hooks/use-posts.ts && printf 'intended-file-exists\\n' || printf 'intended-file-missing\\n'; test -f packages/web/src/pages/posts/EditPostPage.tsx && printf 'edit-page-exists\\n' || printf 'edit-page-missing\\n'",
+        "rg --files | rg 'packages/web/src/(hooks/use-posts|pages/posts/EditPostPage)\\.tsx?$|packages/shared/src/schemas/posts\\.ts|packages/api/src/services/post-crud\\.service\\.ts|packages/web/package\\.json|package\\.json'",
+        "nl -ba packages/web/src/hooks/use-posts.ts | sed -n '1,220p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '1,240p'",
+        "rg -n \"as unknown as|interface Post|type Post|media\\??:|MediaItem|postWithMedia|post\\.media|\\.media\" packages/web/src/hooks/use-posts.ts packages/web/src/pages/posts/EditPostPage.tsx packages/shared/src/schemas/posts.ts packages/api/src/services/post-crud.service.ts",
+        "sed -n '1,220p' package.json",
+        "sed -n '1,220p' packages/web/package.json",
+        "git diff -- packages/web/src/hooks/use-posts.ts packages/web/src/pages/posts/EditPostPage.tsx .clawpatch/findings/fnd_sig-gh-23-1a543eb81a_4eac5ef983.json | sed -n '1,240p'",
+        "rg --files packages/web/src | rg 'EditPostPage.*\\.test\\.(ts|tsx)$|__tests__/.*EditPostPage'",
+        "pnpm --filter @sms/web exec tsc -p tsconfig.app.json --noEmit --pretty false",
+        "nl -ba packages/api/src/services/post-crud.service.ts | sed -n '560,600p'",
+        "pnpm --filter @sms/web exec vitest run --configLoader native src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "nl -ba packages/web/vitest.config.ts | sed -n '1,80p'",
+        "pnpm --filter @sms/web exec vitest run --configLoader runner src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "pnpm --filter @sms/web typecheck",
+        "rg -n -C 4 \"postWithMedia|media\\?: Array|post\\.media|as unknown as\" packages/web/src/pages/posts/EditPostPage.tsx",
+        "nl -ba packages/web/src/components/posts/MediaThumbnail.tsx | sed -n '1,80p'",
+        "rg -n \"interface Post|media\\?: MediaItem\\[\\]|usePost\\(|apiClient\\.get<Post>|export type \\{ Post\" packages/web/src/hooks/use-posts.ts"
+      ],
+      "createdAt": "2026-05-27T05:47:06.620Z"
+    }
+  ],
+  "signature": "sig_gh-23_1a543eb81a",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-23-1a543eb81a-4eac5ef_e1a1735975"
+  ],
+  "createdByRunId": "20260527T040617-93c83b",
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T05:47:06.620Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-24-e0126d09e6_385542f774.json
+++ b/.clawpatch/findings/fnd_sig-gh-24-e0126d09e6_385542f774.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-24-e0126d09e6_385542f774",
+  "featureId": "feat_gh-24_bde73fe024",
+  "title": "gh#24: Perf: Upload files concurrently instead of sequentially",
+  "category": "performance",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "packages/web/src/pages/posts/NewPostPage.tsx",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/web/src/pages/posts/EditPostPage.tsx",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/24.\nBacklog section: Performance.\n\n## Problem\n\nWhen a user drops 4 images, they upload one at a time in a for loop. Each file waits for the previous to complete. useMediaUpload already tracks per-file state via tempId, so parallel uploads would work.\n\n## Identified by\n\nCode quality review Run 3 — web comprehensive review (M-1)\n\n## Fix\n\nReplace sequential for loop with Promise.allSettled (or Promise.all with per-file error handling).\n\n## Files\n\n- \\`packages/web/src/pages/posts/NewPostPage.tsx:143\\`\n- \\`packages/web/src/pages/posts/EditPostPage.tsx:163\\`",
+  "reproduction": "When a user drops 4 images, they upload one at a time in a for loop. Each file waits for the previous to complete. useMediaUpload already tracks per-file state via tempId, so parallel uploads would work.",
+  "recommendation": "Replace sequential for loop with Promise.allSettled (or Promise.all with per-file error handling).",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/web/src/pages/posts/NewPostPage.tsx, packages/web/src/pages/posts/EditPostPage.tsx",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260527T043142-27fb2d",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence paths still exist. The specific line numbers have moved, but both upload handlers are still sequential: packages/web/src/pages/posts/NewPostPage.tsx:170-172 and packages/web/src/pages/posts/EditPostPage.tsx:170-172 both loop over files and await upload(...) inside the loop. There is no Promise.all or Promise.allSettled in those handlers, and useMediaUpload still tracks each upload with its own tempId, so the reported parallelization opportunity remains valid. Existing page tests do not cover multi-file upload concurrency. I attempted the focused Vitest run, but it could not start in this read-only sandbox because Vite tried to write packages/web/node_modules/.vite-temp.",
+      "commands": [
+        "rg -n \"for \\(|for await|Promise\\.all|Promise\\.allSettled|upload\" packages/web/src/pages/posts/NewPostPage.tsx packages/web/src/pages/posts/EditPostPage.tsx",
+        "sed -n '1,260p' packages/web/src/pages/posts/NewPostPage.tsx",
+        "sed -n '1,300p' packages/web/src/pages/posts/EditPostPage.tsx",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '160,192p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '160,192p'",
+        "sed -n '1,260p' packages/web/src/hooks/use-media-upload.ts",
+        "rg -n \"Promise\\.all(Settled)?|handleFilesSelected|for \\(const file of files\\)|upload\\(file\" packages/web/src -g '*.tsx' -g '*.ts'",
+        "cat packages/web/package.json",
+        "rg -n \"handleFilesSelected|useMediaUpload|MediaDropZone|uploadingFiles\" packages/web/src -g '*.{test,spec}.{ts,tsx}' -g '*.{test,spec}.ts' -g '*.{test,spec}.tsx'",
+        "pnpm --filter @sms/web test -- --run packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx"
+      ],
+      "createdAt": "2026-05-27T04:32:41.989Z"
+    },
+    {
+      "runId": "20260527T044235-3f12a7",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence paths still exist. The upload handlers have moved to packages/web/src/pages/posts/NewPostPage.tsx:167 and packages/web/src/pages/posts/EditPostPage.tsx:167, and both now call Promise.allSettled over files.map((file) => upload(...)), so selected files are started concurrently instead of awaiting each upload in sequence. A repo-wide search found no remaining sequential await upload loop for this flow; the only remaining for-of over files is validation in MediaDropZone, not upload execution. Focused regression tests now exist at packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx:261 and packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx:220, asserting two selected uploads are started before either promise is resolved. I attempted to run the focused Vitest tests, but this read-only sandbox prevented Vite/Vitest temp file creation with EPERM, so execution could not complete here.",
+      "commands": [
+        "rg -n \"for \\(|for await|Promise\\.all|Promise\\.allSettled|upload\\(|handleFilesSelected|useMediaUpload\" packages/web/src/pages/posts/NewPostPage.tsx packages/web/src/pages/posts/EditPostPage.tsx",
+        "nl -ba packages/web/src/pages/posts/NewPostPage.tsx | sed -n '130,210p'",
+        "nl -ba packages/web/src/pages/posts/EditPostPage.tsx | sed -n '145,220p'",
+        "rg -n \"Promise\\.allSettled|allSettled|concurrent|handleFilesSelected|useMediaUpload|upload\\(\" packages/web/src -g '*.{test,spec}.{ts,tsx}' -g '*.{test,spec}.ts' -g '*.{test,spec}.tsx'",
+        "rg -n \"Promise\\.allSettled|for \\(const file of files\\)|files\\.map\\(\\(file\\) => upload|await upload\\(\" packages/web/src/pages/posts packages/web/src/hooks -g '*.ts' -g '*.tsx'",
+        "sed -n '1,260p' packages/web/src/hooks/use-media-upload.ts",
+        "nl -ba packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx | sed -n '240,310p'",
+        "nl -ba packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx | sed -n '200,270p'",
+        "pnpm --filter @sms/web test -- --run packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "pnpm exec vitest run --configLoader runner src/pages/posts/__tests__/NewPostPage.test.tsx src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "NODE_OPTIONS=\"--import=data:text/javascript,globalThis.__dirname='/Users/slaughterassistant/social-media-scheduler-backlog-sync/packages/web'\" pnpm exec vitest run --configLoader runner src/pages/posts/__tests__/NewPostPage.test.tsx src/pages/posts/__tests__/EditPostPage.test.tsx",
+        "rg -n \"for \\(const file of files\\)|for await|await upload\\(|files\\.map\\(\\(file\\) => upload\\(|Promise\\.allSettled\\(\" packages/web/src -g '*.ts' -g '*.tsx'",
+        "nl -ba packages/web/src/components/posts/MediaDropZone.tsx | sed -n '35,85p'"
+      ],
+      "createdAt": "2026-05-27T04:45:05.678Z"
+    }
+  ],
+  "signature": "sig_gh-24_e0126d09e6",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-24-e0126d09e6-385542f_f24bf582fa"
+  ],
+  "createdByRunId": "20260527T040617-93c83b",
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T04:45:05.678Z"
+}

--- a/packages/web/src/components/posts/PostSubmitActions.tsx
+++ b/packages/web/src/components/posts/PostSubmitActions.tsx
@@ -1,0 +1,105 @@
+import type { ReactNode } from 'react';
+import type { Platform } from '../../hooks/use-profiles';
+import { Button } from '../ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '../ui/tooltip';
+import { SplitButton } from './SplitButton';
+
+const URL_REGEX = /^https?:\/\/.+/i;
+export const INVALID_POST_LINK_URL_MESSAGE = 'Enter a valid http or https URL.';
+
+export function isPostLinkUrlValid(linkUrl: string) {
+  return URL_REGEX.test(linkUrl);
+}
+
+export function getPostSubmitDisabledReason({
+  hasTranscodingMedia,
+  hasFailedMedia,
+  platform,
+  linkUrl,
+}: {
+  hasTranscodingMedia: boolean;
+  hasFailedMedia: boolean;
+  platform: Platform;
+  linkUrl: string;
+}): string | null {
+  if (hasTranscodingMedia) return 'Video is still transcoding.';
+  if (hasFailedMedia) return 'Fix or remove failed media before submitting.';
+  if (platform === 'facebook' && linkUrl && !isPostLinkUrlValid(linkUrl)) {
+    return INVALID_POST_LINK_URL_MESSAGE;
+  }
+  return null;
+}
+
+type PostSubmitActionsProps = {
+  disabled: boolean;
+  disabledReason: string | null;
+} & (
+  | {
+      mode: 'queue';
+      isSaving: boolean;
+      onSubmit: () => void;
+    }
+  | {
+      mode: 'split';
+      isLoading: boolean;
+      onDraft: () => void;
+      onPrimary: () => void;
+      primaryLabel?: string;
+    }
+);
+
+export function PostSubmitActions(props: PostSubmitActionsProps) {
+  const disabled = props.disabled || !!props.disabledReason;
+  const submitContent = props.mode === 'queue' ? (
+    <Button onClick={props.onSubmit} disabled={disabled}>
+      {props.isSaving ? 'Saving...' : 'Save to Queue'}
+    </Button>
+  ) : (
+    <SplitButton
+      onPrimary={props.onPrimary}
+      onDraft={props.onDraft}
+      primaryLabel={props.primaryLabel}
+      isLoading={props.isLoading}
+      disabled={disabled}
+    />
+  );
+
+  return (
+    <SubmitDisabledTooltip disabledReason={props.disabledReason}>
+      {submitContent}
+    </SubmitDisabledTooltip>
+  );
+}
+
+function SubmitDisabledTooltip({
+  disabledReason,
+  children,
+}: {
+  disabledReason: string | null;
+  children: ReactNode;
+}) {
+  if (!disabledReason) return <>{children}</>;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span aria-describedby="submit-disabled-reason">
+            {children}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{disabledReason}</p>
+        </TooltipContent>
+      </Tooltip>
+      <span id="submit-disabled-reason" className="sr-only">
+        {disabledReason}
+      </span>
+    </TooltipProvider>
+  );
+}

--- a/packages/web/src/components/posts/PostSubmitActions.tsx
+++ b/packages/web/src/components/posts/PostSubmitActions.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useId, type ReactNode } from 'react';
 import type { Platform } from '../../hooks/use-profiles';
 import { Button } from '../ui/button';
 import {
@@ -83,13 +83,15 @@ function SubmitDisabledTooltip({
   disabledReason: string | null;
   children: ReactNode;
 }) {
+  const disabledReasonId = useId();
+
   if (!disabledReason) return <>{children}</>;
 
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span aria-describedby="submit-disabled-reason">
+          <span aria-describedby={disabledReasonId}>
             {children}
           </span>
         </TooltipTrigger>
@@ -97,7 +99,7 @@ function SubmitDisabledTooltip({
           <p>{disabledReason}</p>
         </TooltipContent>
       </Tooltip>
-      <span id="submit-disabled-reason" className="sr-only">
+      <span id={disabledReasonId} className="sr-only">
         {disabledReason}
       </span>
     </TooltipProvider>

--- a/packages/web/src/components/posts/__tests__/PostSubmitActions.test.tsx
+++ b/packages/web/src/components/posts/__tests__/PostSubmitActions.test.tsx
@@ -54,6 +54,38 @@ describe('PostSubmitActions', () => {
     expect(screen.getByText('Video is still transcoding.')).toBeInTheDocument();
   });
 
+  it('uses a unique disabled reason id for each rendered action group', () => {
+    render(
+      <>
+        <PostSubmitActions
+          mode="queue"
+          onSubmit={vi.fn()}
+          isSaving={false}
+          disabled={false}
+          disabledReason="Video is still transcoding."
+        />
+        <PostSubmitActions
+          mode="queue"
+          onSubmit={vi.fn()}
+          isSaving={false}
+          disabled={false}
+          disabledReason="Video is still transcoding."
+        />
+      </>,
+    );
+
+    const describedByIds = screen
+      .getAllByRole('button', { name: 'Save to Queue' })
+      .map((button) => button.closest('[aria-describedby]')?.getAttribute('aria-describedby'));
+
+    expect(describedByIds).toHaveLength(2);
+    expect(new Set(describedByIds).size).toBe(2);
+    describedByIds.forEach((id) => {
+      expect(id).toBeTruthy();
+      expect(document.getElementById(id as string)).toHaveTextContent('Video is still transcoding.');
+    });
+  });
+
   it('renders split actions enabled when there is no disabled reason', async () => {
     const user = userEvent.setup();
     const onDraft = vi.fn();

--- a/packages/web/src/components/posts/__tests__/PostSubmitActions.test.tsx
+++ b/packages/web/src/components/posts/__tests__/PostSubmitActions.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  INVALID_POST_LINK_URL_MESSAGE,
+  PostSubmitActions,
+  getPostSubmitDisabledReason,
+} from '../PostSubmitActions';
+
+describe('getPostSubmitDisabledReason', () => {
+  it('prioritizes blocking media before Facebook link validation', () => {
+    expect(
+      getPostSubmitDisabledReason({
+        hasTranscodingMedia: true,
+        hasFailedMedia: false,
+        platform: 'facebook',
+        linkUrl: 'not-a-url',
+      }),
+    ).toBe('Video is still transcoding.');
+
+    expect(
+      getPostSubmitDisabledReason({
+        hasTranscodingMedia: false,
+        hasFailedMedia: true,
+        platform: 'facebook',
+        linkUrl: 'not-a-url',
+      }),
+    ).toBe('Fix or remove failed media before submitting.');
+
+    expect(
+      getPostSubmitDisabledReason({
+        hasTranscodingMedia: false,
+        hasFailedMedia: false,
+        platform: 'facebook',
+        linkUrl: 'not-a-url',
+      }),
+    ).toBe(INVALID_POST_LINK_URL_MESSAGE);
+  });
+});
+
+describe('PostSubmitActions', () => {
+  it('wraps disabled submit actions with an accessible disabled reason', () => {
+    render(
+      <PostSubmitActions
+        mode="queue"
+        onSubmit={vi.fn()}
+        isSaving={false}
+        disabled={false}
+        disabledReason="Video is still transcoding."
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Save to Queue' })).toBeDisabled();
+    expect(screen.getByText('Video is still transcoding.')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/posts/__tests__/PostSubmitActions.test.tsx
+++ b/packages/web/src/components/posts/__tests__/PostSubmitActions.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import {
   INVALID_POST_LINK_URL_MESSAGE,
@@ -51,5 +52,45 @@ describe('PostSubmitActions', () => {
 
     expect(screen.getByRole('button', { name: 'Save to Queue' })).toBeDisabled();
     expect(screen.getByText('Video is still transcoding.')).toBeInTheDocument();
+  });
+
+  it('renders split actions enabled when there is no disabled reason', async () => {
+    const user = userEvent.setup();
+    const onDraft = vi.fn();
+    const onPrimary = vi.fn();
+    render(
+      <PostSubmitActions
+        mode="split"
+        onPrimary={onPrimary}
+        onDraft={onDraft}
+        primaryLabel="Update Queued Post"
+        isLoading={false}
+        disabled={false}
+        disabledReason={null}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Update Queued Post' }));
+    expect(onPrimary).toHaveBeenCalledOnce();
+
+    await user.click(screen.getByRole('button', { name: 'More options' }));
+    await user.click(await screen.findByText('Save as Draft'));
+    expect(onDraft).toHaveBeenCalledOnce();
+    expect(document.querySelector('#submit-disabled-reason')).toBeNull();
+  });
+
+  it('does not render tooltip plumbing without a disabled reason', () => {
+    render(
+      <PostSubmitActions
+        mode="queue"
+        onSubmit={vi.fn()}
+        isSaving={false}
+        disabled={false}
+        disabledReason={null}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Save to Queue' })).toBeEnabled();
+    expect(document.querySelector('#submit-disabled-reason')).toBeNull();
   });
 });

--- a/packages/web/src/hooks/__tests__/use-post-media.test.ts
+++ b/packages/web/src/hooks/__tests__/use-post-media.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePostMedia } from '../use-post-media';
+
+const mocks = vi.hoisted(() => ({
+  upload: vi.fn(),
+  deleteMedia: vi.fn(),
+  retryTranscode: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock('../use-media-upload', () => ({
+  useMediaUpload: () => ({
+    upload: mocks.upload,
+    uploadingFiles: new Map(),
+    isUploading: false,
+  }),
+}));
+
+vi.mock('../use-media', () => ({
+  useDeleteMedia: () => ({ mutate: mocks.deleteMedia }),
+  useRetryTranscode: () => ({ mutate: mocks.retryTranscode }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('usePostMedia', () => {
+  it('derives platform limits and media blocking state from media items', () => {
+    const { result } = renderHook(() => usePostMedia('profile-1', 'twitter'));
+
+    expect(result.current.maxFilesForPlatform).toBe(4);
+
+    act(() => {
+      result.current.setMediaItems([
+        {
+          id: 'media-1',
+          fileName: 'video.mp4',
+          mimeType: 'video/mp4',
+          thumbnailUrl: null,
+          transcodeStatus: 'pending',
+          transcodeError: null,
+        },
+      ]);
+    });
+
+    expect(result.current.maxFilesForPlatform).toBe(1);
+    expect(result.current.hasTranscodingMedia).toBe(true);
+    expect(result.current.isMediaBlocking).toBe(true);
+
+    act(() => {
+      result.current.handleMediaStatusUpdate('media-1', 'completed', null);
+    });
+
+    expect(result.current.hasTranscodingMedia).toBe(false);
+    expect(result.current.isMediaBlocking).toBe(false);
+  });
+
+  it('uploads selected files concurrently and appends successful media', async () => {
+    const resolvers: Array<() => void> = [];
+    mocks.upload.mockImplementation((file: File) =>
+      new Promise((resolve) => {
+        const mediaNumber = resolvers.length + 1;
+        resolvers.push(() =>
+          resolve({
+            id: `media-${mediaNumber}`,
+            fileName: file.name,
+            mimeType: file.type,
+            fileSize: file.size,
+            thumbnailUrl: null,
+            transcodeStatus: 'completed',
+          }),
+        );
+      }),
+    );
+    const { result } = renderHook(() => usePostMedia('profile-1', 'twitter'));
+
+    await act(async () => {
+      const uploadPromise = result.current.handleFilesSelected([
+        new File(['first'], 'first.png', { type: 'image/png' }),
+        new File(['second'], 'second.png', { type: 'image/png' }),
+      ]);
+
+      expect(mocks.upload).toHaveBeenCalledTimes(2);
+      expect(mocks.upload.mock.calls.map(([file]) => (file as File).name)).toEqual([
+        'first.png',
+        'second.png',
+      ]);
+
+      resolvers.forEach((resolve) => resolve());
+      await uploadPromise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.mediaItems.map((item) => item.fileName)).toEqual([
+        'first.png',
+        'second.png',
+      ]);
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/src/hooks/__tests__/use-post-media.test.ts
+++ b/packages/web/src/hooks/__tests__/use-post-media.test.ts
@@ -76,14 +76,13 @@ describe('usePostMedia', () => {
     expect(result.current.isMediaBlocking).toBe(false);
   });
 
-  it('uploads selected files concurrently and appends successful media', async () => {
-    const resolvers: Array<() => void> = [];
+  it('uploads selected files concurrently and appends successful media in selection order', async () => {
+    const resolvers = new Map<string, () => void>();
     mocks.upload.mockImplementation((file: File) =>
       new Promise((resolve) => {
-        const mediaNumber = resolvers.length + 1;
-        resolvers.push(() =>
+        resolvers.set(file.name, () =>
           resolve({
-            id: `media-${mediaNumber}`,
+            id: `media-${file.name}`,
             fileName: file.name,
             mimeType: file.type,
             fileSize: file.size,
@@ -95,8 +94,9 @@ describe('usePostMedia', () => {
     );
     const { result } = renderHook(() => usePostMedia('profile-1', 'twitter'));
 
-    await act(async () => {
-      const uploadPromise = result.current.handleFilesSelected([
+    let uploadPromise!: Promise<void>;
+    act(() => {
+      uploadPromise = result.current.handleFilesSelected([
         new File(['first'], 'first.png', { type: 'image/png' }),
         new File(['second'], 'second.png', { type: 'image/png' }),
       ]);
@@ -106,8 +106,17 @@ describe('usePostMedia', () => {
         'first.png',
         'second.png',
       ]);
+    });
 
-      resolvers.forEach((resolve) => resolve());
+    await act(async () => {
+      resolvers.get('second.png')?.();
+      await Promise.resolve();
+    });
+    expect(result.current.mediaItems).toEqual([]);
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolvers.get('first.png')?.();
       await uploadPromise;
     });
 

--- a/packages/web/src/hooks/__tests__/use-post-media.test.ts
+++ b/packages/web/src/hooks/__tests__/use-post-media.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePostMedia } from '../use-post-media';
+import type { MediaItem } from '../../components/posts/MediaThumbnail';
 
 const mocks = vi.hoisted(() => ({
   upload: vi.fn(),
@@ -31,10 +32,22 @@ vi.mock('sonner', () => ({
 }));
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
 });
 
 describe('usePostMedia', () => {
+  function mediaItem(overrides: Partial<MediaItem> = {}): MediaItem {
+    return {
+      id: 'media-1',
+      fileName: 'media.png',
+      mimeType: 'image/png',
+      thumbnailUrl: null,
+      transcodeStatus: 'completed',
+      transcodeError: null,
+      ...overrides,
+    };
+  }
+
   it('derives platform limits and media blocking state from media items', () => {
     const { result } = renderHook(() => usePostMedia('profile-1', 'twitter'));
 
@@ -42,14 +55,12 @@ describe('usePostMedia', () => {
 
     act(() => {
       result.current.setMediaItems([
-        {
+        mediaItem({
           id: 'media-1',
           fileName: 'video.mp4',
           mimeType: 'video/mp4',
-          thumbnailUrl: null,
           transcodeStatus: 'pending',
-          transcodeError: null,
-        },
+        }),
       ]);
     });
 
@@ -107,5 +118,143 @@ describe('usePostMedia', () => {
       ]);
     });
     expect(mocks.toastSuccess).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows upload errors without appending failed media', async () => {
+    mocks.upload
+      .mockResolvedValueOnce({
+        id: 'media-1',
+        fileName: 'first.png',
+        mimeType: 'image/png',
+        thumbnailUrl: null,
+        transcodeStatus: 'completed',
+      })
+      .mockRejectedValueOnce(new Error('network down'));
+    const { result } = renderHook(() => usePostMedia('profile-1', 'twitter'));
+
+    await act(async () => {
+      await result.current.handleFilesSelected([
+        new File(['first'], 'first.png', { type: 'image/png' }),
+        new File(['second'], 'second.png', { type: 'image/png' }),
+      ]);
+    });
+
+    expect(result.current.mediaItems.map((item) => item.fileName)).toEqual(['first.png']);
+    expect(mocks.toastSuccess).toHaveBeenCalledOnce();
+    expect(mocks.toastError).toHaveBeenCalledWith('Upload failed: network down');
+  });
+
+  it('removes media after the delete mutation succeeds and reports delete errors', () => {
+    const { result } = renderHook(() => usePostMedia('profile-1', 'twitter'));
+
+    act(() => {
+      result.current.setMediaItems([
+        mediaItem({ id: 'media-1', fileName: 'first.png' }),
+        mediaItem({ id: 'media-2', fileName: 'second.png' }),
+      ]);
+    });
+
+    act(() => {
+      result.current.handleRemoveMedia('media-1');
+    });
+
+    expect(mocks.deleteMedia).toHaveBeenCalledWith('media-1', expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    }));
+
+    act(() => {
+      mocks.deleteMedia.mock.calls[0][1].onSuccess();
+    });
+
+    expect(result.current.mediaItems.map((item) => item.id)).toEqual(['media-2']);
+
+    act(() => {
+      result.current.handleRemoveMedia('media-2');
+      mocks.deleteMedia.mock.calls[1][1].onError(new Error('delete failed'));
+    });
+
+    expect(mocks.toastError).toHaveBeenCalledWith('delete failed');
+  });
+
+  it('reorders media and ignores missing ids', () => {
+    const { result } = renderHook(() => usePostMedia('profile-1', 'twitter'));
+
+    act(() => {
+      result.current.setMediaItems([
+        mediaItem({ id: 'media-1', fileName: 'first.png' }),
+        mediaItem({ id: 'media-2', fileName: 'second.png' }),
+      ]);
+      result.current.handleReorderMedia(['media-2', 'missing', 'media-1']);
+    });
+
+    expect(result.current.mediaItems.map((item) => item.id)).toEqual(['media-2', 'media-1']);
+  });
+
+  it('retries failed transcodes and reports retry errors', () => {
+    const { result } = renderHook(() => usePostMedia('profile-1', 'twitter'));
+
+    act(() => {
+      result.current.setMediaItems([
+        mediaItem({
+          id: 'media-1',
+          fileName: 'video.mp4',
+          mimeType: 'video/mp4',
+          transcodeStatus: 'failed',
+          transcodeError: 'codec failed',
+        }),
+      ]);
+      result.current.handleRetryTranscode('media-1');
+    });
+
+    expect(mocks.retryTranscode).toHaveBeenCalledWith('media-1', expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    }));
+
+    act(() => {
+      mocks.retryTranscode.mock.calls[0][1].onSuccess();
+    });
+
+    expect(result.current.mediaItems[0]).toMatchObject({
+      transcodeStatus: 'pending',
+      transcodeError: null,
+    });
+
+    act(() => {
+      result.current.handleRetryTranscode('media-1');
+      mocks.retryTranscode.mock.calls[1][1].onError(new Error('retry failed'));
+    });
+
+    expect(mocks.toastError).toHaveBeenCalledWith('retry failed');
+  });
+
+  it('does not replace media when a status update is unchanged', () => {
+    const { result } = renderHook(() => usePostMedia('profile-1', 'twitter'));
+    const originalItem = mediaItem({
+      id: 'media-1',
+      transcodeStatus: 'completed',
+      transcodeError: null,
+    });
+
+    act(() => {
+      result.current.setMediaItems([originalItem]);
+    });
+
+    act(() => {
+      result.current.handleMediaStatusUpdate('media-1', 'completed', null);
+    });
+
+    expect(result.current.mediaItems[0]).toBe(originalItem);
+
+    act(() => {
+      result.current.handleMediaStatusUpdate('media-1', 'failed', 'transcode failed');
+    });
+
+    expect(result.current.mediaItems[0]).not.toBe(originalItem);
+    expect(result.current.mediaItems[0]).toMatchObject({
+      transcodeStatus: 'failed',
+      transcodeError: 'transcode failed',
+    });
   });
 });

--- a/packages/web/src/hooks/use-post-media.ts
+++ b/packages/web/src/hooks/use-post-media.ts
@@ -28,32 +28,26 @@ export function usePostMedia(profileId: string, platform: Platform) {
   const handleFilesSelected = useCallback(
     async (files: File[]) => {
       if (!profileId || !platform) return;
-      const uploadResults = await Promise.allSettled(
-        files.map((file) => upload(file, profileId, platform)),
+      await Promise.all(
+        files.map(async (file) => {
+          try {
+            const response = await upload(file, profileId, platform);
+            const uploadedMediaItem: MediaItem = {
+              id: response.id,
+              fileName: response.fileName,
+              mimeType: response.mimeType,
+              thumbnailUrl: response.thumbnailUrl,
+              transcodeStatus: response.transcodeStatus,
+              transcodeError: null,
+            };
+            setMediaItems((prev) => [...prev, uploadedMediaItem]);
+            toast.success('File uploaded.');
+          } catch (uploadError) {
+            const errorMessage = uploadError instanceof Error ? uploadError.message : 'Upload failed';
+            toast.error(`Upload failed: ${errorMessage}`);
+          }
+        }),
       );
-      const uploadedMediaItems: MediaItem[] = [];
-
-      for (const result of uploadResults) {
-        if (result.status === 'fulfilled') {
-          const response = result.value;
-          uploadedMediaItems.push({
-            id: response.id,
-            fileName: response.fileName,
-            mimeType: response.mimeType,
-            thumbnailUrl: response.thumbnailUrl,
-            transcodeStatus: response.transcodeStatus,
-            transcodeError: null,
-          });
-          toast.success('File uploaded.');
-        } else {
-          const errorMessage = result.reason instanceof Error ? result.reason.message : 'Upload failed';
-          toast.error(`Upload failed: ${errorMessage}`);
-        }
-      }
-
-      if (uploadedMediaItems.length > 0) {
-        setMediaItems((prev) => [...prev, ...uploadedMediaItems]);
-      }
     },
     [platform, profileId, upload],
   );

--- a/packages/web/src/hooks/use-post-media.ts
+++ b/packages/web/src/hooks/use-post-media.ts
@@ -1,0 +1,136 @@
+import { useCallback, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { PLATFORM_MEDIA_LIMITS } from '@sms/shared';
+import type { MediaItem } from '../components/posts/MediaThumbnail';
+import { useDeleteMedia, useRetryTranscode } from './use-media';
+import { useMediaUpload } from './use-media-upload';
+import type { Platform } from './use-profiles';
+
+export function usePostMedia(profileId: string, platform: Platform) {
+  const [mediaItems, setMediaItems] = useState<MediaItem[]>([]);
+  const { upload, uploadingFiles, isUploading } = useMediaUpload();
+  const { mutate: deleteMedia } = useDeleteMedia();
+  const { mutate: retryTranscode } = useRetryTranscode();
+
+  const maxFilesForPlatform = useMemo(() => {
+    const platformLimits = PLATFORM_MEDIA_LIMITS[platform];
+    if (!platformLimits) return 4;
+    const hasVideo = mediaItems.some((m) => m.mimeType.startsWith('video/'));
+    return hasVideo ? platformLimits.maxVideos : platformLimits.maxImages;
+  }, [mediaItems, platform]);
+
+  const hasTranscodingMedia = mediaItems.some(
+    (m) => m.transcodeStatus === 'pending' || m.transcodeStatus === 'processing',
+  );
+  const hasFailedMedia = mediaItems.some((m) => m.transcodeStatus === 'failed');
+  const isMediaBlocking = hasTranscodingMedia || hasFailedMedia;
+
+  const handleFilesSelected = useCallback(
+    async (files: File[]) => {
+      if (!profileId || !platform) return;
+      const uploadResults = await Promise.allSettled(
+        files.map((file) => upload(file, profileId, platform)),
+      );
+      const uploadedMediaItems: MediaItem[] = [];
+
+      for (const result of uploadResults) {
+        if (result.status === 'fulfilled') {
+          const response = result.value;
+          uploadedMediaItems.push({
+            id: response.id,
+            fileName: response.fileName,
+            mimeType: response.mimeType,
+            thumbnailUrl: response.thumbnailUrl,
+            transcodeStatus: response.transcodeStatus,
+            transcodeError: null,
+          });
+          toast.success('File uploaded.');
+        } else {
+          const errorMessage = result.reason instanceof Error ? result.reason.message : 'Upload failed';
+          toast.error(`Upload failed: ${errorMessage}`);
+        }
+      }
+
+      if (uploadedMediaItems.length > 0) {
+        setMediaItems((prev) => [...prev, ...uploadedMediaItems]);
+      }
+    },
+    [platform, profileId, upload],
+  );
+
+  const handleRemoveMedia = useCallback(
+    (mediaId: string) => {
+      deleteMedia(mediaId, {
+        onSuccess: () => {
+          setMediaItems((prev) => prev.filter((m) => m.id !== mediaId));
+        },
+        onError: (error) => {
+          toast.error(error instanceof Error ? error.message : 'Failed to remove media.');
+        },
+      });
+    },
+    [deleteMedia],
+  );
+
+  const handleReorderMedia = useCallback((newOrder: string[]) => {
+    setMediaItems((prev) => {
+      const itemMap = new Map(prev.map((m) => [m.id, m]));
+      return newOrder.map((id) => itemMap.get(id)).filter((m): m is MediaItem => m !== undefined);
+    });
+  }, []);
+
+  const handleRetryTranscode = useCallback(
+    (mediaId: string) => {
+      retryTranscode(mediaId, {
+        onSuccess: () => {
+          setMediaItems((prev) =>
+            prev.map((m) =>
+              m.id === mediaId
+                ? { ...m, transcodeStatus: 'pending' as const, transcodeError: null }
+                : m,
+            ),
+          );
+        },
+        onError: (error) => {
+          toast.error(error instanceof Error ? error.message : 'Retry failed.');
+        },
+      });
+    },
+    [retryTranscode],
+  );
+
+  const handleMediaStatusUpdate = useCallback(
+    (
+      mediaId: string,
+      status: MediaItem['transcodeStatus'],
+      error: string | null,
+    ) => {
+      setMediaItems((prev) =>
+        prev.map((m) => {
+          if (m.id !== mediaId) return m;
+          if (m.transcodeStatus === status && m.transcodeError === error) {
+            return m;
+          }
+          return { ...m, transcodeStatus: status, transcodeError: error };
+        }),
+      );
+    },
+    [],
+  );
+
+  return {
+    mediaItems,
+    setMediaItems,
+    uploadingFiles,
+    isUploading,
+    maxFilesForPlatform,
+    hasTranscodingMedia,
+    hasFailedMedia,
+    isMediaBlocking,
+    handleFilesSelected,
+    handleRemoveMedia,
+    handleReorderMedia,
+    handleRetryTranscode,
+    handleMediaStatusUpdate,
+  };
+}

--- a/packages/web/src/hooks/use-post-media.ts
+++ b/packages/web/src/hooks/use-post-media.ts
@@ -6,6 +6,10 @@ import { useDeleteMedia, useRetryTranscode } from './use-media';
 import { useMediaUpload } from './use-media-upload';
 import type { Platform } from './use-profiles';
 
+type UploadResult =
+  | { status: 'success'; mediaItem: MediaItem }
+  | { status: 'error'; errorMessage: string };
+
 export function usePostMedia(profileId: string, platform: Platform) {
   const [mediaItems, setMediaItems] = useState<MediaItem[]>([]);
   const { upload, uploadingFiles, isUploading } = useMediaUpload();
@@ -28,7 +32,7 @@ export function usePostMedia(profileId: string, platform: Platform) {
   const handleFilesSelected = useCallback(
     async (files: File[]) => {
       if (!profileId || !platform) return;
-      await Promise.all(
+      const uploadResults: UploadResult[] = await Promise.all(
         files.map(async (file) => {
           try {
             const response = await upload(file, profileId, platform);
@@ -40,14 +44,28 @@ export function usePostMedia(profileId: string, platform: Platform) {
               transcodeStatus: response.transcodeStatus,
               transcodeError: null,
             };
-            setMediaItems((prev) => [...prev, uploadedMediaItem]);
-            toast.success('File uploaded.');
+            return { status: 'success', mediaItem: uploadedMediaItem };
           } catch (uploadError) {
             const errorMessage = uploadError instanceof Error ? uploadError.message : 'Upload failed';
-            toast.error(`Upload failed: ${errorMessage}`);
+            return { status: 'error', errorMessage };
           }
         }),
       );
+
+      const uploadedMediaItems = uploadResults.flatMap((result) =>
+        result.status === 'success' ? [result.mediaItem] : [],
+      );
+      if (uploadedMediaItems.length > 0) {
+        setMediaItems((prev) => [...prev, ...uploadedMediaItems]);
+      }
+
+      uploadResults.forEach((result) => {
+        if (result.status === 'success') {
+          toast.success('File uploaded.');
+        } else {
+          toast.error(`Upload failed: ${result.errorMessage}`);
+        }
+      });
     },
     [platform, profileId, upload],
   );

--- a/packages/web/src/hooks/use-posts.ts
+++ b/packages/web/src/hooks/use-posts.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../lib/api-client';
 import type { CreatePostInput, UpdatePostInput } from '@sms/shared';
+import type { MediaItem } from '../components/posts/MediaThumbnail';
 
 interface PostTag {
   id: string;
@@ -31,6 +32,7 @@ interface Post {
   createdAt: string;
   updatedAt: string;
   tags: PostTag[];
+  media?: MediaItem[];
   profile?: PostProfile;
   headline?: string;
   rank?: number;

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -133,24 +133,14 @@ export default function EditPostPage() {
       }
       setIsFormInitialized(true);
 
-      const postWithMedia = post as unknown as {
-        media?: Array<{
-          id: string;
-          fileName: string;
-          mimeType: string;
-          thumbnailUrl: string | null;
-          transcodeStatus: string;
-          transcodeError: string | null;
-        }>;
-      };
-      if (postWithMedia.media && Array.isArray(postWithMedia.media)) {
+      if (post.media && Array.isArray(post.media)) {
         setMediaItems(
-          postWithMedia.media.map((m) => ({
+          post.media.map((m) => ({
             id: m.id,
             fileName: m.fileName,
             mimeType: m.mimeType,
             thumbnailUrl: m.thumbnailUrl,
-            transcodeStatus: m.transcodeStatus as MediaItem['transcodeStatus'],
+            transcodeStatus: m.transcodeStatus,
             transcodeError: m.transcodeError,
           })),
         );

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -167,25 +167,31 @@ export default function EditPostPage() {
   const handleFilesSelected = useCallback(
     async (files: File[]) => {
       if (!formState.platform || !formState.profileId) return;
-      for (const file of files) {
-        try {
-          const response = await upload(file, formState.profileId, formState.platform);
-          setMediaItems((prev) => [
-            ...prev,
-            {
-              id: response.id,
-              fileName: response.fileName,
-              mimeType: response.mimeType,
-              thumbnailUrl: response.thumbnailUrl,
-              transcodeStatus: response.transcodeStatus,
-              transcodeError: null,
-            },
-          ]);
+      const uploadResults = await Promise.allSettled(
+        files.map((file) => upload(file, formState.profileId, formState.platform)),
+      );
+      const uploadedMediaItems: MediaItem[] = [];
+
+      for (const result of uploadResults) {
+        if (result.status === 'fulfilled') {
+          const response = result.value;
+          uploadedMediaItems.push({
+            id: response.id,
+            fileName: response.fileName,
+            mimeType: response.mimeType,
+            thumbnailUrl: response.thumbnailUrl,
+            transcodeStatus: response.transcodeStatus,
+            transcodeError: null,
+          });
           toast.success('File uploaded.');
-        } catch (uploadError) {
-          const errorMessage = uploadError instanceof Error ? uploadError.message : 'Upload failed';
+        } else {
+          const errorMessage = result.reason instanceof Error ? result.reason.message : 'Upload failed';
           toast.error(`Upload failed: ${errorMessage}`);
         }
+      }
+
+      if (uploadedMediaItems.length > 0) {
+        setMediaItems((prev) => [...prev, ...uploadedMediaItems]);
       }
     },
     [formState.platform, formState.profileId, upload],

--- a/packages/web/src/pages/posts/EditPostPage.tsx
+++ b/packages/web/src/pages/posts/EditPostPage.tsx
@@ -2,13 +2,12 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router';
 import { DateTime } from 'luxon';
 import { toast } from 'sonner';
-import { EDITABLE_STATES, PLATFORM_MEDIA_LIMITS, type PostStatus } from '@sms/shared';
+import { EDITABLE_STATES, type PostStatus } from '@sms/shared';
 import type { Platform } from '../../hooks/use-profiles';
 import { useAuth } from '../../hooks/use-auth';
 import { useProfiles } from '../../hooks/use-profiles';
 import { usePost, useUpdatePost } from '../../hooks/use-posts';
-import { useMediaUpload } from '../../hooks/use-media-upload';
-import { useDeleteMedia, useRetryTranscode } from '../../hooks/use-media';
+import { usePostMedia } from '../../hooks/use-post-media';
 import { serializeThread, deserializeThread, type TweetSegment } from '../../lib/thread';
 import { ProfilePicker } from '../../components/posts/ProfilePicker';
 import { SharedPostFields } from '../../components/posts/SharedPostFields';
@@ -19,23 +18,20 @@ import { TweetPreview } from '../../components/posts/TweetPreview';
 import { LinkedInPreview } from '../../components/posts/LinkedInPreview';
 import { FacebookPreview } from '../../components/posts/FacebookPreview';
 import { CharacterCountRing } from '../../components/posts/CharacterCountRing';
-import { SplitButton } from '../../components/posts/SplitButton';
 import { TagManagementDialog } from '../../components/posts/TagManagementDialog';
 import { RateLimitBanner } from '../../components/posts/RateLimitBanner';
 import { RateLimitSettingsDialog } from '../../components/profiles/RateLimitSettingsDialog';
 import type { MediaItem } from '../../components/posts/MediaThumbnail';
+import {
+  INVALID_POST_LINK_URL_MESSAGE,
+  PostSubmitActions,
+  getPostSubmitDisabledReason,
+  isPostLinkUrlValid,
+} from '../../components/posts/PostSubmitActions';
 import { Textarea } from '../../components/ui/textarea';
 import { Label } from '../../components/ui/label';
 import { Button } from '../../components/ui/button';
 import { Skeleton } from '../../components/ui/skeleton';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '../../components/ui/tooltip';
-
-const URL_REGEX = /^https?:\/\/.+/i;
 
 interface EditFormState {
   platform: Platform;
@@ -85,10 +81,21 @@ export default function EditPostPage() {
   const scheduleInputRef = useRef<HTMLInputElement>(null);
   const [scheduledAtError, setScheduledAtError] = useState<string | null>(null);
 
-  const [mediaItems, setMediaItems] = useState<MediaItem[]>([]);
-  const { upload, uploadingFiles, isUploading } = useMediaUpload();
-  const deleteMediaMutation = useDeleteMedia();
-  const retryTranscodeMutation = useRetryTranscode();
+  const {
+    mediaItems,
+    setMediaItems,
+    uploadingFiles,
+    isUploading,
+    maxFilesForPlatform,
+    hasTranscodingMedia,
+    hasFailedMedia,
+    isMediaBlocking,
+    handleFilesSelected,
+    handleRemoveMedia,
+    handleReorderMedia,
+    handleRetryTranscode,
+    handleMediaStatusUpdate,
+  } = usePostMedia(formState.profileId, formState.platform);
 
   const updateForm = useCallback(
     <K extends keyof EditFormState>(key: K, value: EditFormState[K]) => {
@@ -149,116 +156,7 @@ export default function EditPostPage() {
         );
       }
     }
-  }, [post, profiles, isFormInitialized]);
-
-  const platformLimits = PLATFORM_MEDIA_LIMITS[formState.platform];
-  const maxFilesForPlatform = (() => {
-    if (!platformLimits) return 4;
-    const hasVideo = mediaItems.some((m) => m.mimeType.startsWith('video/'));
-    return hasVideo ? platformLimits.maxVideos : platformLimits.maxImages;
-  })();
-
-  const hasTranscodingMedia = mediaItems.some(
-    (m) => m.transcodeStatus === 'pending' || m.transcodeStatus === 'processing',
-  );
-  const hasFailedMedia = mediaItems.some((m) => m.transcodeStatus === 'failed');
-  const isMediaBlocking = hasTranscodingMedia || hasFailedMedia;
-
-  const handleFilesSelected = useCallback(
-    async (files: File[]) => {
-      if (!formState.platform || !formState.profileId) return;
-      const uploadResults = await Promise.allSettled(
-        files.map((file) => upload(file, formState.profileId, formState.platform)),
-      );
-      const uploadedMediaItems: MediaItem[] = [];
-
-      for (const result of uploadResults) {
-        if (result.status === 'fulfilled') {
-          const response = result.value;
-          uploadedMediaItems.push({
-            id: response.id,
-            fileName: response.fileName,
-            mimeType: response.mimeType,
-            thumbnailUrl: response.thumbnailUrl,
-            transcodeStatus: response.transcodeStatus,
-            transcodeError: null,
-          });
-          toast.success('File uploaded.');
-        } else {
-          const errorMessage = result.reason instanceof Error ? result.reason.message : 'Upload failed';
-          toast.error(`Upload failed: ${errorMessage}`);
-        }
-      }
-
-      if (uploadedMediaItems.length > 0) {
-        setMediaItems((prev) => [...prev, ...uploadedMediaItems]);
-      }
-    },
-    [formState.platform, formState.profileId, upload],
-  );
-
-  function handleRemoveMedia(mediaId: string) {
-    deleteMediaMutation.mutate(mediaId, {
-      onSuccess: () => {
-        setMediaItems((prev) => prev.filter((m) => m.id !== mediaId));
-      },
-      onError: (error) => {
-        toast.error(error instanceof Error ? error.message : 'Failed to remove media.');
-      },
-    });
-  }
-
-  function handleReorderMedia(newOrder: string[]) {
-    setMediaItems((prev) => {
-      const itemMap = new Map(prev.map((m) => [m.id, m]));
-      return newOrder.map((id) => itemMap.get(id)).filter((m): m is MediaItem => m !== undefined);
-    });
-  }
-
-  function handleRetryTranscode(mediaId: string) {
-    retryTranscodeMutation.mutate(mediaId, {
-      onSuccess: () => {
-        setMediaItems((prev) =>
-          prev.map((m) =>
-            m.id === mediaId
-              ? { ...m, transcodeStatus: 'pending' as const, transcodeError: null }
-              : m,
-          ),
-        );
-      },
-      onError: (error) => {
-        toast.error(error instanceof Error ? error.message : 'Retry failed.');
-      },
-    });
-  }
-
-  const handleMediaStatusUpdate = useCallback(
-    (
-      mediaId: string,
-      status: MediaItem['transcodeStatus'],
-      error: string | null,
-    ) => {
-      setMediaItems((prev) =>
-        prev.map((m) => {
-          if (m.id !== mediaId) return m;
-          if (m.transcodeStatus === status && m.transcodeError === error) {
-            return m;
-          }
-          return { ...m, transcodeStatus: status, transcodeError: error };
-        }),
-      );
-    },
-    [],
-  );
-
-  function getSubmitDisabledReason(): string | null {
-    if (hasTranscodingMedia) return 'Video is still transcoding.';
-    if (hasFailedMedia) return 'Fix or remove failed media before submitting.';
-    if (formState.platform === 'facebook' && formState.linkUrl && !URL_REGEX.test(formState.linkUrl)) {
-      return 'Enter a valid http or https URL.';
-    }
-    return null;
-  }
+  }, [post, profiles, isFormInitialized, setMediaItems]);
 
   const hasLinkedProfile = !!post?.profileId;
   const isEditable = post ? hasLinkedProfile && EDITABLE_STATES.includes(post.status as PostStatus) : false;
@@ -547,6 +445,12 @@ export default function EditPostPage() {
   const previewVideoUrl = mediaItems.find((m) => m.mimeType.startsWith('video/'))?.thumbnailUrl ?? null;
   const primaryAction = post.status === 'queued' ? 'keepQueued' : 'schedule';
   const primaryLabel = primaryAction === 'keepQueued' ? 'Update Queued Post' : 'Schedule Post';
+  const submitDisabledReason = getPostSubmitDisabledReason({
+    hasTranscodingMedia,
+    hasFailedMedia,
+    platform: formState.platform,
+    linkUrl: formState.linkUrl,
+  });
 
   return (
     <main className="px-4 py-6 sm:px-6 lg:px-8">
@@ -641,8 +545,8 @@ export default function EditPostPage() {
                 linkUrl={formState.linkUrl}
                 onLinkUrlChange={(value) => updateForm('linkUrl', value)}
                 linkUrlError={
-                  formState.linkUrl && !URL_REGEX.test(formState.linkUrl)
-                    ? 'Enter a valid http or https URL.'
+                  formState.linkUrl && !isPostLinkUrlValid(formState.linkUrl)
+                    ? INVALID_POST_LINK_URL_MESSAGE
                     : null
                 }
                 mediaItems={mediaItems}
@@ -682,42 +586,15 @@ export default function EditPostPage() {
           />
 
           {/* SplitButton — Update as primary, Save as Draft in dropdown */}
-          {(() => {
-            const disabledReason = getSubmitDisabledReason();
-            const scheduleDisabled = updatePostMutation.isPending || isUploading || !!disabledReason;
-
-            const submitContent = (
-              <SplitButton
-                onPrimary={() => handleSubmit(primaryAction)}
-                onDraft={() => handleSubmit('draft')}
-                primaryLabel={primaryLabel}
-                isLoading={updatePostMutation.isPending}
-                disabled={scheduleDisabled}
-              />
-            );
-
-            if (disabledReason) {
-              return (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span aria-describedby="submit-disabled-reason">
-                        {submitContent}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{disabledReason}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <span id="submit-disabled-reason" className="sr-only">
-                    {disabledReason}
-                  </span>
-                </TooltipProvider>
-              );
-            }
-
-            return submitContent;
-          })()}
+          <PostSubmitActions
+            mode="split"
+            onPrimary={() => handleSubmit(primaryAction)}
+            onDraft={() => handleSubmit('draft')}
+            primaryLabel={primaryLabel}
+            isLoading={updatePostMutation.isPending}
+            disabled={updatePostMutation.isPending || isUploading}
+            disabledReason={submitDisabledReason}
+          />
         </div>
 
         {/* Right column: live preview */}

--- a/packages/web/src/pages/posts/NewPostPage.tsx
+++ b/packages/web/src/pages/posts/NewPostPage.tsx
@@ -359,7 +359,7 @@ export default function NewPostPage() {
   const submitDisabledReason = getPostSubmitDisabledReason({
     hasTranscodingMedia,
     hasFailedMedia,
-    platform: formState.platform,
+    platform,
     linkUrl: formState.linkUrl,
   });
 

--- a/packages/web/src/pages/posts/NewPostPage.tsx
+++ b/packages/web/src/pages/posts/NewPostPage.tsx
@@ -167,25 +167,31 @@ export default function NewPostPage() {
   const handleFilesSelected = useCallback(
     async (files: File[]) => {
       if (!platform) return;
-      for (const file of files) {
-        try {
-          const response = await upload(file, effectiveProfileId, platform);
-          setMediaItems((prev) => [
-            ...prev,
-            {
-              id: response.id,
-              fileName: response.fileName,
-              mimeType: response.mimeType,
-              thumbnailUrl: response.thumbnailUrl,
-              transcodeStatus: response.transcodeStatus,
-              transcodeError: null,
-            },
-          ]);
+      const uploadResults = await Promise.allSettled(
+        files.map((file) => upload(file, effectiveProfileId, platform)),
+      );
+      const uploadedMediaItems: MediaItem[] = [];
+
+      for (const result of uploadResults) {
+        if (result.status === 'fulfilled') {
+          const response = result.value;
+          uploadedMediaItems.push({
+            id: response.id,
+            fileName: response.fileName,
+            mimeType: response.mimeType,
+            thumbnailUrl: response.thumbnailUrl,
+            transcodeStatus: response.transcodeStatus,
+            transcodeError: null,
+          });
           toast.success('File uploaded.');
-        } catch (uploadError) {
-          const errorMessage = uploadError instanceof Error ? uploadError.message : 'Upload failed';
+        } else {
+          const errorMessage = result.reason instanceof Error ? result.reason.message : 'Upload failed';
           toast.error(`Upload failed: ${errorMessage}`);
         }
+      }
+
+      if (uploadedMediaItems.length > 0) {
+        setMediaItems((prev) => [...prev, ...uploadedMediaItems]);
       }
     },
     [effectiveProfileId, platform, upload],

--- a/packages/web/src/pages/posts/NewPostPage.tsx
+++ b/packages/web/src/pages/posts/NewPostPage.tsx
@@ -2,15 +2,13 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import { DateTime } from 'luxon';
 import { toast } from 'sonner';
-import { PLATFORM_MEDIA_LIMITS } from '@sms/shared';
 import type { Platform } from '../../hooks/use-profiles';
 import { useAuth } from '../../hooks/use-auth';
 import { useProfiles } from '../../hooks/use-profiles';
 import { useCreatePost } from '../../hooks/use-posts';
 import { useQueue } from '../../hooks/use-queues';
 import { useAddToQueue } from '../../hooks/use-queue-posts';
-import { useMediaUpload } from '../../hooks/use-media-upload';
-import { useDeleteMedia, useRetryTranscode } from '../../hooks/use-media';
+import { usePostMedia } from '../../hooks/use-post-media';
 import { applyPlatformSwitch } from '../../lib/apply-platform-switch';
 import { serializeThread, deserializeThread, type TweetSegment } from '../../lib/thread';
 import { ProfilePicker } from '../../components/posts/ProfilePicker';
@@ -22,24 +20,20 @@ import { TweetPreview } from '../../components/posts/TweetPreview';
 import { LinkedInPreview } from '../../components/posts/LinkedInPreview';
 import { FacebookPreview } from '../../components/posts/FacebookPreview';
 import { CharacterCountRing } from '../../components/posts/CharacterCountRing';
-import { SplitButton } from '../../components/posts/SplitButton';
 import { TagManagementDialog } from '../../components/posts/TagManagementDialog';
 import { RateLimitBanner } from '../../components/posts/RateLimitBanner';
 import { RateLimitBlockError, type RateLimitBlockErrorDetail } from '../../components/posts/RateLimitBlockError';
 import { RateLimitSettingsDialog } from '../../components/profiles/RateLimitSettingsDialog';
-import type { MediaItem } from '../../components/posts/MediaThumbnail';
-import { Button } from '../../components/ui/button';
+import {
+  INVALID_POST_LINK_URL_MESSAGE,
+  PostSubmitActions,
+  getPostSubmitDisabledReason,
+  isPostLinkUrlValid,
+} from '../../components/posts/PostSubmitActions';
 import { Textarea } from '../../components/ui/textarea';
 import { Label } from '../../components/ui/label';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '../../components/ui/tooltip';
 
 const SPINNABLE_PATTERN = /\{[^{}|]+\|[^{}|]+\}/;
-const URL_REGEX = /^https?:\/\/.+/i;
 
 interface PostFormState {
   platform: Platform;
@@ -94,10 +88,24 @@ export default function NewPostPage() {
   const scheduleInputRef = useRef<HTMLInputElement>(null);
   const [scheduledAtError, setScheduledAtError] = useState<string | null>(null);
 
-  const [mediaItems, setMediaItems] = useState<MediaItem[]>([]);
-  const { upload, uploadingFiles, isUploading } = useMediaUpload();
-  const deleteMediaMutation = useDeleteMedia();
-  const retryTranscodeMutation = useRetryTranscode();
+  const effectiveProfileId = isQueueMode ? (queueData?.profileId ?? '') : formState.profileId;
+  const selectedProfile = profiles?.find((p) => p.id === effectiveProfileId) ?? null;
+  const platform = selectedProfile?.platform ?? formState.platform;
+  const {
+    mediaItems,
+    setMediaItems,
+    uploadingFiles,
+    isUploading,
+    maxFilesForPlatform,
+    hasTranscodingMedia,
+    hasFailedMedia,
+    isMediaBlocking,
+    handleFilesSelected,
+    handleRemoveMedia,
+    handleReorderMedia,
+    handleRetryTranscode,
+    handleMediaStatusUpdate,
+  } = usePostMedia(effectiveProfileId, platform);
 
   const updateForm = useCallback(<K extends keyof PostFormState>(key: K, value: PostFormState[K]) => {
     setFormState((prev) => ({ ...prev, [key]: value }));
@@ -116,23 +124,6 @@ export default function NewPostPage() {
     if (!DateTime.fromISO(scheduledAtParam).isValid) return;
     updateForm('scheduledAt', scheduledAtParam);
   }, [formState.scheduledAt, queueId, scheduledAtParam, updateForm]);
-
-  const effectiveProfileId = isQueueMode ? (queueData?.profileId ?? '') : formState.profileId;
-  const selectedProfile = profiles?.find((p) => p.id === effectiveProfileId) ?? null;
-  const platform = selectedProfile?.platform ?? formState.platform;
-
-  const platformLimits = PLATFORM_MEDIA_LIMITS[platform];
-  const maxFilesForPlatform = (() => {
-    if (!platformLimits) return 4;
-    const hasVideo = mediaItems.some((m) => m.mimeType.startsWith('video/'));
-    return hasVideo ? platformLimits.maxVideos : platformLimits.maxImages;
-  })();
-
-  const hasTranscodingMedia = mediaItems.some(
-    (m) => m.transcodeStatus === 'pending' || m.transcodeStatus === 'processing',
-  );
-  const hasFailedMedia = mediaItems.some((m) => m.transcodeStatus === 'failed');
-  const isMediaBlocking = hasTranscodingMedia || hasFailedMedia;
 
   function handleProfileChange(profileId: string, newPlatform: Platform) {
     const oldPlatform = formState.platform;
@@ -163,93 +154,6 @@ export default function NewPostPage() {
     }
     if (result.toast) toast.info(result.toast);
   }
-
-  const handleFilesSelected = useCallback(
-    async (files: File[]) => {
-      if (!platform) return;
-      const uploadResults = await Promise.allSettled(
-        files.map((file) => upload(file, effectiveProfileId, platform)),
-      );
-      const uploadedMediaItems: MediaItem[] = [];
-
-      for (const result of uploadResults) {
-        if (result.status === 'fulfilled') {
-          const response = result.value;
-          uploadedMediaItems.push({
-            id: response.id,
-            fileName: response.fileName,
-            mimeType: response.mimeType,
-            thumbnailUrl: response.thumbnailUrl,
-            transcodeStatus: response.transcodeStatus,
-            transcodeError: null,
-          });
-          toast.success('File uploaded.');
-        } else {
-          const errorMessage = result.reason instanceof Error ? result.reason.message : 'Upload failed';
-          toast.error(`Upload failed: ${errorMessage}`);
-        }
-      }
-
-      if (uploadedMediaItems.length > 0) {
-        setMediaItems((prev) => [...prev, ...uploadedMediaItems]);
-      }
-    },
-    [effectiveProfileId, platform, upload],
-  );
-
-  function handleRemoveMedia(mediaId: string) {
-    deleteMediaMutation.mutate(mediaId, {
-      onSuccess: () => {
-        setMediaItems((prev) => prev.filter((m) => m.id !== mediaId));
-      },
-      onError: (error) => {
-        toast.error(error instanceof Error ? error.message : 'Failed to remove media.');
-      },
-    });
-  }
-
-  function handleReorderMedia(newOrder: string[]) {
-    setMediaItems((prev) => {
-      const itemMap = new Map(prev.map((m) => [m.id, m]));
-      return newOrder.map((id) => itemMap.get(id)).filter((m): m is MediaItem => m !== undefined);
-    });
-  }
-
-  function handleRetryTranscode(mediaId: string) {
-    retryTranscodeMutation.mutate(mediaId, {
-      onSuccess: () => {
-        setMediaItems((prev) =>
-          prev.map((m) =>
-            m.id === mediaId
-              ? { ...m, transcodeStatus: 'pending' as const, transcodeError: null }
-              : m,
-          ),
-        );
-      },
-      onError: (error) => {
-        toast.error(error instanceof Error ? error.message : 'Retry failed.');
-      },
-    });
-  }
-
-  const handleMediaStatusUpdate = useCallback(
-    (
-      mediaId: string,
-      status: MediaItem['transcodeStatus'],
-      error: string | null,
-    ) => {
-      setMediaItems((prev) =>
-        prev.map((m) => {
-          if (m.id !== mediaId) return m;
-          if (m.transcodeStatus === status && m.transcodeError === error) {
-            return m;
-          }
-          return { ...m, transcodeStatus: status, transcodeError: error };
-        }),
-      );
-    },
-    [],
-  );
 
   function handleThreadToggle(checked: boolean) {
     if (checked) {
@@ -287,15 +191,6 @@ export default function NewPostPage() {
   }
 
   const isSubmitting = createPostMutation.isPending || addToQueueMutation.isPending || isUploading;
-
-  function getSubmitDisabledReason(): string | null {
-    if (hasTranscodingMedia) return 'Video is still transcoding.';
-    if (hasFailedMedia) return 'Fix or remove failed media before submitting.';
-    if (formState.platform === 'facebook' && formState.linkUrl && !URL_REGEX.test(formState.linkUrl)) {
-      return 'Enter a valid http or https URL.';
-    }
-    return null;
-  }
 
   function buildBasePayload(text: string) {
     return {
@@ -461,6 +356,12 @@ export default function NewPostPage() {
     .filter((m) => m.mimeType.startsWith('image/'))
     .map((m) => m.thumbnailUrl ?? '');
   const previewVideoUrl = mediaItems.find((m) => m.mimeType.startsWith('video/'))?.thumbnailUrl ?? null;
+  const submitDisabledReason = getPostSubmitDisabledReason({
+    hasTranscodingMedia,
+    hasFailedMedia,
+    platform: formState.platform,
+    linkUrl: formState.linkUrl,
+  });
 
   return (
     <main className="px-4 py-6 sm:px-6 lg:px-8">
@@ -558,8 +459,8 @@ export default function NewPostPage() {
                 linkUrl={formState.linkUrl}
                 onLinkUrlChange={(value) => updateForm('linkUrl', value)}
                 linkUrlError={
-                  formState.linkUrl && !URL_REGEX.test(formState.linkUrl)
-                    ? 'Enter a valid http or https URL.'
+                  formState.linkUrl && !isPostLinkUrlValid(formState.linkUrl)
+                    ? INVALID_POST_LINK_URL_MESSAGE
                     : null
                 }
                 mediaItems={mediaItems}
@@ -605,50 +506,24 @@ export default function NewPostPage() {
           )}
 
           {/* POST-CMN-06: Save as Draft is delivered by SplitButton's draft option. */}
-          {(() => {
-            const disabledReason = getSubmitDisabledReason();
-            const scheduleDisabled = isSubmitting || !!disabledReason;
-
-            const submitContent = isQueueMode ? (
-              <Button
-                onClick={() => validateAndSubmit('queue')}
-                disabled={scheduleDisabled}
-              >
-                {createPostMutation.isPending || addToQueueMutation.isPending
-                  ? 'Saving...'
-                  : 'Save to Queue'}
-              </Button>
-            ) : (
-              <SplitButton
-                onPrimary={() => validateAndSubmit('schedule')}
-                onDraft={() => validateAndSubmit('draft')}
-                isLoading={createPostMutation.isPending}
-                disabled={scheduleDisabled}
-              />
-            );
-
-            if (disabledReason) {
-              return (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span aria-describedby="submit-disabled-reason">
-                        {submitContent}
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{disabledReason}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <span id="submit-disabled-reason" className="sr-only">
-                    {disabledReason}
-                  </span>
-                </TooltipProvider>
-              );
-            }
-
-            return submitContent;
-          })()}
+          {isQueueMode ? (
+            <PostSubmitActions
+              mode="queue"
+              onSubmit={() => validateAndSubmit('queue')}
+              isSaving={createPostMutation.isPending || addToQueueMutation.isPending}
+              disabled={isSubmitting}
+              disabledReason={submitDisabledReason}
+            />
+          ) : (
+            <PostSubmitActions
+              mode="split"
+              onPrimary={() => validateAndSubmit('schedule')}
+              onDraft={() => validateAndSubmit('draft')}
+              isLoading={createPostMutation.isPending}
+              disabled={isSubmitting}
+              disabledReason={submitDisabledReason}
+            />
+          )}
         </div>
 
         {/* Right column: live preview */}

--- a/packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx
@@ -1,12 +1,14 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import EditPostPage from '../EditPostPage';
 
 const navigate = vi.fn();
 const updatePostMutate = vi.fn();
+const uploadMedia = vi.fn();
 const mocks = vi.hoisted(() => ({
   post: {
     id: 'post-1',
@@ -70,7 +72,7 @@ vi.mock('../../../hooks/use-posts', () => ({
 
 vi.mock('../../../hooks/use-media-upload', () => ({
   useMediaUpload: () => ({
-    upload: vi.fn(),
+    upload: uploadMedia,
     uploadingFiles: new Map(),
     isUploading: false,
   }),
@@ -89,15 +91,30 @@ vi.mock('../../../components/posts/TwitterPostFields', () => ({
   TwitterPostFields: ({
     text,
     onTextChange,
+    onFilesSelected,
   }: {
     text: string;
     onTextChange: (value: string) => void;
+    onFilesSelected: (files: File[]) => void;
   }) => (
-    <textarea
-      aria-label="Tweet text"
-      value={text}
-      onChange={(event) => onTextChange(event.target.value)}
-    />
+    <div>
+      <textarea
+        aria-label="Tweet text"
+        value={text}
+        onChange={(event) => onTextChange(event.target.value)}
+      />
+      <button
+        type="button"
+        onClick={() =>
+          onFilesSelected([
+            new File(['first'], 'first.png', { type: 'image/png' }),
+            new File(['second'], 'second.png', { type: 'image/png' }),
+          ])
+        }
+      >
+        Add two images
+      </button>
+    </div>
   ),
 }));
 
@@ -198,5 +215,37 @@ describe('EditPostPage', () => {
     });
     expect(mutationInput.postInput).not.toHaveProperty('status');
     expect(mutationInput.postInput).not.toHaveProperty('scheduledAt');
+  });
+
+  it('starts selected media uploads concurrently', async () => {
+    const user = userEvent.setup();
+    const resolvers: Array<() => void> = [];
+    uploadMedia.mockImplementation((file: File) => {
+      const response = {
+        id: `media-${resolvers.length + 1}`,
+        fileName: file.name,
+        mimeType: file.type,
+        thumbnailUrl: null,
+        transcodeStatus: 'completed',
+      };
+
+      return new Promise((resolve) => {
+        resolvers.push(() => resolve(response));
+      });
+    });
+    renderPage();
+
+    await screen.findByDisplayValue('Queued import with typo');
+    await user.click(screen.getByRole('button', { name: 'Add two images' }));
+
+    expect(uploadMedia).toHaveBeenCalledTimes(2);
+    expect(uploadMedia.mock.calls.map(([file]) => (file as File).name)).toEqual([
+      'first.png',
+      'second.png',
+    ]);
+
+    resolvers.forEach((resolve) => resolve());
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(2));
   });
 });

--- a/packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/EditPostPage.test.tsx
@@ -182,7 +182,7 @@ function renderPage() {
 
 describe('EditPostPage', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it('uses the queued update label for queued post edits', () => {

--- a/packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import NewPostPage from '../NewPostPage';
 
 const navigate = vi.fn();
@@ -116,6 +117,17 @@ vi.mock('../../../components/posts/TwitterPostFields', () => ({
         onClick={() => onFilesSelected([new File(['video'], 'video.mp4')])}
       >
         Add pending video
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          onFilesSelected([
+            new File(['first'], 'first.png', { type: 'image/png' }),
+            new File(['second'], 'second.png', { type: 'image/png' }),
+          ])
+        }
+      >
+        Add two images
       </button>
       <button
         type="button"
@@ -244,5 +256,39 @@ describe('NewPostPage scheduling validation', () => {
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Schedule Post' })).not.toBeDisabled(),
     );
+  });
+
+  it('starts selected media uploads concurrently', async () => {
+    const user = userEvent.setup();
+    const resolvers: Array<() => void> = [];
+    uploadMedia.mockImplementation((file: File) => {
+      const response = {
+        id: `media-${resolvers.length + 1}`,
+        fileName: file.name,
+        mimeType: file.type,
+        thumbnailUrl: null,
+        transcodeStatus: 'completed',
+      };
+
+      return new Promise((resolve) => {
+        resolvers.push(() => resolve(response));
+      });
+    });
+    renderPage();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Use Twitter profile' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Add two images' }));
+
+    expect(uploadMedia).toHaveBeenCalledTimes(2);
+    expect(uploadMedia.mock.calls.map(([file]) => (file as File).name)).toEqual([
+      'first.png',
+      'second.png',
+    ]);
+
+    resolvers.forEach((resolve) => resolve());
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(2));
   });
 });

--- a/packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx
+++ b/packages/web/src/pages/posts/__tests__/NewPostPage.test.tsx
@@ -210,7 +210,7 @@ function renderPage() {
 
 describe('NewPostPage scheduling validation', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     uploadMedia.mockResolvedValue({
       id: 'media-1',
       fileName: 'video.mp4',


### PR DESCRIPTION
Closes #24
Closes #22
Closes #23

## Summary
- upload post media files concurrently
- extract shared post-media state handling into usePostMedia
- type post media responses without unknown casts
- apply RoboRev follow-up coverage for post media UI flows

## Validation
- git diff --check origin/develop..HEAD
- pnpm --filter @sms/shared build
- pnpm --filter @sms/web exec vitest run src/hooks/__tests__/use-post-media.test.ts src/components/posts/__tests__/PostSubmitActions.test.tsx src/pages/posts/__tests__/NewPostPage.test.tsx src/pages/posts/__tests__/EditPostPage.test.tsx --maxWorkers=1
- pnpm --filter @sms/web typecheck
