### PR TITLE
[codex] Make S3 storage optional and add destroy lifecycle

### DIFF
--- a/.clawpatch/features/feat_gh-11_82351ecd5c.json
+++ b/.clawpatch/features/feat_gh-11_82351ecd5c.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-11_82351ecd5c",
+  "title": "gh#11: Deps: Make S3 storage support optional in @sms/shared",
+  "summary": "Imported from GitHub issue gh#11 in BACKLOG.md section \"Refactoring / type safety\".",
+  "kind": "job",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/shared/src/index.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/shared/src/storage/index.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    },
+    {
+      "path": "packages/api/src/index.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/shared/src/index.ts",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/shared/src/storage/index.ts",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/api/src/index.ts",
+      "reason": "mentioned by issue body"
+    },
+    {
+      "path": "packages/worker/src/index.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#11"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#11",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/11",
+    "backlog-order:0048",
+    "backlog-section:refactoring-type-safety"
+  ],
+  "trustBoundaries": [
+    "network",
+    "filesystem",
+    "concurrency"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-11-977a4effb6_34719afc03"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260527T040617-93c83b",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#11",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-27T04:06:17.910Z"
+    }
+  ],
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T05:24:05.283Z"
+}

--- a/.clawpatch/features/feat_gh-27_0618787b87.json
+++ b/.clawpatch/features/feat_gh-27_0618787b87.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "featureId": "feat_gh-27_0618787b87",
+  "title": "gh#27: Shared: Document local contentType handling and add storage destroy lifecycle",
+  "summary": "Imported from GitHub issue gh#27 in BACKLOG.md section \"Refactoring / type safety\".",
+  "kind": "library",
+  "source": "github-issue-import",
+  "confidence": "high",
+  "entrypoints": [
+    {
+      "path": "packages/shared/src/index.ts",
+      "symbol": null,
+      "route": null,
+      "command": null
+    }
+  ],
+  "ownedFiles": [
+    {
+      "path": "packages/shared/src/index.ts",
+      "reason": "mentioned by issue body"
+    }
+  ],
+  "contextFiles": [
+    {
+      "path": "BACKLOG.md",
+      "reason": "backlog queue item for gh#27"
+    }
+  ],
+  "tests": [],
+  "tags": [
+    "github-issue",
+    "gh#27",
+    "github-url:https://github.com/joshgk00/social-media-scheduler/issues/27",
+    "backlog-order:0052",
+    "backlog-section:refactoring-type-safety"
+  ],
+  "trustBoundaries": [
+    "network",
+    "filesystem",
+    "concurrency"
+  ],
+  "status": "fixed",
+  "lock": null,
+  "findingIds": [
+    "fnd_sig-gh-27-65bc080d00_2c29df844c"
+  ],
+  "patchAttemptIds": [],
+  "analysisHistory": [
+    {
+      "runId": "20260527T040617-93c83b",
+      "kind": "github-issue-import",
+      "summary": "Imported GitHub issue gh#27",
+      "provider": "gh",
+      "model": null,
+      "createdAt": "2026-05-27T04:06:17.910Z"
+    }
+  ],
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T05:58:24.171Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-11-977a4effb6_34719afc03.json
+++ b/.clawpatch/findings/fnd_sig-gh-11-977a4effb6_34719afc03.json
@@ -1,0 +1,114 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-11-977a4effb6_34719afc03",
+  "featureId": "feat_gh-11_82351ecd5c",
+  "title": "gh#11: Deps: Make S3 storage support optional in @sms/shared",
+  "category": "build-release",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "risk",
+  "evidence": [
+    {
+      "path": "packages/shared/src/index.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/shared/src/storage/index.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/api/src/index.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    },
+    {
+      "path": "packages/worker/src/index.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/11.\nBacklog section: Refactoring / type safety.\n\n## Problem\n\n`@aws-sdk/client-s3` is currently a production dependency of `@sms/shared`, and `packages/shared/src/storage/index.ts` statically imports `S3Storage`. That means every workspace consumer of `@sms/shared` can pull the AWS SDK graph even though S3 is optional and the default deployment uses local filesystem storage.\n\n## Decision\n\nUse the optional-peer + lazy-import approach.\n\nKeep the storage abstraction in `@sms/shared`, but make the AWS SDK dependency optional and load it only when S3 is actually configured.\n\n## Implementation direction\n\n- Move `@aws-sdk/client-s3` out of `@sms/shared.dependencies`.\n- Add it to `@sms/shared.peerDependencies` with `peerDependenciesMeta.optional: true`.\n- Keep it in `@sms/shared.devDependencies` so shared typecheck/tests still work.\n- Add `@aws-sdk/client-s3` to `@sms/api` and `@sms/worker` production dependencies so S3-capable runtime images still include it.\n- Refactor `S3Storage` to lazy-load the AWS SDK with `await import('@aws-sdk/client-s3')` from inside the S3 code path. Use type-only imports where useful.\n- Keep `createStorageBackend()` returning local storage by default when `MEDIA_STORAGE_BACKEND` is unset or `local`.\n- If `MEDIA_STORAGE_BACKEND=s3` but the optional dependency is unavailable, throw a clear configuration error naming `@aws-sdk/client-s3` and the S3 backend.\n\n## Acceptance criteria\n\n- `@sms/shared` no longer has `@aws-sdk/client-s3` in production `dependencies`.\n- Local-storage deployments do not import or initialize the AWS SDK.\n- S3 deployments still work when API/worker runtime deps include `@aws-sdk/client-s3`.\n- `pnpm --filter @sms/shared typecheck` passes.\n- `pnpm --filter @sms/shared test -- storage` passes, or the closest focused storage test command.\n- API and worker builds still pass after dependency changes.\n\n## Out of scope\n\n- Moving storage ownership out of `@sms/shared`.\n- Removing S3 support.\n- Changing the `StorageBackend` public contract except where #27 adds lifecycle cleanup.\n\n## References\n\n- Related lifecycle/storage contract cleanup: #27\n- Related storage tests: #28",
+  "reproduction": "`@aws-sdk/client-s3` is currently a production dependency of `@sms/shared`, and `packages/shared/src/storage/index.ts` statically imports `S3Storage`. That means every workspace consumer of `@sms/shared` can pull the AWS SDK graph even though S3 is optional and the default deployment uses local filesystem storage.",
+  "recommendation": "Implement the fix described by GitHub issue gh#11 and satisfy its acceptance criteria.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/shared/src/index.ts, packages/shared/src/storage/index.ts, packages/api/src/index.ts, packages/worker/src/index.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260527T050943-2ad232",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence paths still exist. The issue remains open: packages/shared/package.json still lists @aws-sdk/client-s3 under production dependencies at lines 42-43, with no shared peerDependencies or peerDependenciesMeta optional entry. packages/shared/src/storage/index.ts still statically imports S3Storage at line 3 and constructs it synchronously at lines 16-22. packages/shared/src/storage/s3-storage.ts still statically imports S3Client and command classes from @aws-sdk/client-s3 at lines 1-7. packages/api/package.json and packages/worker/package.json dependencies do not include @aws-sdk/client-s3, so the proposed runtime dependency move has not happened. Typecheck passes for shared, api, and worker, but that only shows the current static dependency graph compiles. The focused storage test command could not run in this read-only sandbox because Vitest/Vite attempted to write packages/shared/node_modules/.vite-temp and failed with EPERM; the current storage test source still imports S3Storage directly and mocks @aws-sdk/client-s3, so it does not demonstrate optional/lazy AWS SDK behavior.",
+      "commands": [
+        "pwd && git status --short",
+        "rg -n \"@aws-sdk/client-s3|S3Storage|createStorageBackend|MEDIA_STORAGE_BACKEND|peerDependencies|peerDependenciesMeta|dependencies|devDependencies\" package.json packages/shared/package.json packages/api/package.json packages/worker/package.json packages/shared/src packages/api/src/index.ts packages/worker/src/index.ts",
+        "rg --files packages/shared/src packages/api/src packages/worker/src packages/shared/test packages/shared/tests 2>/dev/null",
+        "sed -n '1,220p' packages/shared/package.json",
+        "sed -n '1,220p' packages/api/package.json",
+        "sed -n '1,220p' packages/worker/package.json",
+        "sed -n '1,220p' packages/shared/src/storage/index.ts",
+        "sed -n '1,260p' packages/shared/src/storage/s3-storage.ts",
+        "sed -n '1,240p' packages/shared/src/__tests__/storage.test.ts",
+        "sed -n '1,220p' packages/shared/src/index.ts",
+        "sed -n '1,130p' packages/api/src/index.ts",
+        "sed -n '1,140p' packages/worker/src/index.ts",
+        "rg -n '\"@aws-sdk/client-s3\"|peerDependencies|peerDependenciesMeta' pnpm-lock.yaml packages/*/package.json",
+        "nl -ba packages/shared/package.json | sed -n '38,56p'",
+        "nl -ba packages/api/package.json | sed -n '10,45p'",
+        "nl -ba packages/worker/package.json | sed -n '10,30p'",
+        "nl -ba packages/shared/src/storage/index.ts | sed -n '1,35p'",
+        "nl -ba packages/shared/src/storage/s3-storage.ts | sed -n '1,55p'",
+        "nl -ba packages/shared/src/__tests__/storage.test.ts | sed -n '1,30p;165,206p'",
+        "pnpm --filter @sms/shared typecheck",
+        "pnpm --filter @sms/shared test -- storage",
+        "pnpm --filter @sms/api typecheck",
+        "pnpm --filter @sms/worker typecheck"
+      ],
+      "createdAt": "2026-05-27T05:11:11.535Z"
+    },
+    {
+      "runId": "20260527T051926-55fcc9",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "Original evidence paths still exist. Current source and manifests implement the requested optional-peer/lazy-import fix: @sms/shared no longer has @aws-sdk/client-s3 in production dependencies, has it as an optional peer plus devDependency, and @sms/api and @sms/worker now carry it as runtime dependencies. packages/shared/src/storage/index.ts defaults to LocalStorage and uses LazyS3Storage with dynamic import('./s3-storage.js'); packages/shared/src/storage/s3-storage.ts uses type-only SDK references and lazy import('@aws-sdk/client-s3') with a clear missing-dependency error. rg found no static value import of @aws-sdk/client-s3 under packages/shared/src. Shared, API, and worker typechecks pass. The focused Vitest storage test could not execute in this read-only sandbox because Vitest/Vite attempted to write temp files and failed with EPERM. Ignored dist artifacts are stale on disk, but dist/ is gitignored and Docker/package scripts rebuild from source, so the source-of-truth finding is fixed.",
+      "commands": [
+        "pwd",
+        "git status --short",
+        "rg -n '@aws-sdk/client-s3|S3Storage|createStorageBackend|MEDIA_STORAGE_BACKEND|peerDependencies|peerDependenciesMeta|dependencies|devDependencies' package.json packages/shared/package.json packages/api/package.json packages/worker/package.json packages/shared/src packages/api/src/index.ts packages/worker/src/index.ts",
+        "sed -n '1,140p' packages/shared/package.json",
+        "sed -n '1,90p' packages/api/package.json",
+        "sed -n '1,70p' packages/worker/package.json",
+        "sed -n '1,140p' packages/shared/src/storage/index.ts",
+        "sed -n '1,220p' packages/shared/src/storage/s3-storage.ts",
+        "sed -n '1,280p' packages/shared/src/__tests__/storage.test.ts",
+        "rg -n '^import .*@aws-sdk/client-s3|from '\\''@aws-sdk/client-s3'\\''|import\\('\\''@aws-sdk/client-s3'\\''\\)|@aws-sdk/client-s3' packages/shared/src packages/api/src packages/worker/src packages/shared/package.json packages/api/package.json packages/worker/package.json pnpm-lock.yaml",
+        "pnpm --filter @sms/shared typecheck",
+        "pnpm --filter @sms/api typecheck",
+        "pnpm --filter @sms/worker typecheck",
+        "pnpm --filter @sms/shared test -- storage",
+        "pnpm --filter @sms/shared exec vitest run src/__tests__/storage.test.ts --configLoader runner",
+        "git status --short --ignored packages/shared/dist/storage/index.js packages/shared/dist/storage/s3-storage.js packages/shared/dist/storage/s3-storage.d.ts",
+        "rg -n 'pnpm .*build|dist/index.js|@sms/shared/storage|createStorageBackend' . -g 'Dockerfile' -g 'docker-compose*.yml' -g 'package.json' -g '!node_modules' -g '!dist'"
+      ],
+      "createdAt": "2026-05-27T05:24:05.229Z"
+    }
+  ],
+  "signature": "sig_gh-11_977a4effb6",
+  "linkedPatchAttemptIds": [],
+  "createdByRunId": "20260527T040617-93c83b",
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T05:24:05.229Z"
+}

--- a/.clawpatch/findings/fnd_sig-gh-27-65bc080d00_2c29df844c.json
+++ b/.clawpatch/findings/fnd_sig-gh-27-65bc080d00_2c29df844c.json
@@ -1,0 +1,103 @@
+{
+  "schemaVersion": 1,
+  "findingId": "fnd_sig-gh-27-65bc080d00_2c29df844c",
+  "featureId": "feat_gh-27_0618787b87",
+  "title": "gh#27: Shared: Document local contentType handling and add storage destroy lifecycle",
+  "category": "api-contract",
+  "severity": "medium",
+  "confidence": "high",
+  "triage": "contract-mismatch",
+  "evidence": [
+    {
+      "path": "packages/shared/src/index.ts",
+      "startLine": null,
+      "endLine": null,
+      "symbol": null,
+      "quote": null
+    }
+  ],
+  "reasoning": "Imported from https://github.com/joshgk00/social-media-scheduler/issues/27.\nBacklog section: Refactoring / type safety.\n\n## Problem\n\n`StorageBackend.save()` accepts a `contentType`, but local storage currently ignores it. That is not a runtime bug for the current local backend because local media is served by Express static middleware and MIME is inferred from the file extension, but the contract should say that plainly.\n\n`StorageBackend` also has no lifecycle hook. `S3Storage` creates an `S3Client`, which owns HTTP resources, but there is no way for API/worker shutdown to call `client.destroy()`.\n\n## Decision\n\nDo not add `.meta` sidecar files for local storage. Document that `contentType` is consumed by S3 and ignored by local storage because local serving infers content type from file extension.\n\nDo add an optional storage lifecycle hook.\n\n## Implementation direction\n\n- Update `StorageBackend` with `destroy?(): Promise<void>`.\n- Add a short doc comment to `StorageBackend.save()` explaining backend-specific `contentType` behavior.\n- Implement `LocalStorage.destroy()` as a no-op, or omit it if the interface stays optional. Prefer a no-op for symmetry in tests.\n- Implement `S3Storage.destroy()` by calling the underlying S3 client's `destroy()` method.\n- Update API shutdown to call `await storage.destroy?.()`.\n- Update worker shutdown to call `await storage.destroy?.()`.\n- Add tests for the lifecycle behavior.\n\n## Acceptance criteria\n\n- The storage interface documents that local storage does not persist content-type metadata.\n- No `.meta` sidecar files are introduced.\n- `S3Storage.destroy()` calls `S3Client.destroy()`.\n- API and worker graceful shutdown paths invoke `storage.destroy?.()`.\n- Existing local storage behavior and URLs remain unchanged.\n- `pnpm --filter @sms/shared test -- storage` passes, or the closest focused storage test command.\n- API and worker typechecks pass.\n\n## Out of scope\n\n- Reworking media serving to read content type from metadata.\n- Changing storage URL format.\n- Moving S3 support out of `@sms/shared`; that is tracked separately in #11.\n\n## References\n\n- Optional AWS dependency cleanup: #11\n- Storage test coverage: #28",
+  "reproduction": "`StorageBackend.save()` accepts a `contentType`, but local storage currently ignores it. That is not a runtime bug for the current local backend because local media is served by Express static middleware and MIME is inferred from the file extension, but the contract should say that plainly.\n\n`StorageBackend` also has no lifecycle hook. `S3Storage` creates an `S3Client`, which owns HTTP resources, but there is no way for API/worker shutdown to call `client.destroy()`.",
+  "recommendation": "Implement the fix described by GitHub issue gh#27 and satisfy its acceptance criteria.",
+  "whyTestsDoNotAlreadyCoverThis": "Imported from GitHub issue. Preserve or add focused regression coverage when the issue acceptance criteria calls for it.",
+  "suggestedRegressionTest": null,
+  "minimumFixScope": "packages/shared/src/index.ts",
+  "status": "fixed",
+  "history": [
+    {
+      "runId": "20260527T054809-90c023",
+      "kind": "revalidate",
+      "status": "open",
+      "note": null,
+      "reasoning": "The original evidence path packages/shared/src/index.ts still exists, but the storage contract has moved to packages/shared/src/storage/*. Current code still does not satisfy the finding: StorageBackend in packages/shared/src/storage/storage-backend.ts has no destroy? lifecycle hook and no save() doc comment; LocalStorage.save() still ignores contentType without documented contract; S3Storage uses ContentType on save but has no destroy() method to call S3Client.destroy(); LazyS3Storage has no destroy forwarding; API shutdown in packages/api/src/index.ts and worker shutdown in packages/worker/src/index.ts do not call storage.destroy?.(). Storage tests contain no lifecycle assertions, though the mock S3 client has a destroy function. No .meta sidecar files were found. Focused shared storage tests could not execute because the read-only sandbox prevented Vitest from writing its .vite-temp config file, but @sms/shared, @sms/api, and @sms/worker typechecks all passed. Based on current code evidence, the issue remains open.",
+      "commands": [
+        "rg --files -g 'package.json' -g 'packages/shared/src/**' -g 'packages/api/src/**' -g 'packages/worker/src/**' -g '*storage*' -g '*Storage*'",
+        "rg -n \"interface StorageBackend|type StorageBackend|class LocalStorage|class S3Storage|destroy\\?|destroy\\(|contentType|storage\\.destroy|createStorage|shutdown|SIGTERM|SIGINT\" packages",
+        "git status --short",
+        "nl -ba packages/shared/src/storage/storage-backend.ts",
+        "nl -ba packages/shared/src/storage/local-storage.ts",
+        "nl -ba packages/shared/src/storage/s3-storage.ts",
+        "nl -ba packages/shared/src/storage/index.ts",
+        "nl -ba packages/api/src/index.ts",
+        "nl -ba packages/worker/src/index.ts",
+        "nl -ba packages/shared/src/__tests__/storage.test.ts",
+        "rg -n \"destroy|contentType|ContentType|\\.meta|metadata|local storage|LocalStorage|S3Storage|StorageBackend\" packages/shared/src packages/api/src packages/worker/src",
+        "cat package.json",
+        "cat packages/shared/package.json",
+        "cat packages/api/package.json",
+        "cat packages/worker/package.json",
+        "pnpm --filter @sms/shared test -- storage",
+        "cat packages/shared/tsconfig.json",
+        "cat packages/api/tsconfig.json",
+        "cat packages/worker/tsconfig.json",
+        "rg -n \"noEmit|incremental|tsBuildInfo|outDir|composite|references\" tsconfig*.json packages/**/tsconfig.json",
+        "cat tsconfig.base.json",
+        "pnpm --filter @sms/api typecheck",
+        "pnpm --filter @sms/worker typecheck",
+        "pnpm --filter @sms/shared typecheck",
+        "nl -ba packages/shared/src/index.ts"
+      ],
+      "createdAt": "2026-05-27T05:50:14.601Z"
+    },
+    {
+      "runId": "20260527T055647-89dfcb",
+      "kind": "revalidate",
+      "status": "fixed",
+      "note": null,
+      "reasoning": "The original evidence path packages/shared/src/index.ts still exists, and the storage contract has moved under packages/shared/src/storage. Current code satisfies the finding: StorageBackend now documents contentType behavior for S3 vs local storage and declares optional destroy?() in packages/shared/src/storage/storage-backend.ts:1-11; LocalStorage has a no-op destroy() and still does not create sidecar metadata; S3Storage.destroy() awaits the initialized client and calls client.destroy(); LazyS3Storage forwards destroy without initializing S3 first; API and worker shutdown paths call storage.destroy?.(). Focused lifecycle tests were added in packages/shared/src/__tests__/storage.test.ts, including no .meta sidecar, LocalStorage destroy, S3 destroy, and lazy S3 destroy behavior. No .meta files were found. @sms/shared, @sms/api, and @sms/worker typechecks passed. The focused Vitest command could not execute in this read-only sandbox because Vite tried to write packages/shared/node_modules/.vite-temp, but the current code and passing typechecks support marking the issue fixed.",
+      "commands": [
+        "rg --files -g 'package.json' -g 'packages/shared/src/**' -g 'packages/api/src/**' -g 'packages/worker/src/**' -g '*storage*' -g '*Storage*'",
+        "rg -n \"interface StorageBackend|type StorageBackend|class LocalStorage|class S3Storage|class LazyS3Storage|destroy\\?|destroy\\(|contentType|ContentType|storage\\.destroy|shutdown|SIGTERM|SIGINT|createStorage|\\.meta|metadata\" packages",
+        "git status --short",
+        "nl -ba packages/shared/src/index.ts",
+        "nl -ba packages/shared/src/storage/storage-backend.ts",
+        "nl -ba packages/shared/src/storage/local-storage.ts",
+        "nl -ba packages/shared/src/storage/s3-storage.ts",
+        "nl -ba packages/shared/src/storage/index.ts",
+        "nl -ba packages/api/src/index.ts",
+        "nl -ba packages/worker/src/index.ts",
+        "nl -ba packages/shared/src/__tests__/storage.test.ts",
+        "rg -n \"\\.meta|content-type sidecar|destroy\\(\\)|destroy\\?\\(|S3Client|ContentType|local storage ignores|Express static\" packages/shared/src/__tests__/storage.test.ts packages/shared/src/storage packages/api/src/index.ts packages/worker/src/index.ts",
+        "cat package.json",
+        "cat packages/shared/package.json",
+        "cat packages/api/package.json",
+        "cat packages/worker/package.json",
+        "pnpm --filter @sms/shared test -- --run storage",
+        "pnpm --filter @sms/shared typecheck",
+        "pnpm --filter @sms/api typecheck",
+        "pnpm --filter @sms/worker typecheck",
+        "rg --files | rg '\\.meta$'",
+        "rg -n \"save\\([^\\n]*contentType|ContentType|destroy\\?\\(|storage\\.destroy|client\\.destroy|content-type sidecar|local storage ignores|Express static serving\" packages/shared/src packages/api/src/index.ts packages/worker/src/index.ts",
+        "git diff -- packages/shared/src/storage/storage-backend.ts packages/shared/src/storage/local-storage.ts packages/shared/src/storage/s3-storage.ts packages/shared/src/storage/index.ts packages/api/src/index.ts packages/worker/src/index.ts packages/shared/src/__tests__/storage.test.ts"
+      ],
+      "createdAt": "2026-05-27T05:58:24.117Z"
+    }
+  ],
+  "signature": "sig_gh-27_65bc080d00",
+  "linkedPatchAttemptIds": [
+    "pat_fnd-sig-gh-27-65bc080d00-2c29df8_a175cc6ccf"
+  ],
+  "createdByRunId": "20260527T040617-93c83b",
+  "createdAt": "2026-05-27T04:06:17.910Z",
+  "updatedAt": "2026-05-27T05:58:24.116Z"
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "~3.1030.0",
     "@bull-board/api": "~6.21.0",
     "@bull-board/express": "~6.21.0",
     "@sms/db": "workspace:*",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -79,6 +79,7 @@ async function main() {
     try { await bulkOpsQueueService.bulkOpsQueue.close(); } catch (err) { logger.error({ err }, 'Bulk operations queue shutdown error'); }
     try { await notificationQueue.close(); } catch (err) { logger.error({ err }, 'Notification queue shutdown error'); }
     try { await transcodeQueue.close(); } catch (err) { logger.error({ err }, 'Transcode queue shutdown error'); }
+    try { await storage.destroy?.(); } catch (err) { logger.error({ err }, 'Storage shutdown error'); }
     try { await redis.quit(); } catch (err) { logger.error({ err }, 'Redis shutdown error'); }
     try { await sql.end(); } catch (err) { logger.error({ err }, 'Database shutdown error'); }
     process.exit(0);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -40,7 +40,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "~3.1030.0",
     "drizzle-orm": "~0.45.2",
     "luxon": "~3.7.2",
     "pino": "~10.3.1",
@@ -48,7 +47,16 @@
     "twitter-text": "~3.1.0",
     "zod": "~3.25.76"
   },
+  "peerDependencies": {
+    "@aws-sdk/client-s3": "~3.1030.0"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-s3": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@aws-sdk/client-s3": "~3.1030.0",
     "@types/luxon": "^3.7.1",
     "@types/node": "^25.5.2",
     "@types/twitter-text": "~3.1.10",

--- a/packages/shared/src/__tests__/storage.test.ts
+++ b/packages/shared/src/__tests__/storage.test.ts
@@ -8,9 +8,14 @@ import { createStorageBackend } from '../storage/index.js';
 
 // Mock @aws-sdk/client-s3 before any imports that use it
 const sendMock = vi.fn();
+const s3ClientConstructorMock = vi.fn();
 
 vi.mock('@aws-sdk/client-s3', () => {
   class MockS3Client {
+    constructor(public config: Record<string, unknown>) {
+      s3ClientConstructorMock(config);
+    }
+
     send = sendMock;
     destroy = vi.fn();
   }
@@ -95,6 +100,7 @@ describe('S3Storage', () => {
 
   beforeEach(() => {
     sendMock.mockReset();
+    s3ClientConstructorMock.mockReset();
 
     storage = new S3Storage({
       endpoint: 'http://minio:9000',
@@ -160,6 +166,24 @@ describe('S3Storage', () => {
     sendMock.mockRejectedValueOnce(notFoundError);
     expect(await storage.exists('uploads/missing.jpg')).toBe(false);
   });
+
+  it('throws a clear error when the optional AWS SDK dependency cannot load', async () => {
+    const storageWithoutSdk = new S3Storage(
+      {
+        endpoint: 'http://minio:9000',
+        bucket: 'test-bucket',
+        accessKey: 'testkey',
+        secretKey: 'testsecret',
+      },
+      async () => {
+        throw new Error('Cannot find package');
+      },
+    );
+
+    await expect(storageWithoutSdk.exists('uploads/file.jpg')).rejects.toThrow(
+      'S3 backend requires optional dependency "@aws-sdk/client-s3"',
+    );
+  });
 });
 
 describe('createStorageBackend', () => {
@@ -167,6 +191,8 @@ describe('createStorageBackend', () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
+    sendMock.mockReset();
+    s3ClientConstructorMock.mockReset();
   });
 
   afterEach(() => {
@@ -177,22 +203,29 @@ describe('createStorageBackend', () => {
     delete process.env.MEDIA_STORAGE_BACKEND;
     const backend = createStorageBackend();
     expect(backend).toBeInstanceOf(LocalStorage);
+    expect(s3ClientConstructorMock).not.toHaveBeenCalled();
   });
 
   it('returns LocalStorage when MEDIA_STORAGE_BACKEND is "local"', () => {
     process.env.MEDIA_STORAGE_BACKEND = 'local';
     const backend = createStorageBackend();
     expect(backend).toBeInstanceOf(LocalStorage);
+    expect(s3ClientConstructorMock).not.toHaveBeenCalled();
   });
 
-  it('returns S3Storage when MEDIA_STORAGE_BACKEND is "s3" and env vars set', () => {
+  it('returns an S3 backend without initializing AWS SDK until it is used', async () => {
     process.env.MEDIA_STORAGE_BACKEND = 's3';
     process.env.S3_ENDPOINT = 'http://minio:9000';
     process.env.S3_BUCKET = 'media';
     process.env.S3_ACCESS_KEY = 'key';
     process.env.S3_SECRET_KEY = 'secret';
     const backend = createStorageBackend();
-    expect(backend).toBeInstanceOf(S3Storage);
+    expect(backend.getUrl('uploads/file.jpg')).toBe('http://minio:9000/media/uploads/file.jpg');
+    expect(s3ClientConstructorMock).not.toHaveBeenCalled();
+
+    sendMock.mockResolvedValueOnce({});
+    expect(await backend.exists('uploads/file.jpg')).toBe(true);
+    expect(s3ClientConstructorMock).toHaveBeenCalledOnce();
   });
 
   it('throws when MEDIA_STORAGE_BACKEND is "s3" but S3_ENDPOINT is missing', () => {

--- a/packages/shared/src/__tests__/storage.test.ts
+++ b/packages/shared/src/__tests__/storage.test.ts
@@ -197,6 +197,30 @@ describe('S3Storage', () => {
     );
   });
 
+  it('retries SDK loading after a transient load failure', async () => {
+    const sdk = await import('@aws-sdk/client-s3');
+    const loadSdk = vi.fn()
+      .mockRejectedValueOnce(new Error('temporary import failure'))
+      .mockResolvedValueOnce(sdk);
+    const storageWithFlakySdk = new S3Storage(
+      {
+        endpoint: 'http://minio:9000',
+        bucket: 'test-bucket',
+        accessKey: 'testkey',
+        secretKey: 'testsecret',
+      },
+      loadSdk,
+    );
+
+    await expect(storageWithFlakySdk.exists('uploads/file.jpg')).rejects.toThrow(
+      'S3 backend requires optional dependency "@aws-sdk/client-s3"',
+    );
+
+    sendMock.mockResolvedValueOnce({});
+    await expect(storageWithFlakySdk.exists('uploads/file.jpg')).resolves.toBe(true);
+    expect(loadSdk).toHaveBeenCalledTimes(2);
+  });
+
   it('destroy() is a no-op before the S3 client is initialized', async () => {
     await expect(storage.destroy()).resolves.toBeUndefined();
 
@@ -257,7 +281,7 @@ describe('createStorageBackend', () => {
     expect(s3ClientConstructorMock).toHaveBeenCalledOnce();
   });
 
-  it('destroy() on a lazy S3 backend does not initialize AWS SDK before use', async () => {
+  it('destroy() on an unused S3 backend does not initialize AWS SDK', async () => {
     process.env.MEDIA_STORAGE_BACKEND = 's3';
     process.env.S3_ENDPOINT = 'http://minio:9000';
     process.env.S3_BUCKET = 'media';

--- a/packages/shared/src/__tests__/storage.test.ts
+++ b/packages/shared/src/__tests__/storage.test.ts
@@ -9,6 +9,7 @@ import { createStorageBackend } from '../storage/index.js';
 // Mock @aws-sdk/client-s3 before any imports that use it
 const sendMock = vi.fn();
 const s3ClientConstructorMock = vi.fn();
+const s3ClientDestroyMock = vi.fn();
 
 vi.mock('@aws-sdk/client-s3', () => {
   class MockS3Client {
@@ -17,7 +18,7 @@ vi.mock('@aws-sdk/client-s3', () => {
     }
 
     send = sendMock;
-    destroy = vi.fn();
+    destroy = s3ClientDestroyMock;
   }
   return {
     S3Client: MockS3Client,
@@ -57,6 +58,12 @@ describe('LocalStorage', () => {
     expect(retrieved).toEqual(content);
   });
 
+  it('save() does not create content-type sidecar metadata', async () => {
+    await storage.save('uploads/image.jpg', Buffer.from('image'), 'image/jpeg');
+
+    await expect(fs.access(path.join(tmpDir, 'uploads/image.jpg.meta'))).rejects.toThrow();
+  });
+
   it('delete() removes the file', async () => {
     const content = Buffer.from('to delete');
     await storage.save('deleteme.txt', content, 'text/plain');
@@ -83,6 +90,10 @@ describe('LocalStorage', () => {
     expect(storage.getUrl('profiles/123/image.jpg')).toBe('/media/profiles/123/image.jpg');
   });
 
+  it('destroy() is a no-op lifecycle hook', async () => {
+    await expect(storage.destroy()).resolves.toBeUndefined();
+  });
+
   it('rejects path traversal attempts with ../', async () => {
     await expect(storage.save('../escape.txt', Buffer.from('bad'), 'text/plain')).rejects.toThrow();
     await expect(storage.get('../../etc/passwd')).rejects.toThrow();
@@ -101,6 +112,7 @@ describe('S3Storage', () => {
   beforeEach(() => {
     sendMock.mockReset();
     s3ClientConstructorMock.mockReset();
+    s3ClientDestroyMock.mockReset();
 
     storage = new S3Storage({
       endpoint: 'http://minio:9000',
@@ -184,6 +196,22 @@ describe('S3Storage', () => {
       'S3 backend requires optional dependency "@aws-sdk/client-s3"',
     );
   });
+
+  it('destroy() is a no-op before the S3 client is initialized', async () => {
+    await expect(storage.destroy()).resolves.toBeUndefined();
+
+    expect(s3ClientConstructorMock).not.toHaveBeenCalled();
+    expect(s3ClientDestroyMock).not.toHaveBeenCalled();
+  });
+
+  it('destroy() destroys the initialized S3 client', async () => {
+    sendMock.mockResolvedValueOnce({});
+    await storage.exists('uploads/file.jpg');
+
+    await storage.destroy();
+
+    expect(s3ClientDestroyMock).toHaveBeenCalledOnce();
+  });
 });
 
 describe('createStorageBackend', () => {
@@ -193,6 +221,7 @@ describe('createStorageBackend', () => {
     process.env = { ...originalEnv };
     sendMock.mockReset();
     s3ClientConstructorMock.mockReset();
+    s3ClientDestroyMock.mockReset();
   });
 
   afterEach(() => {
@@ -226,6 +255,20 @@ describe('createStorageBackend', () => {
     sendMock.mockResolvedValueOnce({});
     expect(await backend.exists('uploads/file.jpg')).toBe(true);
     expect(s3ClientConstructorMock).toHaveBeenCalledOnce();
+  });
+
+  it('destroy() on a lazy S3 backend does not initialize AWS SDK before use', async () => {
+    process.env.MEDIA_STORAGE_BACKEND = 's3';
+    process.env.S3_ENDPOINT = 'http://minio:9000';
+    process.env.S3_BUCKET = 'media';
+    process.env.S3_ACCESS_KEY = 'key';
+    process.env.S3_SECRET_KEY = 'secret';
+    const backend = createStorageBackend();
+
+    await backend.destroy?.();
+
+    expect(s3ClientConstructorMock).not.toHaveBeenCalled();
+    expect(s3ClientDestroyMock).not.toHaveBeenCalled();
   });
 
   it('throws when MEDIA_STORAGE_BACKEND is "s3" but S3_ENDPOINT is missing', () => {

--- a/packages/shared/src/storage/index.ts
+++ b/packages/shared/src/storage/index.ts
@@ -1,6 +1,6 @@
 import { requireEnv } from '../env.js';
 import { LocalStorage } from './local-storage.js';
-import { S3Storage } from './s3-storage.js';
+import type { S3Storage, S3StorageConfig } from './s3-storage.js';
 import type { StorageBackend } from './storage-backend.js';
 
 export { LocalStorage } from './local-storage.js';
@@ -10,11 +10,48 @@ export type { StorageBackend } from './storage-backend.js';
 
 const SUPPORTED_BACKENDS = ['local', 's3'] as const;
 
+class LazyS3Storage implements StorageBackend {
+  private storagePromise?: Promise<S3Storage>;
+
+  constructor(private readonly config: S3StorageConfig) {}
+
+  private getStorage(): Promise<S3Storage> {
+    this.storagePromise ??= import('./s3-storage.js').then(
+      ({ S3Storage }) => new S3Storage(this.config),
+    );
+    return this.storagePromise;
+  }
+
+  async save(key: string, data: Buffer | NodeJS.ReadableStream, contentType: string): Promise<void> {
+    const storage = await this.getStorage();
+    return storage.save(key, data, contentType);
+  }
+
+  async get(key: string): Promise<Buffer> {
+    const storage = await this.getStorage();
+    return storage.get(key);
+  }
+
+  async delete(key: string): Promise<void> {
+    const storage = await this.getStorage();
+    return storage.delete(key);
+  }
+
+  getUrl(key: string): string {
+    return `${this.config.endpoint}/${this.config.bucket}/${key}`;
+  }
+
+  async exists(key: string): Promise<boolean> {
+    const storage = await this.getStorage();
+    return storage.exists(key);
+  }
+}
+
 export function createStorageBackend(): StorageBackend {
   const backend = process.env.MEDIA_STORAGE_BACKEND || 'local';
 
   if (backend === 's3') {
-    return new S3Storage({
+    return new LazyS3Storage({
       endpoint: requireEnv('S3_ENDPOINT'),
       bucket: requireEnv('S3_BUCKET'),
       accessKey: requireEnv('S3_ACCESS_KEY'),

--- a/packages/shared/src/storage/index.ts
+++ b/packages/shared/src/storage/index.ts
@@ -1,6 +1,6 @@
 import { requireEnv } from '../env.js';
 import { LocalStorage } from './local-storage.js';
-import type { S3Storage, S3StorageConfig } from './s3-storage.js';
+import { S3Storage } from './s3-storage.js';
 import type { StorageBackend } from './storage-backend.js';
 
 export { LocalStorage } from './local-storage.js';
@@ -10,57 +10,11 @@ export type { StorageBackend } from './storage-backend.js';
 
 const SUPPORTED_BACKENDS = ['local', 's3'] as const;
 
-class LazyS3Storage implements StorageBackend {
-  private storagePromise?: Promise<S3Storage>;
-
-  constructor(private readonly config: S3StorageConfig) {}
-
-  private getStorage(): Promise<S3Storage> {
-    this.storagePromise ??= import('./s3-storage.js').then(
-      ({ S3Storage }) => new S3Storage(this.config),
-    );
-    return this.storagePromise;
-  }
-
-  async save(key: string, data: Buffer | NodeJS.ReadableStream, contentType: string): Promise<void> {
-    const storage = await this.getStorage();
-    return storage.save(key, data, contentType);
-  }
-
-  async get(key: string): Promise<Buffer> {
-    const storage = await this.getStorage();
-    return storage.get(key);
-  }
-
-  async delete(key: string): Promise<void> {
-    const storage = await this.getStorage();
-    return storage.delete(key);
-  }
-
-  getUrl(key: string): string {
-    return `${this.config.endpoint}/${this.config.bucket}/${key}`;
-  }
-
-  async exists(key: string): Promise<boolean> {
-    const storage = await this.getStorage();
-    return storage.exists(key);
-  }
-
-  async destroy(): Promise<void> {
-    if (!this.storagePromise) {
-      return;
-    }
-
-    const storage = await this.storagePromise;
-    await storage.destroy?.();
-  }
-}
-
 export function createStorageBackend(): StorageBackend {
   const backend = process.env.MEDIA_STORAGE_BACKEND || 'local';
 
   if (backend === 's3') {
-    return new LazyS3Storage({
+    return new S3Storage({
       endpoint: requireEnv('S3_ENDPOINT'),
       bucket: requireEnv('S3_BUCKET'),
       accessKey: requireEnv('S3_ACCESS_KEY'),

--- a/packages/shared/src/storage/index.ts
+++ b/packages/shared/src/storage/index.ts
@@ -45,6 +45,15 @@ class LazyS3Storage implements StorageBackend {
     const storage = await this.getStorage();
     return storage.exists(key);
   }
+
+  async destroy(): Promise<void> {
+    if (!this.storagePromise) {
+      return;
+    }
+
+    const storage = await this.storagePromise;
+    await storage.destroy?.();
+  }
 }
 
 export function createStorageBackend(): StorageBackend {

--- a/packages/shared/src/storage/local-storage.ts
+++ b/packages/shared/src/storage/local-storage.ts
@@ -54,6 +54,8 @@ export class LocalStorage implements StorageBackend {
     }
   }
 
+  async destroy(): Promise<void> {}
+
   private resolveAndGuard(key: string): string {
     const resolved = path.resolve(this.rootDir, key);
     if (!resolved.startsWith(this.rootDir + path.sep) && resolved !== this.rootDir) {

--- a/packages/shared/src/storage/s3-storage.ts
+++ b/packages/shared/src/storage/s3-storage.ts
@@ -37,7 +37,10 @@ export class S3Storage implements StorageBackend {
   }
 
   private getClient(): Promise<LoadedS3Client> {
-    this.clientPromise ??= this.createClient();
+    this.clientPromise ??= this.createClient().catch((error) => {
+      this.clientPromise = undefined;
+      throw error;
+    });
     return this.clientPromise;
   }
 

--- a/packages/shared/src/storage/s3-storage.ts
+++ b/packages/shared/src/storage/s3-storage.ts
@@ -137,4 +137,14 @@ export class S3Storage implements StorageBackend {
       throw error;
     }
   }
+
+  async destroy(): Promise<void> {
+    if (!this.clientPromise) {
+      return;
+    }
+
+    const { client } = await this.clientPromise;
+    client.destroy();
+    this.clientPromise = undefined;
+  }
 }

--- a/packages/shared/src/storage/s3-storage.ts
+++ b/packages/shared/src/storage/s3-storage.ts
@@ -1,11 +1,15 @@
-import {
-  S3Client,
-  PutObjectCommand,
-  GetObjectCommand,
-  DeleteObjectCommand,
-  HeadObjectCommand,
-} from '@aws-sdk/client-s3';
 import type { StorageBackend } from './storage-backend.js';
+
+type S3Sdk = typeof import('@aws-sdk/client-s3');
+type S3SdkLoader = () => Promise<S3Sdk>;
+
+interface LoadedS3Client {
+  client: InstanceType<S3Sdk['S3Client']>;
+  PutObjectCommand: S3Sdk['PutObjectCommand'];
+  GetObjectCommand: S3Sdk['GetObjectCommand'];
+  DeleteObjectCommand: S3Sdk['DeleteObjectCommand'];
+  HeadObjectCommand: S3Sdk['HeadObjectCommand'];
+}
 
 export interface S3StorageConfig {
   endpoint: string;
@@ -16,25 +20,59 @@ export interface S3StorageConfig {
 }
 
 export class S3Storage implements StorageBackend {
-  private readonly client: S3Client;
   private readonly bucket: string;
   private readonly endpoint: string;
+  private readonly config: S3StorageConfig;
+  private readonly loadSdk: S3SdkLoader;
+  private clientPromise?: Promise<LoadedS3Client>;
 
-  constructor(config: S3StorageConfig) {
+  constructor(
+    config: S3StorageConfig,
+    loadSdk: S3SdkLoader = () => import('@aws-sdk/client-s3'),
+  ) {
     this.bucket = config.bucket;
     this.endpoint = config.endpoint;
-    this.client = new S3Client({
-      endpoint: config.endpoint,
-      region: config.region || 'us-east-1',
+    this.config = config;
+    this.loadSdk = loadSdk;
+  }
+
+  private getClient(): Promise<LoadedS3Client> {
+    this.clientPromise ??= this.createClient();
+    return this.clientPromise;
+  }
+
+  private async createClient(): Promise<LoadedS3Client> {
+    let sdk: S3Sdk;
+    try {
+      sdk = await this.loadSdk();
+    } catch (error) {
+      throw new Error(
+        'S3 backend requires optional dependency "@aws-sdk/client-s3". Install @aws-sdk/client-s3 in the runtime package or set MEDIA_STORAGE_BACKEND=local.',
+        { cause: error },
+      );
+    }
+
+    const client = new sdk.S3Client({
+      endpoint: this.config.endpoint,
+      region: this.config.region || 'us-east-1',
       credentials: {
-        accessKeyId: config.accessKey,
-        secretAccessKey: config.secretKey,
+        accessKeyId: this.config.accessKey,
+        secretAccessKey: this.config.secretKey,
       },
       forcePathStyle: true,
     });
+
+    return {
+      client,
+      PutObjectCommand: sdk.PutObjectCommand,
+      GetObjectCommand: sdk.GetObjectCommand,
+      DeleteObjectCommand: sdk.DeleteObjectCommand,
+      HeadObjectCommand: sdk.HeadObjectCommand,
+    };
   }
 
   async save(key: string, data: Buffer | NodeJS.ReadableStream, contentType: string): Promise<void> {
+    const { client, PutObjectCommand } = await this.getClient();
     let body: Buffer;
     if (Buffer.isBuffer(data)) {
       body = data;
@@ -46,7 +84,7 @@ export class S3Storage implements StorageBackend {
       body = Buffer.concat(chunks);
     }
 
-    await this.client.send(new PutObjectCommand({
+    await client.send(new PutObjectCommand({
       Bucket: this.bucket,
       Key: key,
       Body: body,
@@ -55,7 +93,8 @@ export class S3Storage implements StorageBackend {
   }
 
   async get(key: string): Promise<Buffer> {
-    const response = await this.client.send(new GetObjectCommand({
+    const { client, GetObjectCommand } = await this.getClient();
+    const response = await client.send(new GetObjectCommand({
       Bucket: this.bucket,
       Key: key,
     }));
@@ -72,7 +111,8 @@ export class S3Storage implements StorageBackend {
   }
 
   async delete(key: string): Promise<void> {
-    await this.client.send(new DeleteObjectCommand({
+    const { client, DeleteObjectCommand } = await this.getClient();
+    await client.send(new DeleteObjectCommand({
       Bucket: this.bucket,
       Key: key,
     }));
@@ -83,8 +123,9 @@ export class S3Storage implements StorageBackend {
   }
 
   async exists(key: string): Promise<boolean> {
+    const { client, HeadObjectCommand } = await this.getClient();
     try {
-      await this.client.send(new HeadObjectCommand({
+      await client.send(new HeadObjectCommand({
         Bucket: this.bucket,
         Key: key,
       }));

--- a/packages/shared/src/storage/storage-backend.ts
+++ b/packages/shared/src/storage/storage-backend.ts
@@ -1,7 +1,12 @@
 export interface StorageBackend {
+  /**
+   * Persist data for a key. S3 stores the provided contentType as object metadata;
+   * local storage ignores it because Express static serving infers MIME type from the file extension.
+   */
   save(key: string, data: Buffer | NodeJS.ReadableStream, contentType: string): Promise<void>;
   get(key: string): Promise<Buffer>;
   delete(key: string): Promise<void>;
   getUrl(key: string): string;
   exists(key: string): Promise<boolean>;
+  destroy?(): Promise<void>;
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -11,6 +11,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "~3.1030.0",
     "@sms/db": "workspace:*",
     "@sms/shared": "workspace:*",
     "bullmq": "~5.73.0",

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -191,6 +191,7 @@ async function main() {
     await closeWithTimeout('cleanupQueue', () => cleanupQueue.close());
     await closeWithTimeout('tokenRefreshQueue', () => tokenRefreshQueue.close());
     await closeWithTimeout('notificationQueue', () => notificationQueue.close());
+    await closeWithTimeout('storage', () => storage.destroy?.() ?? Promise.resolve());
     if (transporter) {
       await closeWithTimeout('smtpTransporter', () => Promise.resolve(transporter.close()));
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   packages/api:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ~3.1030.0
+        version: 3.1030.0
       '@bull-board/api':
         specifier: ~6.21.0
         version: 6.21.0(@bull-board/ui@6.21.0)
@@ -172,9 +175,6 @@ importers:
 
   packages/shared:
     dependencies:
-      '@aws-sdk/client-s3':
-        specifier: ~3.1030.0
-        version: 3.1030.0
       drizzle-orm:
         specifier: ~0.45.2
         version: 0.45.2(postgres@3.4.9)
@@ -194,6 +194,9 @@ importers:
         specifier: ~3.25.76
         version: 3.25.76
     devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: ~3.1030.0
+        version: 3.1030.0
       '@types/luxon':
         specifier: ^3.7.1
         version: 3.7.1
@@ -393,6 +396,9 @@ importers:
 
   packages/worker:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ~3.1030.0
+        version: 3.1030.0
       '@sms/db':
         specifier: workspace:*
         version: link:../db


### PR DESCRIPTION
Closes #11
Closes #27

## Summary
- lazy-load the S3 storage implementation so the shared package no longer has a hard AWS SDK runtime requirement
- add content type and destroy lifecycle coverage to the storage backend contract
- apply RoboRev follow-up coverage for shared storage edge cases

## Validation
- git diff --check origin/develop..HEAD
- pnpm --filter @sms/shared exec vitest run src/__tests__/storage.test.ts --maxWorkers=1
- pnpm --filter @sms/shared typecheck
- pnpm --filter @sms/shared build
